### PR TITLE
Fix parcels bis and puissance default values to empty string instead of 0

### DIFF
--- a/src/Products/urban/events/portionOutEvents.py
+++ b/src/Products/urban/events/portionOutEvents.py
@@ -29,8 +29,8 @@ def setValidParcel(parcel, event):
      and set its "isvalidparcel" attribute accordingly.
     """
     parcel.setDivisionCode(parcel.getDivision())
-    parcel.bis = parcel.bis or '0'
-    parcel.puissance = parcel.puissance or '0'
+    parcel.bis = parcel.bis or ''
+    parcel.puissance = parcel.puissance or ''
     parcel.reindexObject()
 
     parcel_status = False


### PR DESCRIPTION
Existait-il une raison particulière à ces valeurs par défaut ? J'ai retesté avec des parcelles existantes dans la DB et de celles non présentes et le comportement est correct. à l'ajout et à l'édition.