### PR TITLE
Get parcels

### DIFF
--- a/src/Products/urban/docgen/helper_view.py
+++ b/src/Products/urban/docgen/helper_view.py
@@ -385,7 +385,7 @@ class UrbanDocGenerationHelperView(ATDocumentGenerationHelperView):
         for parcel in parcels:
             if parcel.getDivisionAlternativeName() != division:
                 division = parcel.getDivisionAlternativeName()
-                grouped_parcels = []
+                del grouped_parcels[:]
                 grouped_parcels.append(parcel)
                 list_grouped_parcels.append(grouped_parcels)
             else:
@@ -396,16 +396,26 @@ class UrbanDocGenerationHelperView(ATDocumentGenerationHelperView):
                     if elms[i].getSection() > elms[j].getSection():
                         elms[i], elms[j] = elms[j], elms[i]
         for gp in enumerate(list_grouped_parcels):
-            result += gp[1][0].getDivisionAlternativeName() + ' '
+            if not gp[1][0].getDivisionAlternativeName():
+                result += 'None '
+            else:
+                result += gp[1][0].getDivisionAlternativeName() + ' '
             section = gp[1][0].getSection()
             result += 'section {} '.format(section)
             for p in enumerate(gp[1]):
                 if section != p[1].getSection():
                     section = p[1].getSection()
                     result += 'section {} '.format(section)
-                result += u"n° {}{}{}{}".format(
-                    p[1].getRadical(), p[1].getBis(), p[1].getExposant(), p[1].getPuissance()
-                )
+                if p[1].getBis() and not '0':
+                    result += u"n° {}/{} {}".format(
+                        p[1].getRadical(), p[1].getBis(), p[1].getExposant()
+                    )
+                else:
+                    result += u"n° {} {}".format(
+                        p[1].getRadical(), p[1].getExposant()
+                    )
+                if p[1].getPuissance() and not '0':
+                    result += u" {}".format(p[1].getPuissance())
                 if p[0] + 1 != len(gp[1]):
                     result += ', '
             if gp[0] + 1 != len(list_grouped_parcels):

--- a/src/Products/urban/docgen/helper_view.py
+++ b/src/Products/urban/docgen/helper_view.py
@@ -372,6 +372,9 @@ class UrbanDocGenerationHelperView(ATDocumentGenerationHelperView):
         return self.format_date(limitDate)
 
     def get_parcels(self):
+        """
+            Return a displayable version of the parcels, grouped by Divisions and Sections
+        """
         result = u""
         context = self.real_context
         parcels = context.getParcels()
@@ -406,7 +409,7 @@ class UrbanDocGenerationHelperView(ATDocumentGenerationHelperView):
                 if section != p[1].getSection():
                     section = p[1].getSection()
                     result += 'section {} '.format(section)
-                if p[1].getBis() and not '0':
+                if p[1].getBis() and not p[1].getBis() == '0':
                     result += u"n° {}/{} {}".format(
                         p[1].getRadical(), p[1].getBis(), p[1].getExposant()
                     )
@@ -414,7 +417,7 @@ class UrbanDocGenerationHelperView(ATDocumentGenerationHelperView):
                     result += u"n° {} {}".format(
                         p[1].getRadical(), p[1].getExposant()
                     )
-                if p[1].getPuissance() and not '0':
+                if p[1].getPuissance() and not p[1].getPuissance() == '0':
                     result += u" {}".format(p[1].getPuissance())
                 if p[0] + 1 != len(gp[1]):
                     result += ', '


### PR DESCRIPTION
C'est le petit fix que j'avais fait un vendredi pour améliorer la méthode get_parcels()
-> elle ne crash plus s'il n'existe pas de division sur la parcelle (surtout utile pour tester en local sans connexion à une DB cadastre)
-> Elle va renvoyer une parcelle avec une meilleure mise en page : Div 1 A n°100/1 C
Au lieu de Div 1 A 1001C