### PR TITLE
SUP-40288_fix_external_decision_values

### DIFF
--- a/news/SUP-40288.bugfix
+++ b/news/SUP-40288.bugfix
@@ -1,2 +1,5 @@
 Fix external decision values
 [daggelpop]
+
+Handle default vocabulary values for a non-array field
+[daggelpop]

--- a/news/SUP-40288.bugfix
+++ b/news/SUP-40288.bugfix
@@ -1,0 +1,2 @@
+Fix external decision values
+[daggelpop]

--- a/src/Products/urban/UrbanEvent.py
+++ b/src/Products/urban/UrbanEvent.py
@@ -592,12 +592,19 @@ class UrbanEvent(BaseFolder, BrowserDefaultMixin):
         if not context or not field:
             return [""]
 
-        empty_value = getattr(field, "multivalued", "") and [] or ""
+        multivalued = bool(getattr(field, "multivalued", ""))
+        empty_value = multivalued and [] or ""
         if hasattr(field, "vocabulary") and isinstance(
             field.vocabulary, UrbanVocabulary
         ):
             licence = context.aq_parent
-            return field.vocabulary.get_default_values(licence)
+            default_values = field.vocabulary.get_default_values(licence)
+            # handle case of a list of default values (only one, in principle) for a string field
+            if not multivalued and type(default_values) == list and len(default_values) > 0:
+                return default_values[0]
+            else:
+                return default_values
+
         return empty_value
 
     security.declarePublic("getDefaultText")

--- a/src/Products/urban/migration/update_270.py
+++ b/src/Products/urban/migration/update_270.py
@@ -2,6 +2,7 @@
 
 from Acquisition import aq_parent
 from OFS.interfaces import IOrderedContainer
+from Products.urban.interfaces import IGenericLicence
 from Products.urban.migration.utils import refresh_workflow_permissions
 from Products.urban.setuphandlers import createFolderDefaultValues
 from imio.schedule.content.object_factories import MacroCreationConditionObject
@@ -327,5 +328,22 @@ def fix_patrimony_certificate_class(context):
         licence.meta_type = "PatrimonyCertificate"
         licence.schema = PatrimonyCertificate.schema
         licence.reindexObject()
+
+    logger.info("upgrade step done!")
+
+
+def fix_external_decision_values(context):
+    logger = logging.getLogger("urban: Fix external decision values")
+    logger.info("starting upgrade steps")
+
+    catalog = api.portal.get_tool("portal_catalog")
+    licence_brains = catalog(object_provides=IGenericLicence.__identifier__)
+
+    for licence_brain in licence_brains:
+        licence = licence_brain.getObject()
+        for opinion in licence.objectValues("UrbanEventOpinionRequest"):
+            external_decision = opinion.getField("externalDecision").get(opinion)
+            if type(external_decision) is list and len(external_decision) == 1:
+                opinion.setExternalDecision(external_decision[0])
 
     logger.info("upgrade step done!")

--- a/src/Products/urban/migration/upgrades.zcml
+++ b/src/Products/urban/migration/upgrades.zcml
@@ -729,4 +729,13 @@
         profile="Products.urban:default"
         />
 
+    <gs:upgradeStep
+        title="Fix external decision values (list[str] -> str)"
+        description=""
+        source="1159"
+        destination="1160"
+        handler=".update_270.fix_external_decision_values"
+        profile="Products.urban:default"
+        />
+
 </configure>

--- a/src/Products/urban/profiles/default/metadata.xml
+++ b/src/Products/urban/profiles/default/metadata.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <metadata>
-  <version>1159</version>
+  <version>1160</version>
   <dependencies>
     <dependency>profile-Products.urban:preinstall</dependency>
   </dependencies>


### PR DESCRIPTION
One term for external decision vocabulary ("favorable-defaut") is  "isDefaultValue": True

When using button "add all opinion requests", getDefaultValue sets ["favorable-defaut"] instead of "favorable-defaut".

=> handle this case + fix existing values via migration