### PR TITLE
SUP-31983. Fix icon tag in table

### DIFF
--- a/news/SUP-31983.bugfix
+++ b/news/SUP-31983.bugfix
@@ -1,0 +1,2 @@
+Fix icon tag in table
+[jchandelle]

--- a/src/Products/urban/browser/table/column.py
+++ b/src/Products/urban/browser/table/column.py
@@ -596,7 +596,13 @@ class GenerationColumn(LinkColumn):
     def renderCell(self, item):
         if not self.has_mailing(item):
             return ''
-        return super(GenerationColumn, self).renderCell(item)
+        return '<a href="%s"%s%s%s>%s</a>' % (
+            escape(self.getLinkURL(item)),
+            self.getLinkTarget(item),
+            self.getLinkCSS(item),
+            self.getLinkTitle(item),
+            self.getLinkContent(item),
+        )
 
 
 class InspectionReportVisitDate(UrbanColumn):


### PR DESCRIPTION
They add a html.escape on the content in z3c.table in rendering cell