### PR TITLE
Sup-35028 Rename referenceDGO3 and referenceFT labels in Permis Unique

### DIFF
--- a/news/SUP-35028.feature
+++ b/news/SUP-35028.feature
@@ -1,0 +1,2 @@
+Rename the fields reference ARNE and reference FT(ARNE) for unique licence"
+[WBoudabous]

--- a/src/Products/urban/content/licence/CODT_UniqueLicence.py
+++ b/src/Products/urban/content/licence/CODT_UniqueLicence.py
@@ -455,6 +455,8 @@ def finalizeSchema(schema):
     schema.moveField(
         "locationTechnicalAdviceAfterInquiry", after="locationTechnicalAdvice"
     )
+    schema["referenceDGATLP"].widget.label = _("urban_label_referenceDGO3_custom")
+    schema["referenceFT"].widget.label = _("urban_label_referenceFT_custom")
 
 
 # finalizeSchema comes from BuildLicence to be sure to have the same changes reflected

--- a/src/Products/urban/locales/fr/LC_MESSAGES/urban.po
+++ b/src/Products/urban/locales/fr/LC_MESSAGES/urban.po
@@ -4614,6 +4614,12 @@ msgstr "Référence SPW Economie, Emploi, Recherche"
 msgid "urban_label_referenceFT"
 msgstr "Référence FT (ARNE)"
 
+msgid "urban_label_referenceFT_custom"
+msgstr "Référence FT"
+
+msgid "urban_label_referenceDGO3_custom"
+msgstr "Référence FD"
+
 #. Default: "Referenceprosecution"
 #: ../content/licence/Inspection.py:38
 #: ../content/licence/Ticket.py:39


### PR DESCRIPTION
**Renommage des libellés des champs "referenceDGO3" et "referenceFT" pour la procédure Permis Unique**

Cette pull request modifie les libellés affichés pour les champs suivants dans le cadre de la procédure Permis Unique :

-     Champ referenceDGO3 : Référence FD
-     Champ referenceFT : RéférenceFT