### PR TITLE
SUP-39098 : Fix address comparison in _areSameAdresses

### DIFF
--- a/news/SUP-39098.bugfix
+++ b/news/SUP-39098.bugfix
@@ -1,0 +1,2 @@
+Fix address comparison in _areSameAdresses
+[dmshd]

--- a/news/SUP-39098_erreur_encodage_proprietaire_sans_adresse.bugfix
+++ b/news/SUP-39098_erreur_encodage_proprietaire_sans_adresse.bugfix
@@ -1,0 +1,2 @@
+SUP-39098 : Fix address comparison in _areSameAdresses
+[dmshd]

--- a/news/SUP-39098_erreur_encodage_proprietaire_sans_adresse.bugfix
+++ b/news/SUP-39098_erreur_encodage_proprietaire_sans_adresse.bugfix
@@ -1,2 +1,0 @@
-SUP-39098 : Fix address comparison in _areSameAdresses
-[dmshd]

--- a/src/Products/urban/browser/searchparcelsview.py
+++ b/src/Products/urban/browser/searchparcelsview.py
@@ -280,6 +280,9 @@ class SearchParcelsView(BrowserView):
                 street_b = street.getStreetName().decode("utf8")
             number_b = wl["number"]
 
+        if not all([street_a, street_b, number_a, number_b]):
+            return False
+
         same_street = Levenshtein.ratio(street_a, street_b) > 0.8
         same_number = self._haveSameNumbers(number_a, number_b)
 


### PR DESCRIPTION
This fixes the following error.
I did it in pair @daggelpop and I reproduced the same problem with the same data locally and our code seems to resolve the problem.
Problem was if `street_a` was empty (tenant had no address set in the "cadastre", the tace was generated and the tenants where not properly created. See https://support.imio.be/browse/SUP-39098 for more info.
```
<155>Sep 19 13:25:59 urban007 zope[2243328]: lalouviere_urb25 instance2 [ERROR] Zope.SiteErrorLog | 1726745159.670.781332659531 https://lalouviere-urban.imio-app.be/urban/codt_urbancertificateones/codt_urbancertificateones/codt_urbancertificateone.2024-09-19.7151418318/searchparcels
Traceback (innermost last):
  Module ZPublisher.Publish, line 138, in publish
  Module ZPublisher.mapply, line 77, in mapply
  Module ZPublisher.Publish, line 48, in call_object
  Module Products.urban.browser.searchparcelsview, line 74, in __call__
  Module Products.urban.browser.searchparcelsview, line 197, in createParcelAndProprietary
  Module Products.urban.browser.searchparcelsview, line 248, in createApplicantFromParcel
  Module Products.urban.browser.searchparcelsview, line 283, in _areSameAdresses
TypeError: ratio expected two Strings or two Unicodes
```