### PR TITLE
URB-3131: Give dynamic group reader roles for obsolete licences

### DIFF
--- a/news/URB-3131.bugfix
+++ b/news/URB-3131.bugfix
@@ -1,0 +1,2 @@
+Give dynamic group reader roles for obsolete licences
+[daggelpop]

--- a/src/Products/urban/workflows/codt_licence_workflow.py
+++ b/src/Products/urban/workflows/codt_licence_workflow.py
@@ -58,4 +58,9 @@ class StateRolesMapping(BaseRoleMapping):
             BaseRoleMapping.get_readers: ("Reader",),
             BaseRoleMapping.get_editors: ("Reader", "Reviewer"),
         },
+        "obsolete": {
+            BaseRoleMapping.get_readers: ("Reader",),
+            BaseRoleMapping.get_editors: ("Reader", "Reviewer"),
+            BaseRoleMapping.get_opinion_editors: ("Reader",),
+        },
     }


### PR DESCRIPTION
Equivalent for Liège: https://github.com/IMIO/liege.urban/pull/9