### PR TITLE
URB-3121: Add patrimony fieldset to multiple licence types

### DIFF
--- a/news/URB-3121.feature
+++ b/news/URB-3121.feature
@@ -1,0 +1,2 @@
+Add patrimony fieldset to multiple licence types
+[daggelpop]

--- a/src/Products/urban/LicenceConfig.py
+++ b/src/Products/urban/LicenceConfig.py
@@ -488,6 +488,7 @@ class LicenceConfig(BaseFolder, BrowserDefaultMixin, OrderedContainer):
             "environment",
             "location",
             "road",
+            "patrimony",
         ]
         env_inquiry_tabs_config = [
             "description",
@@ -497,8 +498,15 @@ class LicenceConfig(BaseFolder, BrowserDefaultMixin, OrderedContainer):
             "environment",
             "location",
             "road",
+            "patrimony",
         ]
-        inspection_tabs_config = ["description", "advices", "inspection", "location"]
+        inspection_tabs_config = [
+            "description",
+            "advices",
+            "inspection",
+            "location",
+            "patrimony",
+        ]
         patrimonycertificate_tabs_config = [
             "description",
             "analysis",
@@ -506,7 +514,15 @@ class LicenceConfig(BaseFolder, BrowserDefaultMixin, OrderedContainer):
             "road",
             "patrimony",
         ]
-        ticket_tabs_config = ["description", "inspection", "location"]
+        ticket_tabs_config = ["description", "inspection", "location", "patrimony"]
+        miscdemand_tabs_config = ["description", "analysis", "location", "road", "patrimony"]
+        explosivespossession_tabs_config = [
+            "description",
+            "advices",
+            "inquiry",
+            "environment",
+            "patrimony",
+        ]
 
         types = {
             "buildlicence": buildlicence_tabs_config,
@@ -527,18 +543,16 @@ class LicenceConfig(BaseFolder, BrowserDefaultMixin, OrderedContainer):
             "envclassthree": env_advice_tabs_config,
             "envclassone": env_inquiry_tabs_config,
             "envclasstwo": env_inquiry_tabs_config,
-            "explosivespossession": [
-                "description",
-                "advices",
-                "inquiry",
-                "environment",
-            ],
+            "explosivespossession": explosivespossession_tabs_config,
             "envclassbordering": env_inquiry_tabs_config,
             "inspection": inspection_tabs_config,
             "patrimonycertificate": patrimonycertificate_tabs_config,
             "ticket": ticket_tabs_config,
             "roaddecree": buildlicence_tabs_config,
             "division": certificatebase_tabs_config,
+            "miscdemand": miscdemand_tabs_config,
+            "projectmeeting": miscdemand_tabs_config,
+            "preliminarynotice": miscdemand_tabs_config,
         }
         licence_type = self.id
 

--- a/src/Products/urban/browser/licence/envclassborderingview.py
+++ b/src/Products/urban/browser/licence/envclassborderingview.py
@@ -26,3 +26,19 @@ class EnvClassBorderingView(EnvironmentLicenceView):
 
     def getExpirationDate(self):
         return None
+
+    def getPatrimonyFields(self):
+        return self.getSchemataFields(schemata="urban_patrimony")
+
+    def getRankingOrdinanceLink(self):
+        liendoc = "http://spw.wallonie.be/dgo4/index.php?thema=bc_pat&details=57081-CLT-0239-01"
+        return liendoc
+
+    def getRankingOrdinanceTitle(self):
+        code_dgo4 = "code dgo4"
+        libelle = "libelle"
+        historique_dossier = "historique_dossier"
+        liendoc = "liendoc"
+        return "{} - {} - {} - {}".format(
+            code_dgo4, libelle, historique_dossier, liendoc
+        )

--- a/src/Products/urban/browser/licence/envclassoneview.py
+++ b/src/Products/urban/browser/licence/envclassoneview.py
@@ -25,3 +25,19 @@ class EnvClassOneView(EnvironmentLicenceView):
 
     def getExpirationDate(self):
         return None
+
+    def getPatrimonyFields(self):
+        return self.getSchemataFields(schemata="urban_patrimony")
+
+    def getRankingOrdinanceLink(self):
+        liendoc = "http://spw.wallonie.be/dgo4/index.php?thema=bc_pat&details=57081-CLT-0239-01"
+        return liendoc
+
+    def getRankingOrdinanceTitle(self):
+        code_dgo4 = "code dgo4"
+        libelle = "libelle"
+        historique_dossier = "historique_dossier"
+        liendoc = "liendoc"
+        return "{} - {} - {} - {}".format(
+            code_dgo4, libelle, historique_dossier, liendoc
+        )

--- a/src/Products/urban/browser/licence/envclassthreeview.py
+++ b/src/Products/urban/browser/licence/envclassthreeview.py
@@ -19,3 +19,19 @@ class EnvClassThreeView(EnvironmentLicenceView):
 
     def getMacroViewName(self):
         return "envclassthree-macros"
+
+    def getPatrimonyFields(self):
+        return self.getSchemataFields(schemata="urban_patrimony")
+
+    def getRankingOrdinanceLink(self):
+        liendoc = "http://spw.wallonie.be/dgo4/index.php?thema=bc_pat&details=57081-CLT-0239-01"
+        return liendoc
+
+    def getRankingOrdinanceTitle(self):
+        code_dgo4 = "code dgo4"
+        libelle = "libelle"
+        historique_dossier = "historique_dossier"
+        liendoc = "liendoc"
+        return "{} - {} - {} - {}".format(
+            code_dgo4, libelle, historique_dossier, liendoc
+        )

--- a/src/Products/urban/browser/licence/envclasstwoview.py
+++ b/src/Products/urban/browser/licence/envclasstwoview.py
@@ -25,3 +25,19 @@ class EnvClassTwoView(EnvironmentLicenceView):
 
     def getExpirationDate(self):
         return None
+
+    def getPatrimonyFields(self):
+        return self.getSchemataFields(schemata="urban_patrimony")
+
+    def getRankingOrdinanceLink(self):
+        liendoc = "http://spw.wallonie.be/dgo4/index.php?thema=bc_pat&details=57081-CLT-0239-01"
+        return liendoc
+
+    def getRankingOrdinanceTitle(self):
+        code_dgo4 = "code dgo4"
+        libelle = "libelle"
+        historique_dossier = "historique_dossier"
+        liendoc = "liendoc"
+        return "{} - {} - {} - {}".format(
+            code_dgo4, libelle, historique_dossier, liendoc
+        )

--- a/src/Products/urban/browser/licence/explosivespossessionview.py
+++ b/src/Products/urban/browser/licence/explosivespossessionview.py
@@ -23,3 +23,19 @@ class ExplosivesPossessionView(EnvironmentLicenceView):
 
     def getExpirationDate(self):
         return None
+
+    def getPatrimonyFields(self):
+        return self.getSchemataFields(schemata="urban_patrimony")
+
+    def getRankingOrdinanceLink(self):
+        liendoc = "http://spw.wallonie.be/dgo4/index.php?thema=bc_pat&details=57081-CLT-0239-01"
+        return liendoc
+
+    def getRankingOrdinanceTitle(self):
+        code_dgo4 = "code dgo4"
+        libelle = "libelle"
+        historique_dossier = "historique_dossier"
+        liendoc = "liendoc"
+        return "{} - {} - {} - {}".format(
+            code_dgo4, libelle, historique_dossier, liendoc
+        )

--- a/src/Products/urban/browser/licence/inspectionview.py
+++ b/src/Products/urban/browser/licence/inspectionview.py
@@ -48,3 +48,19 @@ class InspectionView(LicenceView):
     def renderRepportsListing(self):
         reporttable = InspectionReportsTable(self.context, self.request)
         return self.renderListing(reporttable)
+
+    def getPatrimonyFields(self):
+        return self.getSchemataFields(schemata="urban_patrimony")
+
+    def getRankingOrdinanceLink(self):
+        liendoc = "http://spw.wallonie.be/dgo4/index.php?thema=bc_pat&details=57081-CLT-0239-01"
+        return liendoc
+
+    def getRankingOrdinanceTitle(self):
+        code_dgo4 = "code dgo4"
+        libelle = "libelle"
+        historique_dossier = "historique_dossier"
+        liendoc = "liendoc"
+        return "{} - {} - {} - {}".format(
+            code_dgo4, libelle, historique_dossier, liendoc
+        )

--- a/src/Products/urban/browser/licence/miscdemandview.py
+++ b/src/Products/urban/browser/licence/miscdemandview.py
@@ -21,3 +21,19 @@ class MiscDemandView(LicenceView):
 
     def getMacroViewName(self):
         return "miscdemand-macros"
+
+    def getPatrimonyFields(self):
+        return self.getSchemataFields(schemata="urban_patrimony")
+
+    def getRankingOrdinanceLink(self):
+        liendoc = "http://spw.wallonie.be/dgo4/index.php?thema=bc_pat&details=57081-CLT-0239-01"
+        return liendoc
+
+    def getRankingOrdinanceTitle(self):
+        code_dgo4 = "code dgo4"
+        libelle = "libelle"
+        historique_dossier = "historique_dossier"
+        liendoc = "liendoc"
+        return "{} - {} - {} - {}".format(
+            code_dgo4, libelle, historique_dossier, liendoc
+        )

--- a/src/Products/urban/browser/licence/preliminarynoticeview.py
+++ b/src/Products/urban/browser/licence/preliminarynoticeview.py
@@ -21,3 +21,19 @@ class PreliminaryNoticeView(LicenceView):
 
     def getMacroViewName(self):
         return "preliminarynotice-macros"
+
+    def getPatrimonyFields(self):
+        return self.getSchemataFields(schemata="urban_patrimony")
+
+    def getRankingOrdinanceLink(self):
+        liendoc = "http://spw.wallonie.be/dgo4/index.php?thema=bc_pat&details=57081-CLT-0239-01"
+        return liendoc
+
+    def getRankingOrdinanceTitle(self):
+        code_dgo4 = "code dgo4"
+        libelle = "libelle"
+        historique_dossier = "historique_dossier"
+        liendoc = "liendoc"
+        return "{} - {} - {} - {}".format(
+            code_dgo4, libelle, historique_dossier, liendoc
+        )

--- a/src/Products/urban/browser/licence/projectmeetingview.py
+++ b/src/Products/urban/browser/licence/projectmeetingview.py
@@ -21,3 +21,19 @@ class ProjectMeetingView(LicenceView):
 
     def getMacroViewName(self):
         return "projectmeeting-macros"
+
+    def getPatrimonyFields(self):
+        return self.getSchemataFields(schemata="urban_patrimony")
+
+    def getRankingOrdinanceLink(self):
+        liendoc = "http://spw.wallonie.be/dgo4/index.php?thema=bc_pat&details=57081-CLT-0239-01"
+        return liendoc
+
+    def getRankingOrdinanceTitle(self):
+        code_dgo4 = "code dgo4"
+        libelle = "libelle"
+        historique_dossier = "historique_dossier"
+        liendoc = "liendoc"
+        return "{} - {} - {} - {}".format(
+            code_dgo4, libelle, historique_dossier, liendoc
+        )

--- a/src/Products/urban/browser/licence/templates/envclassborderingmacros.pt
+++ b/src/Products/urban/browser/licence/templates/envclassborderingmacros.pt
@@ -84,3 +84,8 @@
 <metal:inquiry define-macro="inquiry_macro" i18n:domain="urban">
     <metal:parent_call use-macro="here/@@licencetabs-macros/inquiry_macro" />
 </metal:inquiry>
+
+<metal:patrimony define-macro="patrimony_macro" i18n:domain="urban">
+    <metal:parent_call use-macro="here/@@licencetabs-macros/patrimony_macro">
+    </metal:parent_call>
+</metal:patrimony>

--- a/src/Products/urban/browser/licence/templates/envclassonemacros.pt
+++ b/src/Products/urban/browser/licence/templates/envclassonemacros.pt
@@ -52,3 +52,8 @@
 <metal:inquiry define-macro="inquiry_macro" i18n:domain="urban">
     <metal:parent_call use-macro="here/@@licencetabs-macros/inquiry_macro" />
 </metal:inquiry>
+
+<metal:patrimony define-macro="patrimony_macro" i18n:domain="urban">
+    <metal:parent_call use-macro="here/@@licencetabs-macros/patrimony_macro">
+    </metal:parent_call>
+</metal:patrimony>

--- a/src/Products/urban/browser/licence/templates/envclassthreemacros.pt
+++ b/src/Products/urban/browser/licence/templates/envclassthreemacros.pt
@@ -43,3 +43,8 @@
 <metal:advices define-macro="advices_macro" i18n:domain="urban">
     <metal:parent_call use-macro="here/@@licencetabs-macros/advices_macro" />
 </metal:advices>
+
+<metal:patrimony define-macro="patrimony_macro" i18n:domain="urban">
+    <metal:parent_call use-macro="here/@@licencetabs-macros/patrimony_macro">
+    </metal:parent_call>
+</metal:patrimony>

--- a/src/Products/urban/browser/licence/templates/envclasstwomacros.pt
+++ b/src/Products/urban/browser/licence/templates/envclasstwomacros.pt
@@ -57,3 +57,8 @@
 <metal:inquiry define-macro="inquiry_macro" i18n:domain="urban">
     <metal:parent_call use-macro="here/@@licencetabs-macros/inquiry_macro" />
 </metal:inquiry>
+
+<metal:patrimony define-macro="patrimony_macro" i18n:domain="urban">
+    <metal:parent_call use-macro="here/@@licencetabs-macros/patrimony_macro">
+    </metal:parent_call>
+</metal:patrimony>

--- a/src/Products/urban/browser/licence/templates/explosivespossessionmacros.pt
+++ b/src/Products/urban/browser/licence/templates/explosivespossessionmacros.pt
@@ -37,3 +37,8 @@
 <metal:inquiry define-macro="inquiry_macro" i18n:domain="urban">
     <metal:parent_call use-macro="here/@@licencetabs-macros/inquiry_macro" />
 </metal:inquiry>
+
+<metal:patrimony define-macro="patrimony_macro" i18n:domain="urban">
+    <metal:parent_call use-macro="here/@@licencetabs-macros/patrimony_macro">
+    </metal:parent_call>
+</metal:patrimony>

--- a/src/Products/urban/browser/licence/templates/inspectionmacros.pt
+++ b/src/Products/urban/browser/licence/templates/inspectionmacros.pt
@@ -36,3 +36,8 @@
     <metal:parent_call use-macro="here/@@licencetabs-macros/location_macro">
     </metal:parent_call>
 </metal:location>
+
+<metal:patrimony define-macro="patrimony_macro" i18n:domain="urban">
+    <metal:parent_call use-macro="here/@@licencetabs-macros/patrimony_macro">
+    </metal:parent_call>
+</metal:patrimony>

--- a/src/Products/urban/browser/licence/templates/miscdemandmacros.pt
+++ b/src/Products/urban/browser/licence/templates/miscdemandmacros.pt
@@ -26,3 +26,8 @@
     <metal:parent_call use-macro="here/@@licencetabs-macros/location_macro">
     </metal:parent_call>
 </metal:location>
+
+<metal:patrimony define-macro="patrimony_macro" i18n:domain="urban">
+    <metal:parent_call use-macro="here/@@licencetabs-macros/patrimony_macro">
+    </metal:parent_call>
+</metal:patrimony>

--- a/src/Products/urban/browser/licence/templates/preliminarynoticemacros.pt
+++ b/src/Products/urban/browser/licence/templates/preliminarynoticemacros.pt
@@ -33,3 +33,8 @@
     <metal:parent_call use-macro="here/@@licencetabs-macros/location_macro">
     </metal:parent_call>
 </metal:location>
+
+<metal:patrimony define-macro="patrimony_macro" i18n:domain="urban">
+    <metal:parent_call use-macro="here/@@licencetabs-macros/patrimony_macro">
+    </metal:parent_call>
+</metal:patrimony>

--- a/src/Products/urban/browser/licence/templates/projectmeetingmacros.pt
+++ b/src/Products/urban/browser/licence/templates/projectmeetingmacros.pt
@@ -33,3 +33,8 @@
     <metal:parent_call use-macro="here/@@licencetabs-macros/location_macro">
     </metal:parent_call>
 </metal:location>
+
+<metal:patrimony define-macro="patrimony_macro" i18n:domain="urban">
+    <metal:parent_call use-macro="here/@@licencetabs-macros/patrimony_macro">
+    </metal:parent_call>
+</metal:patrimony>

--- a/src/Products/urban/browser/licence/templates/ticketmacros.pt
+++ b/src/Products/urban/browser/licence/templates/ticketmacros.pt
@@ -32,3 +32,8 @@
     <metal:parent_call use-macro="here/@@licencetabs-macros/location_macro">
     </metal:parent_call>
 </metal:location>
+
+<metal:patrimony define-macro="patrimony_macro" i18n:domain="urban">
+    <metal:parent_call use-macro="here/@@licencetabs-macros/patrimony_macro">
+    </metal:parent_call>
+</metal:patrimony>

--- a/src/Products/urban/browser/licence/ticketview.py
+++ b/src/Products/urban/browser/licence/ticketview.py
@@ -39,3 +39,19 @@ class TicketView(LicenceView):
     def renderRepportsListing(self):
         reporttable = InspectionReportsTable(self.context, self.request)
         return self.renderListing(reporttable)
+
+    def getPatrimonyFields(self):
+        return self.getSchemataFields(schemata="urban_patrimony")
+
+    def getRankingOrdinanceLink(self):
+        liendoc = "http://spw.wallonie.be/dgo4/index.php?thema=bc_pat&details=57081-CLT-0239-01"
+        return liendoc
+
+    def getRankingOrdinanceTitle(self):
+        code_dgo4 = "code dgo4"
+        libelle = "libelle"
+        historique_dossier = "historique_dossier"
+        liendoc = "liendoc"
+        return "{} - {} - {} - {}".format(
+            code_dgo4, libelle, historique_dossier, liendoc
+        )

--- a/src/Products/urban/content/licence/EnvClassThree.py
+++ b/src/Products/urban/content/licence/EnvClassThree.py
@@ -14,6 +14,7 @@ __author__ = """Gauthier BASTIEN <gbastien@commune.sambreville.be>, Stephan GEUL
 __docformat__ = "plaintext"
 
 from AccessControl import ClassSecurityInfo
+from Products.MasterSelectWidget.MasterSelectWidget import MasterSelectWidget
 from Products.urban.widget.select2widget import MultiSelect2Widget
 from Products.Archetypes.atapi import *
 from zope.interface import implements
@@ -31,6 +32,88 @@ from Products.urban.config import *
 ##code-section module-header #fill in your manual code here
 from Products.MasterSelectWidget.MasterBooleanWidget import MasterBooleanWidget
 from Products.urban.UrbanVocabularyTerm import UrbanVocabulary
+
+from collective.archetypes.select2.select2widget import MultiSelect2Widget
+
+
+full_patrimony_slave_fields = (
+    {
+        "name": "patrimony_site",
+        "action": "hide",
+        "hide_values": ("none",),
+    },
+    {
+        "name": "patrimony_architectural_complex",
+        "action": "hide",
+        "hide_values": ("none",),
+    },
+    {
+        "name": "archeological_site",
+        "action": "hide",
+        "hide_values": ("none",),
+    },
+    {
+        "name": "protection_zone",
+        "action": "hide",
+        "hide_values": ("none",),
+    },
+    {
+        "name": "regional_inventory_building",
+        "action": "hide",
+        "hide_values": ("none",),
+    },
+    {
+        "name": "small_popular_patrimony",
+        "action": "hide",
+        "hide_values": ("none",),
+    },
+    {
+        "name": "communal_inventory",
+        "action": "hide",
+        "hide_values": ("none",),
+    },
+    {
+        "name": "regional_inventory",
+        "action": "hide",
+        "hide_values": ("none",),
+    },
+    {
+        "name": "patrimony_archaeological_map",
+        "action": "hide",
+        "hide_values": ("none",),
+    },
+    {
+        "name": "patrimony_project_gtoret_1ha",
+        "action": "hide",
+        "hide_values": ("none",),
+    },
+    {
+        "name": "observation",
+        "action": "hide",
+        "hide_values": ("none",),
+    },
+    {
+        "name": "patrimony_monument",
+        "action": "hide",
+        "hide_values": ("none", "patrimonial"),
+    },
+    {
+        "name": "classification_order_scope",
+        "action": "hide",
+        "hide_values": ("none", "patrimonial"),
+    },
+    {
+        "name": "patrimony_analysis",
+        "action": "hide",
+        "hide_values": ("none",),
+    },
+    {
+        "name": "patrimony_observation",
+        "action": "hide",
+        "hide_values": ("none",),
+    },
+)
+
 
 slave_fields_additionalconditions = (
     {
@@ -122,6 +205,173 @@ schema = Schema(
             default_method="getDefaultText",
             default_output_type="text/x-html-safe",
         ),
+        StringField(
+            name="patrimony",
+            default="none",
+            widget=MasterSelectWidget(
+                slave_fields=full_patrimony_slave_fields,
+                label=_("urban_label_patrimony", default="Patrimony"),
+            ),
+            vocabulary="list_patrimony_types",
+            schemata="urban_patrimony",
+        ),
+        BooleanField(
+            name="archeological_site",
+            default=False,
+            widget=BooleanField._properties["widget"](
+                label=_("urban_label_archeological_site", default="Archeological_site"),
+            ),
+            schemata="urban_patrimony",
+        ),
+        BooleanField(
+            name="protection_zone",
+            default=False,
+            widget=BooleanField._properties["widget"](
+                label=_("urban_label_protection_zone", default="Protection_zone"),
+            ),
+            schemata="urban_patrimony",
+        ),
+        BooleanField(
+            name="regional_inventory_building",
+            default=False,
+            widget=BooleanField._properties["widget"](
+                label=_(
+                    "urban_label_regional_inventory_building",
+                    default="Regional_inventory_building",
+                ),
+            ),
+            schemata="urban_patrimony",
+        ),
+        BooleanField(
+            name="small_popular_patrimony",
+            default=False,
+            widget=BooleanField._properties["widget"](
+                label=_(
+                    "urban_label_small_popular_patrimony",
+                    default="Small_popular_patrimony",
+                ),
+            ),
+            schemata="urban_patrimony",
+        ),
+        BooleanField(
+            name="communal_inventory",
+            default=False,
+            widget=BooleanField._properties["widget"](
+                label=_("urban_label_communal_inventory", default="Communal_inventory"),
+            ),
+            schemata="urban_patrimony",
+        ),
+        BooleanField(
+            name="regional_inventory",
+            default=False,
+            widget=BooleanField._properties["widget"](
+                label=_("urban_label_regional_inventory", default="Regional_inventory"),
+            ),
+            schemata="urban_patrimony",
+        ),
+        TextField(
+            name="patrimony_analysis",
+            widget=RichWidget(
+                label=_("urban_label_patrimony_analysis", default="Patrimony_analysis"),
+            ),
+            default_content_type="text/html",
+            allowable_content_types=("text/html",),
+            schemata="urban_patrimony",
+            default_method="getDefaultText",
+            default_output_type="text/x-html-safe",
+            accessor="PatrimonyAnalysis",
+        ),
+        BooleanField(
+            name="patrimony_architectural_complex",
+            default=False,
+            widget=BooleanField._properties["widget"](
+                label=_(
+                    "urban_label_patrimony_architectural_complex",
+                    default="Patrimony_architectural_complex",
+                ),
+            ),
+            schemata="urban_patrimony",
+        ),
+        BooleanField(
+            name="patrimony_site",
+            default=False,
+            widget=BooleanField._properties["widget"](
+                label=_("urban_label_patrimony_site", default="Patrimony_site"),
+            ),
+            schemata="urban_patrimony",
+        ),
+        BooleanField(
+            name="patrimony_archaeological_map",
+            default=False,
+            widget=BooleanField._properties["widget"](
+                label=_(
+                    "urban_label_patrimony_archaeological_map",
+                    default="Patrimony_archaeological_map",
+                ),
+            ),
+            schemata="urban_patrimony",
+        ),
+        BooleanField(
+            name="patrimony_project_gtoret_1ha",
+            default=False,
+            widget=BooleanField._properties["widget"](
+                label=_(
+                    "urban_label_patrimony_project_gtoret_1ha",
+                    default="Patrimony_project_gtoret_1ha",
+                ),
+            ),
+            schemata="urban_patrimony",
+        ),
+        BooleanField(
+            name="patrimony_monument",
+            default=False,
+            widget=BooleanField._properties["widget"](
+                label=_("urban_label_patrimony_monument", default="Patrimony_monument"),
+            ),
+            schemata="urban_patrimony",
+        ),
+        TextField(
+            name="patrimony_observation",
+            widget=RichWidget(
+                label=_(
+                    "urban_label_patrimony_observation", default="Patrimony_observation"
+                ),
+            ),
+            default_content_type="text/html",
+            allowable_content_types=("text/html",),
+            schemata="urban_patrimony",
+            default_method="getDefaultText",
+            default_output_type="text/x-html-safe",
+            accessor="PatrimonyObservation",
+        ),
+        LinesField(
+            name="classification_order_scope",
+            widget=MultiSelect2Widget(
+                format="checkbox",
+                label=_(
+                    "urban_label_classification_order_scope",
+                    default="Classification_order_scope",
+                ),
+            ),
+            schemata="urban_patrimony",
+            multiValued=1,
+            vocabulary=UrbanVocabulary(
+                "classification_order_scope", inUrbanConfig=False
+            ),
+            default_method="getDefaultValue",
+        ),
+        StringField(
+            name="general_disposition",
+            widget=SelectionWidget(
+                label=_(
+                    "urban_label_general_disposition", default="General_disposition"
+                ),
+            ),
+            schemata="urban_patrimony",
+            vocabulary=UrbanVocabulary(
+                "general_disposition", inUrbanConfig=False, with_empty_value=True
+            ),
+        ),
     ),
 )
 
@@ -170,6 +420,15 @@ class EnvClassThree(BaseFolder, EnvironmentBase, BrowserDefaultMixin):
     def getProcedureDelays(self, *values):
         return "15j"
 
+    def list_patrimony_types(self):
+        """ """
+        vocabulary = (
+            ("none", "aucune incidence"),
+            ("patrimonial", "incidence patrimoniale"),
+            ("classified", "bien classé"),
+        )
+        return DisplayList(vocabulary)
+
 
 registerType(EnvClassThree, PROJECTNAME)
 # end of class EnvClassThree
@@ -187,6 +446,8 @@ def finalizeSchema(schema):
     schema.moveField("description", after="additionalLegalConditions")
     schema.moveField("missingParts", after="inadmissibilityReasons")
     schema.moveField("missingPartsDetails", after="missingParts")
+    schema.moveField("general_disposition", after="protectedBuilding")
+    schema.moveField("patrimony", after="general_disposition")
     schema["validityDelay"].default = 10
     return schema
 

--- a/src/Products/urban/content/licence/EnvClassThree.py
+++ b/src/Products/urban/content/licence/EnvClassThree.py
@@ -130,6 +130,22 @@ optional_fields = [
     "inadmissibilityreasonsDetails",
     "annoncedDelay",
     "annoncedDelayDetails",
+    "patrimony",
+    "archeological_site",
+    "protection_zone",
+    "regional_inventory_building",
+    "small_popular_patrimony",
+    "communal_inventory",
+    "regional_inventory",
+    "patrimony_analysis",
+    "patrimony_architectural_complex",
+    "patrimony_site",
+    "patrimony_archaeological_map",
+    "patrimony_project_gtoret_1ha",
+    "patrimony_monument",
+    "patrimony_observation",
+    "classification_order_scope",
+    "general_disposition",
 ]
 
 ##/code-section module-header

--- a/src/Products/urban/content/licence/EnvironmentLicence.py
+++ b/src/Products/urban/content/licence/EnvironmentLicence.py
@@ -14,6 +14,7 @@ __author__ = """Gauthier BASTIEN <gbastien@commune.sambreville.be>, Stephan GEUL
 __docformat__ = "plaintext"
 
 from AccessControl import ClassSecurityInfo
+from Products.MasterSelectWidget.MasterSelectWidget import MasterSelectWidget
 from Products.urban.widget.select2widget import MultiSelect2Widget
 from Products.Archetypes.atapi import *
 from zope.interface import implements
@@ -37,6 +38,7 @@ from Products.urban.UrbanVocabularyTerm import UrbanVocabulary
 from archetypes.referencebrowserwidget.widget import ReferenceBrowserWidget
 from Products.MasterSelectWidget.MasterBooleanWidget import MasterBooleanWidget
 
+from collective.archetypes.select2.select2widget import MultiSelect2Widget
 from collective.datagridcolumns.ReferenceColumn import ReferenceColumn
 from collective.datagridcolumns.TextAreaColumn import TextAreaColumn
 
@@ -51,6 +53,86 @@ optional_fields = [
     "conclusions",
     "commentsOnSPWOpinion",
 ]
+
+
+full_patrimony_slave_fields = (
+    {
+        "name": "patrimony_site",
+        "action": "hide",
+        "hide_values": ("none",),
+    },
+    {
+        "name": "patrimony_architectural_complex",
+        "action": "hide",
+        "hide_values": ("none",),
+    },
+    {
+        "name": "archeological_site",
+        "action": "hide",
+        "hide_values": ("none",),
+    },
+    {
+        "name": "protection_zone",
+        "action": "hide",
+        "hide_values": ("none",),
+    },
+    {
+        "name": "regional_inventory_building",
+        "action": "hide",
+        "hide_values": ("none",),
+    },
+    {
+        "name": "small_popular_patrimony",
+        "action": "hide",
+        "hide_values": ("none",),
+    },
+    {
+        "name": "communal_inventory",
+        "action": "hide",
+        "hide_values": ("none",),
+    },
+    {
+        "name": "regional_inventory",
+        "action": "hide",
+        "hide_values": ("none",),
+    },
+    {
+        "name": "patrimony_archaeological_map",
+        "action": "hide",
+        "hide_values": ("none",),
+    },
+    {
+        "name": "patrimony_project_gtoret_1ha",
+        "action": "hide",
+        "hide_values": ("none",),
+    },
+    {
+        "name": "observation",
+        "action": "hide",
+        "hide_values": ("none",),
+    },
+    {
+        "name": "patrimony_monument",
+        "action": "hide",
+        "hide_values": ("none", "patrimonial"),
+    },
+    {
+        "name": "classification_order_scope",
+        "action": "hide",
+        "hide_values": ("none", "patrimonial"),
+    },
+    {
+        "name": "patrimony_analysis",
+        "action": "hide",
+        "hide_values": ("none",),
+    },
+    {
+        "name": "patrimony_observation",
+        "action": "hide",
+        "hide_values": ("none",),
+    },
+)
+
 
 slave_fields_procedurechoice = [
     {
@@ -226,6 +308,173 @@ schema = Schema(
             default_method="getDefaultText",
             schemata="urban_environment",
             default_output_type="text/x-html-safe",
+        ),
+        StringField(
+            name="patrimony",
+            default="none",
+            widget=MasterSelectWidget(
+                slave_fields=full_patrimony_slave_fields,
+                label=_("urban_label_patrimony", default="Patrimony"),
+            ),
+            vocabulary="list_patrimony_types",
+            schemata="urban_patrimony",
+        ),
+        BooleanField(
+            name="archeological_site",
+            default=False,
+            widget=BooleanField._properties["widget"](
+                label=_("urban_label_archeological_site", default="Archeological_site"),
+            ),
+            schemata="urban_patrimony",
+        ),
+        BooleanField(
+            name="protection_zone",
+            default=False,
+            widget=BooleanField._properties["widget"](
+                label=_("urban_label_protection_zone", default="Protection_zone"),
+            ),
+            schemata="urban_patrimony",
+        ),
+        BooleanField(
+            name="regional_inventory_building",
+            default=False,
+            widget=BooleanField._properties["widget"](
+                label=_(
+                    "urban_label_regional_inventory_building",
+                    default="Regional_inventory_building",
+                ),
+            ),
+            schemata="urban_patrimony",
+        ),
+        BooleanField(
+            name="small_popular_patrimony",
+            default=False,
+            widget=BooleanField._properties["widget"](
+                label=_(
+                    "urban_label_small_popular_patrimony",
+                    default="Small_popular_patrimony",
+                ),
+            ),
+            schemata="urban_patrimony",
+        ),
+        BooleanField(
+            name="communal_inventory",
+            default=False,
+            widget=BooleanField._properties["widget"](
+                label=_("urban_label_communal_inventory", default="Communal_inventory"),
+            ),
+            schemata="urban_patrimony",
+        ),
+        BooleanField(
+            name="regional_inventory",
+            default=False,
+            widget=BooleanField._properties["widget"](
+                label=_("urban_label_regional_inventory", default="Regional_inventory"),
+            ),
+            schemata="urban_patrimony",
+        ),
+        TextField(
+            name="patrimony_analysis",
+            widget=RichWidget(
+                label=_("urban_label_patrimony_analysis", default="Patrimony_analysis"),
+            ),
+            default_content_type="text/html",
+            allowable_content_types=("text/html",),
+            schemata="urban_patrimony",
+            default_method="getDefaultText",
+            default_output_type="text/x-html-safe",
+            accessor="PatrimonyAnalysis",
+        ),
+        BooleanField(
+            name="patrimony_architectural_complex",
+            default=False,
+            widget=BooleanField._properties["widget"](
+                label=_(
+                    "urban_label_patrimony_architectural_complex",
+                    default="Patrimony_architectural_complex",
+                ),
+            ),
+            schemata="urban_patrimony",
+        ),
+        BooleanField(
+            name="patrimony_site",
+            default=False,
+            widget=BooleanField._properties["widget"](
+                label=_("urban_label_patrimony_site", default="Patrimony_site"),
+            ),
+            schemata="urban_patrimony",
+        ),
+        BooleanField(
+            name="patrimony_archaeological_map",
+            default=False,
+            widget=BooleanField._properties["widget"](
+                label=_(
+                    "urban_label_patrimony_archaeological_map",
+                    default="Patrimony_archaeological_map",
+                ),
+            ),
+            schemata="urban_patrimony",
+        ),
+        BooleanField(
+            name="patrimony_project_gtoret_1ha",
+            default=False,
+            widget=BooleanField._properties["widget"](
+                label=_(
+                    "urban_label_patrimony_project_gtoret_1ha",
+                    default="Patrimony_project_gtoret_1ha",
+                ),
+            ),
+            schemata="urban_patrimony",
+        ),
+        BooleanField(
+            name="patrimony_monument",
+            default=False,
+            widget=BooleanField._properties["widget"](
+                label=_("urban_label_patrimony_monument", default="Patrimony_monument"),
+            ),
+            schemata="urban_patrimony",
+        ),
+        TextField(
+            name="patrimony_observation",
+            widget=RichWidget(
+                label=_(
+                    "urban_label_patrimony_observation", default="Patrimony_observation"
+                ),
+            ),
+            default_content_type="text/html",
+            allowable_content_types=("text/html",),
+            schemata="urban_patrimony",
+            default_method="getDefaultText",
+            default_output_type="text/x-html-safe",
+            accessor="PatrimonyObservation",
+        ),
+        LinesField(
+            name="classification_order_scope",
+            widget=MultiSelect2Widget(
+                format="checkbox",
+                label=_(
+                    "urban_label_classification_order_scope",
+                    default="Classification_order_scope",
+                ),
+            ),
+            schemata="urban_patrimony",
+            multiValued=1,
+            vocabulary=UrbanVocabulary(
+                "classification_order_scope", inUrbanConfig=False
+            ),
+            default_method="getDefaultValue",
+        ),
+        StringField(
+            name="general_disposition",
+            widget=SelectionWidget(
+                label=_(
+                    "urban_label_general_disposition", default="General_disposition"
+                ),
+            ),
+            schemata="urban_patrimony",
+            vocabulary=UrbanVocabulary(
+                "general_disposition", inUrbanConfig=False, with_empty_value=True
+            ),
         ),
     ),
 )
@@ -406,6 +655,15 @@ class EnvironmentLicence(BaseFolder, EnvironmentBase, BrowserDefaultMixin):
         )
         return csv_adresses
 
+    def list_patrimony_types(self):
+        """ """
+        vocabulary = (
+            ("none", "aucune incidence"),
+            ("patrimonial", "incidence patrimoniale"),
+            ("classified", "bien classé"),
+        )
+        return DisplayList(vocabulary)
+
 
 registerType(EnvironmentLicence, PROJECTNAME)
 # end of class EnvironmentLicence
@@ -423,6 +681,8 @@ def finalizeSchema(schema, folderish=False, moveDiscussion=True):
     schema.moveField("environmentTechnicalRemarks", after="conclusions")
     schema.moveField("bound_licences", after="annoncedDelayDetails")
     schema.moveField("natura2000", after="bound_licences")
+    schema.moveField("general_disposition", after="protectedBuilding")
+    schema.moveField("patrimony", after="general_disposition")
     schema["procedureChoice"].widget.slave_fields = slave_fields_procedurechoice
 
 

--- a/src/Products/urban/content/licence/EnvironmentLicence.py
+++ b/src/Products/urban/content/licence/EnvironmentLicence.py
@@ -52,6 +52,22 @@ optional_fields = [
     "claimsSynthesis",
     "conclusions",
     "commentsOnSPWOpinion",
+    "patrimony",
+    "archeological_site",
+    "protection_zone",
+    "regional_inventory_building",
+    "small_popular_patrimony",
+    "communal_inventory",
+    "regional_inventory",
+    "patrimony_analysis",
+    "patrimony_architectural_complex",
+    "patrimony_site",
+    "patrimony_archaeological_map",
+    "patrimony_project_gtoret_1ha",
+    "patrimony_monument",
+    "patrimony_observation",
+    "classification_order_scope",
+    "general_disposition",
 ]
 
 

--- a/src/Products/urban/content/licence/Inspection.py
+++ b/src/Products/urban/content/licence/Inspection.py
@@ -12,6 +12,7 @@ from Products.urban.config import PROJECTNAME
 from Products.urban.config import URBAN_TYPES
 from Products.urban.content.licence.GenericLicence import GenericLicence
 from Products.urban.content.Inquiry import Inquiry
+from Products.urban.utils import setOptionalAttributes
 from Products.urban.utils import setSchemataForInquiry
 from Products.ATReferenceBrowserWidget.ATReferenceBrowserWidget import (
     ReferenceBrowserWidget,
@@ -23,6 +24,26 @@ from plone import api
 from zope.annotation import IAnnotations
 
 from collective.archetypes.select2.select2widget import MultiSelect2Widget
+
+
+optional_fields = [
+    "patrimony",
+    "archeological_site",
+    "protection_zone",
+    "regional_inventory_building",
+    "small_popular_patrimony",
+    "communal_inventory",
+    "regional_inventory",
+    "patrimony_analysis",
+    "patrimony_architectural_complex",
+    "patrimony_site",
+    "patrimony_archaeological_map",
+    "patrimony_project_gtoret_1ha",
+    "patrimony_monument",
+    "patrimony_observation",
+    "classification_order_scope",
+    "general_disposition",
+]
 
 
 full_patrimony_slave_fields = (
@@ -375,6 +396,7 @@ Inspection_schema = (
     + schema.copy()
 )
 
+setOptionalAttributes(Inspection_schema, optional_fields)
 setSchemataForInquiry(Inspection_schema)
 
 

--- a/src/Products/urban/content/licence/Inspection.py
+++ b/src/Products/urban/content/licence/Inspection.py
@@ -2,6 +2,7 @@
 
 from AccessControl import ClassSecurityInfo
 from Products.Archetypes.atapi import *
+from Products.MasterSelectWidget.MasterSelectWidget import MasterSelectWidget
 from zope.interface import implements
 
 from Products.urban import UrbanMessage as _
@@ -20,6 +21,88 @@ from Products.MasterSelectWidget.MasterBooleanWidget import MasterBooleanWidget
 from plone import api
 
 from zope.annotation import IAnnotations
+
+from collective.archetypes.select2.select2widget import MultiSelect2Widget
+
+
+full_patrimony_slave_fields = (
+    {
+        "name": "patrimony_site",
+        "action": "hide",
+        "hide_values": ("none",),
+    },
+    {
+        "name": "patrimony_architectural_complex",
+        "action": "hide",
+        "hide_values": ("none",),
+    },
+    {
+        "name": "archeological_site",
+        "action": "hide",
+        "hide_values": ("none",),
+    },
+    {
+        "name": "protection_zone",
+        "action": "hide",
+        "hide_values": ("none",),
+    },
+    {
+        "name": "regional_inventory_building",
+        "action": "hide",
+        "hide_values": ("none",),
+    },
+    {
+        "name": "small_popular_patrimony",
+        "action": "hide",
+        "hide_values": ("none",),
+    },
+    {
+        "name": "communal_inventory",
+        "action": "hide",
+        "hide_values": ("none",),
+    },
+    {
+        "name": "regional_inventory",
+        "action": "hide",
+        "hide_values": ("none",),
+    },
+    {
+        "name": "patrimony_archaeological_map",
+        "action": "hide",
+        "hide_values": ("none",),
+    },
+    {
+        "name": "patrimony_project_gtoret_1ha",
+        "action": "hide",
+        "hide_values": ("none",),
+    },
+    {
+        "name": "observation",
+        "action": "hide",
+        "hide_values": ("none",),
+    },
+    {
+        "name": "patrimony_monument",
+        "action": "hide",
+        "hide_values": ("none", "patrimonial"),
+    },
+    {
+        "name": "classification_order_scope",
+        "action": "hide",
+        "hide_values": ("none", "patrimonial"),
+    },
+    {
+        "name": "patrimony_analysis",
+        "action": "hide",
+        "hide_values": ("none",),
+    },
+    {
+        "name": "patrimony_observation",
+        "action": "hide",
+        "hide_values": ("none",),
+    },
+)
+
 
 slave_fields_bound_licence = (
     {
@@ -115,6 +198,173 @@ schema = Schema(
             schemata="urban_inspection",
             default_method="getDefaultText",
             default_output_type="text/x-html-safe",
+        ),
+        StringField(
+            name="patrimony",
+            default="none",
+            widget=MasterSelectWidget(
+                slave_fields=full_patrimony_slave_fields,
+                label=_("urban_label_patrimony", default="Patrimony"),
+            ),
+            vocabulary="list_patrimony_types",
+            schemata="urban_patrimony",
+        ),
+        BooleanField(
+            name="archeological_site",
+            default=False,
+            widget=BooleanField._properties["widget"](
+                label=_("urban_label_archeological_site", default="Archeological_site"),
+            ),
+            schemata="urban_patrimony",
+        ),
+        BooleanField(
+            name="protection_zone",
+            default=False,
+            widget=BooleanField._properties["widget"](
+                label=_("urban_label_protection_zone", default="Protection_zone"),
+            ),
+            schemata="urban_patrimony",
+        ),
+        BooleanField(
+            name="regional_inventory_building",
+            default=False,
+            widget=BooleanField._properties["widget"](
+                label=_(
+                    "urban_label_regional_inventory_building",
+                    default="Regional_inventory_building",
+                ),
+            ),
+            schemata="urban_patrimony",
+        ),
+        BooleanField(
+            name="small_popular_patrimony",
+            default=False,
+            widget=BooleanField._properties["widget"](
+                label=_(
+                    "urban_label_small_popular_patrimony",
+                    default="Small_popular_patrimony",
+                ),
+            ),
+            schemata="urban_patrimony",
+        ),
+        BooleanField(
+            name="communal_inventory",
+            default=False,
+            widget=BooleanField._properties["widget"](
+                label=_("urban_label_communal_inventory", default="Communal_inventory"),
+            ),
+            schemata="urban_patrimony",
+        ),
+        BooleanField(
+            name="regional_inventory",
+            default=False,
+            widget=BooleanField._properties["widget"](
+                label=_("urban_label_regional_inventory", default="Regional_inventory"),
+            ),
+            schemata="urban_patrimony",
+        ),
+        TextField(
+            name="patrimony_analysis",
+            widget=RichWidget(
+                label=_("urban_label_patrimony_analysis", default="Patrimony_analysis"),
+            ),
+            default_content_type="text/html",
+            allowable_content_types=("text/html",),
+            schemata="urban_patrimony",
+            default_method="getDefaultText",
+            default_output_type="text/x-html-safe",
+            accessor="PatrimonyAnalysis",
+        ),
+        BooleanField(
+            name="patrimony_architectural_complex",
+            default=False,
+            widget=BooleanField._properties["widget"](
+                label=_(
+                    "urban_label_patrimony_architectural_complex",
+                    default="Patrimony_architectural_complex",
+                ),
+            ),
+            schemata="urban_patrimony",
+        ),
+        BooleanField(
+            name="patrimony_site",
+            default=False,
+            widget=BooleanField._properties["widget"](
+                label=_("urban_label_patrimony_site", default="Patrimony_site"),
+            ),
+            schemata="urban_patrimony",
+        ),
+        BooleanField(
+            name="patrimony_archaeological_map",
+            default=False,
+            widget=BooleanField._properties["widget"](
+                label=_(
+                    "urban_label_patrimony_archaeological_map",
+                    default="Patrimony_archaeological_map",
+                ),
+            ),
+            schemata="urban_patrimony",
+        ),
+        BooleanField(
+            name="patrimony_project_gtoret_1ha",
+            default=False,
+            widget=BooleanField._properties["widget"](
+                label=_(
+                    "urban_label_patrimony_project_gtoret_1ha",
+                    default="Patrimony_project_gtoret_1ha",
+                ),
+            ),
+            schemata="urban_patrimony",
+        ),
+        BooleanField(
+            name="patrimony_monument",
+            default=False,
+            widget=BooleanField._properties["widget"](
+                label=_("urban_label_patrimony_monument", default="Patrimony_monument"),
+            ),
+            schemata="urban_patrimony",
+        ),
+        TextField(
+            name="patrimony_observation",
+            widget=RichWidget(
+                label=_(
+                    "urban_label_patrimony_observation", default="Patrimony_observation"
+                ),
+            ),
+            default_content_type="text/html",
+            allowable_content_types=("text/html",),
+            schemata="urban_patrimony",
+            default_method="getDefaultText",
+            default_output_type="text/x-html-safe",
+            accessor="PatrimonyObservation",
+        ),
+        LinesField(
+            name="classification_order_scope",
+            widget=MultiSelect2Widget(
+                format="checkbox",
+                label=_(
+                    "urban_label_classification_order_scope",
+                    default="Classification_order_scope",
+                ),
+            ),
+            schemata="urban_patrimony",
+            multiValued=1,
+            vocabulary=UrbanVocabulary(
+                "classification_order_scope", inUrbanConfig=False
+            ),
+            default_method="getDefaultValue",
+        ),
+        StringField(
+            name="general_disposition",
+            widget=SelectionWidget(
+                label=_(
+                    "urban_label_general_disposition", default="General_disposition"
+                ),
+            ),
+            schemata="urban_patrimony",
+            vocabulary=UrbanVocabulary(
+                "general_disposition", inUrbanConfig=False, with_empty_value=True
+            ),
         ),
     ),
 )
@@ -419,6 +669,15 @@ class Inspection(BaseFolder, GenericLicence, Inquiry, BrowserDefaultMixin):
             tickets = [b.getObject() for b in uid_catalog(UID=ticket_uids)]
             return tickets
 
+    def list_patrimony_types(self):
+        """ """
+        vocabulary = (
+            ("none", "aucune incidence"),
+            ("patrimonial", "incidence patrimoniale"),
+            ("classified", "bien classé"),
+        )
+        return DisplayList(vocabulary)
+
 
 registerType(Inspection, PROJECTNAME)
 
@@ -431,6 +690,8 @@ def finalize_schema(schema, folderish=False, moveDiscussion=True):
     schema.moveField("referenceProsecution", after="reference")
     schema.moveField("policeTicketReference", after="referenceProsecution")
     schema.moveField("description", after="inspection_context")
+    schema.moveField("general_disposition", after="protectedBuilding")
+    schema.moveField("patrimony", after="general_disposition")
     schema.moveField("bound_licences", before="workLocations")
     schema.moveField("use_bound_licence_infos", after="bound_licences")
     schema["parcellings"].widget.label = _("urban_label_parceloutlicences")

--- a/src/Products/urban/content/licence/MiscDemand.py
+++ b/src/Products/urban/content/licence/MiscDemand.py
@@ -115,7 +115,25 @@ full_patrimony_slave_fields = (
 )
 
 
-optional_fields = ["architects"]
+optional_fields = [
+    "architects",
+    "patrimony",
+    "archeological_site",
+    "protection_zone",
+    "regional_inventory_building",
+    "small_popular_patrimony",
+    "communal_inventory",
+    "regional_inventory",
+    "patrimony_analysis",
+    "patrimony_architectural_complex",
+    "patrimony_site",
+    "patrimony_archaeological_map",
+    "patrimony_project_gtoret_1ha",
+    "patrimony_monument",
+    "patrimony_observation",
+    "classification_order_scope",
+    "general_disposition",
+]
 ##/code-section module-header
 
 schema = Schema(

--- a/src/Products/urban/content/licence/MiscDemand.py
+++ b/src/Products/urban/content/licence/MiscDemand.py
@@ -15,6 +15,7 @@ __docformat__ = "plaintext"
 
 from AccessControl import ClassSecurityInfo
 from Products.Archetypes.atapi import *
+from Products.MasterSelectWidget.MasterSelectWidget import MasterSelectWidget
 from zope.interface import implements
 from Products.urban import interfaces
 from Products.urban.content.licence.GenericLicence import GenericLicence
@@ -31,6 +32,88 @@ from Products.ATReferenceBrowserWidget.ATReferenceBrowserWidget import (
     ReferenceBrowserWidget,
 )
 from Products.urban.UrbanVocabularyTerm import UrbanVocabulary
+
+from collective.archetypes.select2.select2widget import MultiSelect2Widget
+
+
+full_patrimony_slave_fields = (
+    {
+        "name": "patrimony_site",
+        "action": "hide",
+        "hide_values": ("none",),
+    },
+    {
+        "name": "patrimony_architectural_complex",
+        "action": "hide",
+        "hide_values": ("none",),
+    },
+    {
+        "name": "archeological_site",
+        "action": "hide",
+        "hide_values": ("none",),
+    },
+    {
+        "name": "protection_zone",
+        "action": "hide",
+        "hide_values": ("none",),
+    },
+    {
+        "name": "regional_inventory_building",
+        "action": "hide",
+        "hide_values": ("none",),
+    },
+    {
+        "name": "small_popular_patrimony",
+        "action": "hide",
+        "hide_values": ("none",),
+    },
+    {
+        "name": "communal_inventory",
+        "action": "hide",
+        "hide_values": ("none",),
+    },
+    {
+        "name": "regional_inventory",
+        "action": "hide",
+        "hide_values": ("none",),
+    },
+    {
+        "name": "patrimony_archaeological_map",
+        "action": "hide",
+        "hide_values": ("none",),
+    },
+    {
+        "name": "patrimony_project_gtoret_1ha",
+        "action": "hide",
+        "hide_values": ("none",),
+    },
+    {
+        "name": "observation",
+        "action": "hide",
+        "hide_values": ("none",),
+    },
+    {
+        "name": "patrimony_monument",
+        "action": "hide",
+        "hide_values": ("none", "patrimonial"),
+    },
+    {
+        "name": "classification_order_scope",
+        "action": "hide",
+        "hide_values": ("none", "patrimonial"),
+    },
+    {
+        "name": "patrimony_analysis",
+        "action": "hide",
+        "hide_values": ("none",),
+    },
+    {
+        "name": "patrimony_observation",
+        "action": "hide",
+        "hide_values": ("none",),
+    },
+)
+
 
 optional_fields = ["architects"]
 ##/code-section module-header
@@ -56,6 +139,173 @@ schema = Schema(
             multiValued=True,
             relationship="miscdemandarchitects",
             allowed_types="Architect",
+        ),
+        StringField(
+            name="patrimony",
+            default="none",
+            widget=MasterSelectWidget(
+                slave_fields=full_patrimony_slave_fields,
+                label=_("urban_label_patrimony", default="Patrimony"),
+            ),
+            vocabulary="list_patrimony_types",
+            schemata="urban_patrimony",
+        ),
+        BooleanField(
+            name="archeological_site",
+            default=False,
+            widget=BooleanField._properties["widget"](
+                label=_("urban_label_archeological_site", default="Archeological_site"),
+            ),
+            schemata="urban_patrimony",
+        ),
+        BooleanField(
+            name="protection_zone",
+            default=False,
+            widget=BooleanField._properties["widget"](
+                label=_("urban_label_protection_zone", default="Protection_zone"),
+            ),
+            schemata="urban_patrimony",
+        ),
+        BooleanField(
+            name="regional_inventory_building",
+            default=False,
+            widget=BooleanField._properties["widget"](
+                label=_(
+                    "urban_label_regional_inventory_building",
+                    default="Regional_inventory_building",
+                ),
+            ),
+            schemata="urban_patrimony",
+        ),
+        BooleanField(
+            name="small_popular_patrimony",
+            default=False,
+            widget=BooleanField._properties["widget"](
+                label=_(
+                    "urban_label_small_popular_patrimony",
+                    default="Small_popular_patrimony",
+                ),
+            ),
+            schemata="urban_patrimony",
+        ),
+        BooleanField(
+            name="communal_inventory",
+            default=False,
+            widget=BooleanField._properties["widget"](
+                label=_("urban_label_communal_inventory", default="Communal_inventory"),
+            ),
+            schemata="urban_patrimony",
+        ),
+        BooleanField(
+            name="regional_inventory",
+            default=False,
+            widget=BooleanField._properties["widget"](
+                label=_("urban_label_regional_inventory", default="Regional_inventory"),
+            ),
+            schemata="urban_patrimony",
+        ),
+        TextField(
+            name="patrimony_analysis",
+            widget=RichWidget(
+                label=_("urban_label_patrimony_analysis", default="Patrimony_analysis"),
+            ),
+            default_content_type="text/html",
+            allowable_content_types=("text/html",),
+            schemata="urban_patrimony",
+            default_method="getDefaultText",
+            default_output_type="text/x-html-safe",
+            accessor="PatrimonyAnalysis",
+        ),
+        BooleanField(
+            name="patrimony_architectural_complex",
+            default=False,
+            widget=BooleanField._properties["widget"](
+                label=_(
+                    "urban_label_patrimony_architectural_complex",
+                    default="Patrimony_architectural_complex",
+                ),
+            ),
+            schemata="urban_patrimony",
+        ),
+        BooleanField(
+            name="patrimony_site",
+            default=False,
+            widget=BooleanField._properties["widget"](
+                label=_("urban_label_patrimony_site", default="Patrimony_site"),
+            ),
+            schemata="urban_patrimony",
+        ),
+        BooleanField(
+            name="patrimony_archaeological_map",
+            default=False,
+            widget=BooleanField._properties["widget"](
+                label=_(
+                    "urban_label_patrimony_archaeological_map",
+                    default="Patrimony_archaeological_map",
+                ),
+            ),
+            schemata="urban_patrimony",
+        ),
+        BooleanField(
+            name="patrimony_project_gtoret_1ha",
+            default=False,
+            widget=BooleanField._properties["widget"](
+                label=_(
+                    "urban_label_patrimony_project_gtoret_1ha",
+                    default="Patrimony_project_gtoret_1ha",
+                ),
+            ),
+            schemata="urban_patrimony",
+        ),
+        BooleanField(
+            name="patrimony_monument",
+            default=False,
+            widget=BooleanField._properties["widget"](
+                label=_("urban_label_patrimony_monument", default="Patrimony_monument"),
+            ),
+            schemata="urban_patrimony",
+        ),
+        TextField(
+            name="patrimony_observation",
+            widget=RichWidget(
+                label=_(
+                    "urban_label_patrimony_observation", default="Patrimony_observation"
+                ),
+            ),
+            default_content_type="text/html",
+            allowable_content_types=("text/html",),
+            schemata="urban_patrimony",
+            default_method="getDefaultText",
+            default_output_type="text/x-html-safe",
+            accessor="PatrimonyObservation",
+        ),
+        LinesField(
+            name="classification_order_scope",
+            widget=MultiSelect2Widget(
+                format="checkbox",
+                label=_(
+                    "urban_label_classification_order_scope",
+                    default="Classification_order_scope",
+                ),
+            ),
+            schemata="urban_patrimony",
+            multiValued=1,
+            vocabulary=UrbanVocabulary(
+                "classification_order_scope", inUrbanConfig=False
+            ),
+            default_method="getDefaultValue",
+        ),
+        StringField(
+            name="general_disposition",
+            widget=SelectionWidget(
+                label=_(
+                    "urban_label_general_disposition", default="General_disposition"
+                ),
+            ),
+            schemata="urban_patrimony",
+            vocabulary=UrbanVocabulary(
+                "general_disposition", inUrbanConfig=False, with_empty_value=True
+            ),
         ),
     ),
 )
@@ -109,6 +359,15 @@ class MiscDemand(BaseFolder, GenericLicence, Inquiry, BrowserDefaultMixin):
     def getLastTheLicence(self):
         return self.getLastEvent(interfaces.ITheLicenceEvent)
 
+    def list_patrimony_types(self):
+        """ """
+        vocabulary = (
+            ("none", "aucune incidence"),
+            ("patrimonial", "incidence patrimoniale"),
+            ("classified", "bien classé"),
+        )
+        return DisplayList(vocabulary)
+
 
 registerType(MiscDemand, PROJECTNAME)
 # end of class MiscDemand
@@ -120,6 +379,8 @@ def finalizeSchema(schema, folderish=False, moveDiscussion=True):
     Finalizes the type schema to alter some fields
     """
     schema.moveField("description", after="architects")
+    schema.moveField("general_disposition", after="protectedBuilding")
+    schema.moveField("patrimony", after="general_disposition")
     schema["parcellings"].widget.label = _("urban_label_parceloutlicences")
     schema["isInSubdivision"].widget.label = _("urban_label_is_in_parceloutlicences")
     schema["subdivisionDetails"].widget.label = _(

--- a/src/Products/urban/content/licence/Ticket.py
+++ b/src/Products/urban/content/licence/Ticket.py
@@ -2,6 +2,7 @@
 #
 from AccessControl import ClassSecurityInfo
 from Products.Archetypes.atapi import *
+from Products.MasterSelectWidget.MasterSelectWidget import MasterSelectWidget
 from zope.interface import implements
 
 from Products.urban import UrbanMessage as _
@@ -19,6 +20,88 @@ from Products.MasterSelectWidget.MasterBooleanWidget import MasterBooleanWidget
 from plone import api
 
 from zope.i18n import translate
+
+from collective.archetypes.select2.select2widget import MultiSelect2Widget
+
+
+full_patrimony_slave_fields = (
+    {
+        "name": "patrimony_site",
+        "action": "hide",
+        "hide_values": ("none",),
+    },
+    {
+        "name": "patrimony_architectural_complex",
+        "action": "hide",
+        "hide_values": ("none",),
+    },
+    {
+        "name": "archeological_site",
+        "action": "hide",
+        "hide_values": ("none",),
+    },
+    {
+        "name": "protection_zone",
+        "action": "hide",
+        "hide_values": ("none",),
+    },
+    {
+        "name": "regional_inventory_building",
+        "action": "hide",
+        "hide_values": ("none",),
+    },
+    {
+        "name": "small_popular_patrimony",
+        "action": "hide",
+        "hide_values": ("none",),
+    },
+    {
+        "name": "communal_inventory",
+        "action": "hide",
+        "hide_values": ("none",),
+    },
+    {
+        "name": "regional_inventory",
+        "action": "hide",
+        "hide_values": ("none",),
+    },
+    {
+        "name": "patrimony_archaeological_map",
+        "action": "hide",
+        "hide_values": ("none",),
+    },
+    {
+        "name": "patrimony_project_gtoret_1ha",
+        "action": "hide",
+        "hide_values": ("none",),
+    },
+    {
+        "name": "observation",
+        "action": "hide",
+        "hide_values": ("none",),
+    },
+    {
+        "name": "patrimony_monument",
+        "action": "hide",
+        "hide_values": ("none", "patrimonial"),
+    },
+    {
+        "name": "classification_order_scope",
+        "action": "hide",
+        "hide_values": ("none", "patrimonial"),
+    },
+    {
+        "name": "patrimony_analysis",
+        "action": "hide",
+        "hide_values": ("none",),
+    },
+    {
+        "name": "patrimony_observation",
+        "action": "hide",
+        "hide_values": ("none",),
+    },
+)
+
 
 slave_fields_bound_inspection = (
     {
@@ -132,6 +215,173 @@ schema = Schema(
             schemata="urban_inspection",
             default_method="getDefaultText",
             default_output_type="text/x-html-safe",
+        ),
+        StringField(
+            name="patrimony",
+            default="none",
+            widget=MasterSelectWidget(
+                slave_fields=full_patrimony_slave_fields,
+                label=_("urban_label_patrimony", default="Patrimony"),
+            ),
+            vocabulary="list_patrimony_types",
+            schemata="urban_patrimony",
+        ),
+        BooleanField(
+            name="archeological_site",
+            default=False,
+            widget=BooleanField._properties["widget"](
+                label=_("urban_label_archeological_site", default="Archeological_site"),
+            ),
+            schemata="urban_patrimony",
+        ),
+        BooleanField(
+            name="protection_zone",
+            default=False,
+            widget=BooleanField._properties["widget"](
+                label=_("urban_label_protection_zone", default="Protection_zone"),
+            ),
+            schemata="urban_patrimony",
+        ),
+        BooleanField(
+            name="regional_inventory_building",
+            default=False,
+            widget=BooleanField._properties["widget"](
+                label=_(
+                    "urban_label_regional_inventory_building",
+                    default="Regional_inventory_building",
+                ),
+            ),
+            schemata="urban_patrimony",
+        ),
+        BooleanField(
+            name="small_popular_patrimony",
+            default=False,
+            widget=BooleanField._properties["widget"](
+                label=_(
+                    "urban_label_small_popular_patrimony",
+                    default="Small_popular_patrimony",
+                ),
+            ),
+            schemata="urban_patrimony",
+        ),
+        BooleanField(
+            name="communal_inventory",
+            default=False,
+            widget=BooleanField._properties["widget"](
+                label=_("urban_label_communal_inventory", default="Communal_inventory"),
+            ),
+            schemata="urban_patrimony",
+        ),
+        BooleanField(
+            name="regional_inventory",
+            default=False,
+            widget=BooleanField._properties["widget"](
+                label=_("urban_label_regional_inventory", default="Regional_inventory"),
+            ),
+            schemata="urban_patrimony",
+        ),
+        TextField(
+            name="patrimony_analysis",
+            widget=RichWidget(
+                label=_("urban_label_patrimony_analysis", default="Patrimony_analysis"),
+            ),
+            default_content_type="text/html",
+            allowable_content_types=("text/html",),
+            schemata="urban_patrimony",
+            default_method="getDefaultText",
+            default_output_type="text/x-html-safe",
+            accessor="PatrimonyAnalysis",
+        ),
+        BooleanField(
+            name="patrimony_architectural_complex",
+            default=False,
+            widget=BooleanField._properties["widget"](
+                label=_(
+                    "urban_label_patrimony_architectural_complex",
+                    default="Patrimony_architectural_complex",
+                ),
+            ),
+            schemata="urban_patrimony",
+        ),
+        BooleanField(
+            name="patrimony_site",
+            default=False,
+            widget=BooleanField._properties["widget"](
+                label=_("urban_label_patrimony_site", default="Patrimony_site"),
+            ),
+            schemata="urban_patrimony",
+        ),
+        BooleanField(
+            name="patrimony_archaeological_map",
+            default=False,
+            widget=BooleanField._properties["widget"](
+                label=_(
+                    "urban_label_patrimony_archaeological_map",
+                    default="Patrimony_archaeological_map",
+                ),
+            ),
+            schemata="urban_patrimony",
+        ),
+        BooleanField(
+            name="patrimony_project_gtoret_1ha",
+            default=False,
+            widget=BooleanField._properties["widget"](
+                label=_(
+                    "urban_label_patrimony_project_gtoret_1ha",
+                    default="Patrimony_project_gtoret_1ha",
+                ),
+            ),
+            schemata="urban_patrimony",
+        ),
+        BooleanField(
+            name="patrimony_monument",
+            default=False,
+            widget=BooleanField._properties["widget"](
+                label=_("urban_label_patrimony_monument", default="Patrimony_monument"),
+            ),
+            schemata="urban_patrimony",
+        ),
+        TextField(
+            name="patrimony_observation",
+            widget=RichWidget(
+                label=_(
+                    "urban_label_patrimony_observation", default="Patrimony_observation"
+                ),
+            ),
+            default_content_type="text/html",
+            allowable_content_types=("text/html",),
+            schemata="urban_patrimony",
+            default_method="getDefaultText",
+            default_output_type="text/x-html-safe",
+            accessor="PatrimonyObservation",
+        ),
+        LinesField(
+            name="classification_order_scope",
+            widget=MultiSelect2Widget(
+                format="checkbox",
+                label=_(
+                    "urban_label_classification_order_scope",
+                    default="Classification_order_scope",
+                ),
+            ),
+            schemata="urban_patrimony",
+            multiValued=1,
+            vocabulary=UrbanVocabulary(
+                "classification_order_scope", inUrbanConfig=False
+            ),
+            default_method="getDefaultValue",
+        ),
+        StringField(
+            name="general_disposition",
+            widget=SelectionWidget(
+                label=_(
+                    "urban_label_general_disposition", default="General_disposition"
+                ),
+            ),
+            schemata="urban_patrimony",
+            vocabulary=UrbanVocabulary(
+                "general_disposition", inUrbanConfig=False, with_empty_value=True
+            ),
         ),
     ),
 )
@@ -361,6 +611,15 @@ class Ticket(BaseFolder, GenericLicence, BrowserDefaultMixin):
     def getLastReportEvent(self):
         return self.getLastEvent(interfaces.IUrbanEventInspectionReport)
 
+    def list_patrimony_types(self):
+        """ """
+        vocabulary = (
+            ("none", "aucune incidence"),
+            ("patrimonial", "incidence patrimoniale"),
+            ("classified", "bien classé"),
+        )
+        return DisplayList(vocabulary)
+
 
 registerType(Ticket, PROJECTNAME)
 
@@ -377,6 +636,8 @@ def finalize_schema(schema, folderish=False, moveDiscussion=True):
     schema.moveField("bound_licences", after="use_bound_inspection_infos")
     schema.moveField("managed_by_prosecutor", after="foldermanagers")
     schema.moveField("description", after="managed_by_prosecutor")
+    schema.moveField("general_disposition", after="protectedBuilding")
+    schema.moveField("patrimony", after="general_disposition")
     schema["parcellings"].widget.label = _("urban_label_parceloutlicences")
     schema["isInSubdivision"].widget.label = _("urban_label_is_in_parceloutlicences")
     schema["subdivisionDetails"].widget.label = _(

--- a/src/Products/urban/content/licence/Ticket.py
+++ b/src/Products/urban/content/licence/Ticket.py
@@ -111,7 +111,26 @@ slave_fields_bound_inspection = (
     },
 )
 
-optional_fields = ["managed_by_prosecutor", "inspectionDescription"]
+optional_fields = [
+    "managed_by_prosecutor",
+    "inspectionDescription",
+    "patrimony",
+    "archeological_site",
+    "protection_zone",
+    "regional_inventory_building",
+    "small_popular_patrimony",
+    "communal_inventory",
+    "regional_inventory",
+    "patrimony_analysis",
+    "patrimony_architectural_complex",
+    "patrimony_site",
+    "patrimony_archaeological_map",
+    "patrimony_project_gtoret_1ha",
+    "patrimony_monument",
+    "patrimony_observation",
+    "classification_order_scope",
+    "general_disposition",
+]
 
 schema = Schema(
     (

--- a/src/Products/urban/migration/update_270.py
+++ b/src/Products/urban/migration/update_270.py
@@ -2,6 +2,7 @@
 
 from Acquisition import aq_parent
 from OFS.interfaces import IOrderedContainer
+from Products.CMFCore.utils import getToolByName
 from Products.urban.interfaces import IGenericLicence
 from Products.urban.migration.utils import refresh_workflow_permissions
 from Products.urban.setuphandlers import createFolderDefaultValues
@@ -359,5 +360,34 @@ def fix_external_decision_values(context):
             external_decision = opinion.getField("externalDecision").get(opinion)
             if type(external_decision) is list and len(external_decision) == 1:
                 opinion.setExternalDecision(external_decision[0])
+
+    logger.info("upgrade step done!")
+
+
+def hide_patrimony_tab_in_licence_config(context):
+    logger = logging.getLogger("urban: Hiding patrimony tab where newly available")
+    logger.info("starting upgrade steps")
+
+    included = [
+        "preliminarynotice",
+        "envclassone",
+        "envclasstwo",
+        "envclassthree",
+        "envclassbordering",
+        "miscdemand",
+        "projectmeeting",
+        "explosivespossession",
+        "inspection",
+        "ticket",
+    ]
+    portal_urban = getToolByName(context, "portal_urban")
+    for licence_config in portal_urban.objectValues("LicenceConfig"):
+        if licence_config.id in included:
+            # add hidden tab config (unless there is one already)
+            if not [tab for tab in licence_config.tabsConfig if tab["value"] == "patrimony"]:
+                updated_config = licence_config.tabsConfig + (
+                    {"display": "", "display_name": "Patrimoine", "value": "patrimony"},
+                )
+                licence_config.setTabsConfig(updated_config)
 
     logger.info("upgrade step done!")

--- a/src/Products/urban/migration/upgrades.zcml
+++ b/src/Products/urban/migration/upgrades.zcml
@@ -738,4 +738,13 @@
         profile="Products.urban:default"
         />
 
+    <gs:upgradeStep
+        title="Hide patrimony tab newly added in some licence configs"
+        description=""
+        source="1160"
+        destination="1161"
+        handler=".update_270.hide_patrimony_tab_in_licence_config"
+        profile="Products.urban:default"
+        />
+
 </configure>

--- a/src/Products/urban/profiles/default/metadata.xml
+++ b/src/Products/urban/profiles/default/metadata.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <metadata>
-  <version>1160</version>
+  <version>1161</version>
   <dependencies>
     <dependency>profile-Products.urban:preinstall</dependency>
   </dependencies>


### PR DESCRIPTION

| type                         | class                | gets patrimony thru |
| ---------------------------- | -------------------- | ------------------- |
| demandes d'avis préalable    | PreliminaryNotice    | MiscDemand          |
| environnement classe 1       | EnvClassOne          | EnvironmentLicence  |
| environnement classe 2       | EnvClassTwo          | EnvironmentLicence  |
| déclaration environnementale | EnvClassThree        | EnvClassThree       |
| permis limitrophe            | EnvClassBordering    | EnvironmentLicence  |
| demande diverses             | MiscDemand           | MiscDemand          |
| réunion de projet            | ProjectMeeting       | MiscDemand          |
| détention d'explosif         | ExplosivesPossession | EnvironmentLicence  |
| inspection                   | Inspection           | Inspection          |
| procès verbal                | Ticket               | Ticket              |
