### PR TITLE
Fix parcel/plot comparison on manual creation

### DIFF
--- a/src/Products/urban/events/portionOutEvents.py
+++ b/src/Products/urban/events/portionOutEvents.py
@@ -32,9 +32,13 @@ def setValidParcel(parcel, event):
      Check if the manually added parcel exists in he cadastral DB
      and set its "isvalidparcel" attribute accordingly.
     """
-
     is_official = True
-    references = parcel.reference_as_dict()
+    parcel.setDivisionCode(parcel.getDivision())
+    parcel.bis = '0' if parcel.bis == '' else parcel.bis
+    parcel.puissance = '0' if parcel.puissance == '' else parcel.puissance
+    parcel.reindexObject()
+
+    references = parcel.reference_as_dict(True)
     try:
         cadastre = services.cadastre.new_session()
         is_outdated = cadastre.is_outdated_parcel(**references)


### PR DESCRIPTION
Fix division absence to compare
Init integer default value to 0 instead of empty string to avoid query data error
Fix reference dict comparison with all the parcel/plot attributes