### PR TITLE
fix'(profiles): change external doc link

### DIFF
--- a/news/SUP-33019.feature
+++ b/news/SUP-33019.feature
@@ -1,0 +1,2 @@
+Update external documentation link
+[bleybaert,daggelpop]

--- a/src/Products/urban/migration/update_270.py
+++ b/src/Products/urban/migration/update_270.py
@@ -361,3 +361,13 @@ def fix_external_decision_values(context):
                 opinion.setExternalDecision(external_decision[0])
 
     logger.info("upgrade step done!")
+
+
+def update_documentation_link(context):
+    logger = logging.getLogger("urban: Update documentation link")
+    logger.info("starting upgrade steps")
+
+    setup_tool = api.portal.get_tool("portal_setup")
+    setup_tool.runImportStepFromProfile("profile-Products.urban:default", "actions")
+
+    logger.info("upgrade step done!")

--- a/src/Products/urban/migration/upgrades.zcml
+++ b/src/Products/urban/migration/upgrades.zcml
@@ -738,4 +738,13 @@
         profile="Products.urban:default"
         />
 
+    <gs:upgradeStep
+        title="Update documentation link"
+        description=""
+        source="1160"
+        destination="1161"
+        handler=".update_270.update_documentation_link"
+        profile="Products.urban:default"
+        />
+
 </configure>

--- a/src/Products/urban/profiles/default/actions.xml
+++ b/src/Products/urban/profiles/default/actions.xml
@@ -22,9 +22,9 @@
    <property name="title">Documentation</property>
    <property name="description"></property>
    <property
-      name="url_expr">string:https://docs.imio.be/imio-doc/ia.urban/</property>
+      name="url_expr">string:https://docs.imio.be/iaurban/</property>
    <property
-      name="link_target">https://docs.imio.be/imio-doc/ia.urban/</property>
+      name="link_target">https://docs.imio.be/iaurban/</property>
    <property name="icon_expr"></property>
    <property name="available_expr"></property>
    <property name="permissions">

--- a/src/Products/urban/profiles/default/metadata.xml
+++ b/src/Products/urban/profiles/default/metadata.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <metadata>
-  <version>1160</version>
+  <version>1161</version>
   <dependencies>
     <dependency>profile-Products.urban:preinstall</dependency>
   </dependencies>


### PR DESCRIPTION
Hello,

J'ai changé le lien vers la doc externe dans le menu du compte utilisateur -> Documentation.
La nouvelle doc se trouve à l'adresse : https://docs.imio.be/iaurban/