### PR TITLE
SUP-36417: Add recipient import to public inquiries (Liège specific)

### DIFF
--- a/news/SUP-36417.feature
+++ b/news/SUP-36417.feature
@@ -1,0 +1,2 @@
+Add recipient import to inquiries
+[daggelpop]

--- a/src/Products/urban/browser/templates/urbaneventinquiryview.pt
+++ b/src/Products/urban/browser/templates/urbaneventinquiryview.pt
@@ -205,6 +205,13 @@
                                 </form>
                                 <p>&nbsp;</p>
                             </tal:block>
+
+                            <tal:import_recipients_form define="form python: view.import_recipients_listing_form">
+                                <tal:with-form-as-view define="view nocall:form">
+                                    <metal:block use-macro="form/@@ploneform-macros/titlelessform"/>
+                                </tal:with-form-as-view>
+                            </tal:import_recipients_form>
+
                             <tal:block condition="python: context.REQUEST.get('template_uid') != None">
                                 <tal:block define="docObj python:context.uid_catalog(UID=context.REQUEST.get('template_uid'))[0]">
                                     <Script tal:content="python:'document.location = \''+docObj.getObject().absolute_url()+'/external_edit\';'" />

--- a/src/Products/urban/browser/urbaneventviews.py
+++ b/src/Products/urban/browser/urbaneventviews.py
@@ -399,9 +399,12 @@ class ImportRecipientListingForm(form.Form):
             recipient_arg["adr1"] = "{} {}".format(
                 recipient_arg["zipcode"], recipient_arg["city"]
             )
-            recipient_arg["adr2"] = "{} {}".format(
+            adr2 = "{} {}".format(
                 recipient_arg["street"], recipient_arg["number"]
             )
+            if recipient_arg["number_index"]:
+                adr2 = "{} ({})".format(adr2, recipient_arg["number_index"])
+            recipient_arg["adr2"] = adr2
             # create recipient
             with api.env.adopt_roles(["Manager"]):
                 recipient_id = self.context.invokeFactory(

--- a/src/Products/urban/locales/fr/LC_MESSAGES/urban.po
+++ b/src/Products/urban/locales/fr/LC_MESSAGES/urban.po
@@ -572,9 +572,13 @@ msgstr "Etat du permis"
 msgid "Licence types"
 msgstr "Type de permis"
 
-#: ../browser/urbaneventviews.py:224
-msgid "Listing file"
-msgstr ""
+#: ../browser/urbaneventviews.py:250
+msgid "Listing file (claimants)"
+msgstr "Importer un fichier de réclamants (csv)"
+
+#: ../browser/urbaneventviews.py:319
+msgid "Listing file (recipients)"
+msgstr "Importer un fichier de destinataires (csv)"
 
 #: ../interfaces.py:663
 msgid "Mailing limit"
@@ -759,7 +763,11 @@ msgstr ""
 msgid "Tests Extension profile for urban."
 msgstr ""
 
-#: ../browser/urbaneventviews.py:510
+#: ../browser/urbaneventviews.py:367
+msgid "The CSV file couldn't be read properly. Please verify its structure and try again."
+msgstr "Le fichier CSV n'a pas pu être lu correctement. Veuillez vérifier son contenu et réessayer."
+
+#: ../browser/urbaneventviews.py:636
 msgid "The claimants import will be ready tomorrow!"
 msgstr "L'import des réclamants a bien été enregistré et sera éxécuté cette nuit"
 
@@ -2750,6 +2758,10 @@ msgstr "Si ce champ n'est pas rempli, l'identifiant de ce terme sera utilisé"
 #: BuildLicence.py
 msgid "urban_help_townshipCouncilFolder"
 msgstr "Si coché, un paragraphe supplémentaire apparaîtra dans le permis"
+
+#: ../browser/urbaneventviews.py:412
+msgid "urban_imported_recipients"
+msgstr "Destinataires importés"
 
 #. Default: "Buildlicencenumerotation"
 #: UrbanTool.py

--- a/src/Products/urban/locales/urban.pot
+++ b/src/Products/urban/locales/urban.pot
@@ -555,8 +555,12 @@ msgstr ""
 msgid "Licence types"
 msgstr ""
 
-#: ../browser/urbaneventviews.py:224
-msgid "Listing file"
+#: ../browser/urbaneventviews.py:250
+msgid "Listing file (claimants)"
+msgstr ""
+
+#: ../browser/urbaneventviews.py:319
+msgid "Listing file (recipients)"
 msgstr ""
 
 #: ../interfaces.py:663
@@ -741,7 +745,11 @@ msgstr ""
 msgid "Tests Extension profile for urban."
 msgstr ""
 
-#: ../browser/urbaneventviews.py:510
+#: ../browser/urbaneventviews.py:367
+msgid "The CSV file couldn't be read properly. Please verify its structure and try again."
+msgstr ""
+
+#: ../browser/urbaneventviews.py:636
 msgid "The claimants import will be ready tomorrow!"
 msgstr ""
 
@@ -2716,6 +2724,10 @@ msgstr ""
 #. Default: "If checked, an additional paragraph will be added in the licence document"
 #: BuildLicence.py
 msgid "urban_help_townshipCouncilFolder"
+msgstr ""
+
+#: ../browser/urbaneventviews.py:412
+msgid "urban_imported_recipients"
 msgstr ""
 
 #. Default: "Buildlicencenumerotation"


### PR DESCRIPTION
The CSV format is different from the template used in Urban Classic (URB-2573).

Most notably, there is no handling of national registry numbers.