### PR TITLE
Handle null value in `EventTypeConditionExecutor`

### DIFF
--- a/news/SUP-39901.bugfix
+++ b/news/SUP-39901.bugfix
@@ -1,0 +1,2 @@
+Handle null value in `EventTypeConditionExecutor`
+[daggelpop]

--- a/src/Products/urban/contentrules/event_type.py
+++ b/src/Products/urban/contentrules/event_type.py
@@ -57,10 +57,11 @@ class EventTypeConditionExecutor(object):
         self.event = event
 
     def __call__(self):
+        config_event_types = []
         event_type_condition = self.element.event_type
-        config_event_types = self.event.object.getUrbaneventtypes().eventType
-        if not config_event_types:
-            config_event_types = []
+        event_config = self.event.object.getUrbaneventtypes()
+        if event_config:
+            config_event_types = event_config.eventType
         return event_type_condition in config_event_types
 
 


### PR DESCRIPTION
`getUrbaneventtypes()` sometimes returns nothing.