### PR TITLE
Remove broken Liege browser layer

### DIFF
--- a/news/URB-3006.bugfix
+++ b/news/URB-3006.bugfix
@@ -1,0 +1,2 @@
+Remove broken Liege browser layer
+[daggelpop]

--- a/src/Products/urban/migration/upgrades.zcml
+++ b/src/Products/urban/migration/upgrades.zcml
@@ -173,4 +173,13 @@
         profile="Products.urban:default"
         />
 
+    <gs:upgradeStep
+        title="Remove broken Liege browser layer"
+        description=""
+        source="1137"
+        destination="1138"
+        handler=".update_codt_2024.remove_broken_liege_browserlayer"
+        profile="Products.urban:default"
+        />
+
 </configure>

--- a/src/Products/urban/profiles/default/metadata.xml
+++ b/src/Products/urban/profiles/default/metadata.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <metadata>
-  <version>1137</version>
+  <version>1138</version>
   <dependencies>
     <dependency>profile-Products.urban:preinstall</dependency>
   </dependencies>


### PR DESCRIPTION
Only needed for Liège.

The broken layer must be removed to fix collective.exportimport use.

It only "overwrites" the layer with an in-package "fake" layer.

-----

As a next step:

Unregistering this layer should work, but I couldn't be fully test it as transaction.commit() seems to break Undo's.
