### PR TITLE
Urb-2585 Add notary reference field to UrbanCertificateBase

### DIFF
--- a/news/URB-2585.feature
+++ b/news/URB-2585.feature
@@ -1,0 +1,2 @@
+Introduce a notaryReference field to UrbanCertificateBase and integrate it into the Division procedure.
+[WBoudabous]

--- a/src/Products/urban/content/licence/Division.py
+++ b/src/Products/urban/content/licence/Division.py
@@ -19,6 +19,7 @@ from Products.Archetypes.atapi import *
 from zope.interface import implements
 from Products.urban import interfaces
 from Products.urban.content.licence.GenericLicence import GenericLicence
+from Products.urban.content.licence.UrbanCertificateBase import notaryReference
 from Products.CMFDynamicViewFTI.browserdefault import BrowserDefaultMixin
 
 from Products.urban.config import *
@@ -32,6 +33,7 @@ from Products.ATReferenceBrowserWidget.ATReferenceBrowserWidget import (
 )
 from Products.urban.UrbanVocabularyTerm import UrbanVocabulary
 from Products.MasterSelectWidget.MasterSelectWidget import MasterSelectWidget
+from copy import deepcopy
 
 optional_fields = []
 ##/code-section module-header
@@ -302,6 +304,7 @@ schema = Schema(
                 "general_disposition", inUrbanConfig=False, with_empty_value=True
             ),
         ),
+        
     ),
 )
 
@@ -313,6 +316,9 @@ Division_schema = (
     BaseFolderSchema.copy()
     + getattr(GenericLicence, "schema", Schema(())).copy()
     + schema.copy()
+    + Schema((
+    notaryReference.copy(), 
+))
 )
 
 ##code-section after-schema #fill in your manual code here
@@ -416,6 +422,7 @@ def finalizeSchema(schema, folderish=False, moveDiscussion=True):
     """
     Finalizes the type schema to alter some fields
     """
+    schema.moveField("notaryReference", after="reference")
     schema.moveField("description", after="notaryContact")
     schema.moveField("foldermanagers", after="workLocations")
     schema["parcellings"].widget.label = _("urban_label_parceloutlicences")

--- a/src/Products/urban/content/licence/UrbanCertificateBase.py
+++ b/src/Products/urban/content/licence/UrbanCertificateBase.py
@@ -624,11 +624,14 @@ notaryReference= StringField(
 ##code-section after-local-schema #fill in your manual code here
 setOptionalAttributes(schema, optional_fields)
 ##/code-section after-local-schema
-from copy import deepcopy
+
 UrbanCertificateBase_schema = (
     BaseFolderSchema.copy()
     + getattr(GenericLicence, "schema", Schema(())).copy()
     + schema.copy()
+    + Schema((
+    notaryReference.copy(), 
+))
     
 )
 ##code-section after-schema #fill in your manual code here
@@ -923,7 +926,7 @@ def finalizeSchema(schema, folderish=False, moveDiscussion=True):
     """
     Finalizes the type schema to alter some fields
     """
-    #schema.moveField("referenceDGATLP", after="reference")
+    schema.moveField("notaryReference", after="reference")
     schema.moveField("notaryContact", after="workLocations")
     schema.moveField("foldermanagers", after="notaryContact")
     schema.moveField("description", after="opinionsToAskIfWorks")
@@ -959,7 +962,7 @@ def finalizeSchema(schema, folderish=False, moveDiscussion=True):
     schema.moveField("protectedBuildingDetails", after="protectedBuilding")
     schema.moveField("patrimony_analysis", after="protectedBuildingDetails")
     schema.moveField("patrimony_observation", after="patrimony_analysis")
-    schema["referenceDGATLP"].widget.label = _("urban_label_notaryReference")
+    
     return schema
 
 

--- a/src/Products/urban/content/licence/UrbanCertificateBase.py
+++ b/src/Products/urban/content/licence/UrbanCertificateBase.py
@@ -610,19 +610,27 @@ schema = Schema(
             ),
             schemata="urban_patrimony",
         ),
+        
     ),
 )
-
+notaryReference= StringField(
+            name="notaryReference",
+            widget=StringField._properties["widget"](
+                size=60,
+                label=_("urban_label_notaryReference", default="NotaryReference"),
+            ),
+            schemata="urban_description",
+        )
 ##code-section after-local-schema #fill in your manual code here
 setOptionalAttributes(schema, optional_fields)
 ##/code-section after-local-schema
-
+from copy import deepcopy
 UrbanCertificateBase_schema = (
     BaseFolderSchema.copy()
     + getattr(GenericLicence, "schema", Schema(())).copy()
     + schema.copy()
+    
 )
-
 ##code-section after-schema #fill in your manual code here
 UrbanCertificateBase_schema["title"].required = False
 ##/code-section after-schema
@@ -915,7 +923,7 @@ def finalizeSchema(schema, folderish=False, moveDiscussion=True):
     """
     Finalizes the type schema to alter some fields
     """
-    schema.moveField("referenceDGATLP", after="reference")
+    #schema.moveField("referenceDGATLP", after="reference")
     schema.moveField("notaryContact", after="workLocations")
     schema.moveField("foldermanagers", after="notaryContact")
     schema.moveField("description", after="opinionsToAskIfWorks")

--- a/src/Products/urban/locales/fr/LC_MESSAGES/urban.po
+++ b/src/Products/urban/locales/fr/LC_MESSAGES/urban.po
@@ -4169,10 +4169,6 @@ msgstr "Non applicable"
 msgid "urban_label_notaryContact"
 msgstr "Notaire(s)"
 
-#: ../content/licence/UrbanCertificateBase.py:954
-msgid "urban_label_notaryReference"
-msgstr "Référence notaire"
-
 #. Default: "Noteworthytrees"
 #: ../content/licence/GenericLicence.py:1192
 msgid "urban_label_noteworthyTrees"
@@ -5430,3 +5426,6 @@ msgstr "ans"
 
 msgid "zip_folder_title"
 msgstr "Zone d'initiative privilégiée"
+
+msgid "urban_label_notaryReference"
+msgstr "Référence notaire"


### PR DESCRIPTION
**Ajout du champ "référence notaire" sur UrbanCertificateBase (utilisé ensuite pour les divisions)**

Cette pull request introduit :

-     L’ajout d’un champ référence notaires sur le type de contenu UrbanCertificateBase.

    Ce champ est réutilisé dans Division.