### PR TITLE
SUP-31043. Add option to disable ref format check for license creation

### DIFF
--- a/docs/CHANGES.rst
+++ b/docs/CHANGES.rst
@@ -6,7 +6,8 @@ Changes
 2.6.3 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Add option to POST endpoint when creating a licence to disable check ref format [SUP-31043]
+  [jchandelle]
 
 
 2.6.2 (2023-07-04)

--- a/src/Products/urban/services/configure.zcml
+++ b/src/Products/urban/services/configure.zcml
@@ -26,5 +26,6 @@
     factory="Products.urban.services.gig.GigSession" />
 
   <adapter factory=".serializer.UrbanDefaultFieldSerializer" />
+  <adapter factory=".deserializer.DeserializeFromJsonUrban" />
 
 </configure>

--- a/src/Products/urban/services/deserializer.py
+++ b/src/Products/urban/services/deserializer.py
@@ -1,0 +1,32 @@
+# -*- coding: utf-8 -*-
+from plone.restapi.deserializer import json_body
+from plone.restapi.deserializer.atcontent import DeserializeFromJson
+from plone.restapi.interfaces import IDeserializeFromJson
+from Products.Archetypes.interfaces import IBaseObject
+from Products.urban.interfaces import IProductUrbanLayer
+from zope.component import adapter
+from zope.interface import implementer
+
+
+@implementer(IDeserializeFromJson)
+@adapter(IBaseObject, IProductUrbanLayer)
+class DeserializeFromJsonUrban(DeserializeFromJson):
+    def validate(self):
+        """
+        Add a key "disable_check_ref_format" with a value true in the body json
+        to disable the check of the format of the reference field
+        """
+        data = json_body(self.request)
+        errors = super(DeserializeFromJsonUrban, self).validate()
+
+        if (
+            "disable_check_ref_format" in data
+            and data["disable_check_ref_format"]
+            and "reference" in errors
+            and errors["reference"].startswith(
+                "This reference does not match the expected format of"
+            )
+        ):
+            del errors["reference"]
+
+        return errors


### PR DESCRIPTION
Introducing an option in the license creation POST endpoint to disable reference format check.