### PR TITLE
SUP-35563: Fix comment retrieval in transition form

### DIFF
--- a/news/SUP-35563.bugfix
+++ b/news/SUP-35563.bugfix
@@ -1,0 +1,2 @@
+Fix comment retrieval in transition form
+[daggelpop]

--- a/src/Products/urban/browser/actionspanel/confirm.pt
+++ b/src/Products/urban/browser/actionspanel/confirm.pt
@@ -19,7 +19,7 @@
     </script>
 
     <h1 class="documentFirstHeading" tal:content="context/Title">Title</h1>
-    <form id="confirmTransitionForm">
+    <form id="commentsForm">
     <tal:warning condition="view/has_open_tasks">
         <br />
        <table class="listing task_status_table" tal:define="tasks view/get_started_tasks"


### PR DESCRIPTION
Bug lié à un changement dans imio.actionspanel:

https://github.com/IMIO/imio.actionspanel/commit/681387fd340e08d6791b419b4d22d4301ac0a874#diff-83e0e6355908b4fe2c96542c0e7caed7d984cbb1d2563c92ab2788a65da58760R58

Le javascript pour récupérer le texte du champ commentaire se base sur un nouveau sélecteur.