### PR TITLE
URBBDC-3192: Add missing method for schedule calculation

### DIFF
--- a/news/URBBDC-3192.bugfix
+++ b/news/URBBDC-3192.bugfix
@@ -1,0 +1,2 @@
+Add missing method for schedule calculation
+[daggelpop]

--- a/src/Products/urban/content/licence/BaseBuildLicence.py
+++ b/src/Products/urban/content/licence/BaseBuildLicence.py
@@ -674,6 +674,9 @@ class BaseBuildLicence(BaseFolder, Inquiry, GenericLicence, BrowserDefaultMixin)
     def getLastModificationDeposit(self):
         return self.getLastEvent(interfaces.IModificationDepositEvent)
 
+    def getLastDecisionProjectFromSPW(self):
+        return self.getLastEvent(interfaces.IDecisionProjectFromSPWEvent)
+
     def getLastTheLicence(self):
         return self.getLastEvent(interfaces.ITheLicenceEvent)
 


### PR DESCRIPTION
Needed to fix a cron job run:

```
Traceback (innermost last):
  Module ZPublisher.Publish, line 138, in publish
  Module ZPublisher.mapply, line 77, in mapply
  Module ZPublisher.Publish, line 48, in call_object
  Module Products.cron4plone.browser.views.cron_tick, line 104, in wrapper
  Module Products.cron4plone.browser.views.cron_tick, line 115, in tick
  Module Products.cron4plone.tools.crontool, line 91, in run_tasks
  Module Products.CMFCore.Expression, line 47, in __call__
  Module zope.tales.expressions, line 217, in __call__
  Module Products.PageTemplates.Expressions, line 155, in _eval
  Module Products.PageTemplates.Expressions, line 117, in render
  Module Products.urban.browser.cron.tasks, line 107, in __call__
  Module zope.event, line 31, in notify
  Module zope.component.event, line 24, in dispatch
  Module zope.component._api, line 136, in subscribers
  Module zope.component.registry, line 321, in subscribers
  Module zope.interface.adapter, line 585, in subscribers
  Module zope.component.event, line 32, in objectEventNotify
  Module zope.component._api, line 136, in subscribers
  Module zope.component.registry, line 321, in subscribers
  Module zope.interface.adapter, line 585, in subscribers
  Module imio.schedule.events.update_tasks, line 186, in update_due_date
  Module imio.schedule.content.task_config, line 1082, in compute_due_date
  Module imio.schedule.content.delay, line 40, in due_date
  Module imio.schedule.content.delay, line 25, in start_date
  Module Products.urban.schedule.start_date, line 173, in start_date
AttributeError: getLastDecisionProjectFromSPW
```