### PR TITLE
URB-3269: Fix race condition on `fullmap` load

### DIFF
--- a/news/URB-3269.bugfix
+++ b/news/URB-3269.bugfix
@@ -1,0 +1,2 @@
+Fix race condition on `fullmap` load
+[daggelpop]

--- a/src/Products/urban/browser/templates/map_macros.pt
+++ b/src/Products/urban/browser/templates/map_macros.pt
@@ -64,10 +64,10 @@
 </div>
 
 <div metal:define-macro="imioSpwMapSetup" tal:define="staticUrbanMapHost view/get_urbanmap_url">
-        <script type="text/javascript" tal:attributes="src python: 'https://{}/?t={}'.format(view.get_mapviewer_url(), view.get_mapviewer_js_id())" src=""></script>
+        <script defer type="text/javascript" tal:attributes="src python: 'https://{}/?t={}'.format(view.get_mapviewer_url(), view.get_mapviewer_js_id())" src=""></script>
 		<link rel="stylesheet" type="text/css" tal:attributes="href python: '//%s/static/geoviewer4.css' % staticUrbanMapHost"/>
         <link rel="stylesheet" type="text/css" tal:attributes="href python:'//%s/static/spwfix.css'%staticUrbanMapHost"/>
-        <script type="text/javascript" tal:attributes="src python:'//%s/static/imiomapspw.js'%staticUrbanMapHost"></script>
+        <script defer type="text/javascript" tal:attributes="src python:'//%s/static/imiomapspw.js'%staticUrbanMapHost"></script>
         <script tal:content="string:var NIS='${view/get_NIS}';var urbanProrietariesCapakeyArray=${view/getListProprietariesCapaKey};var urbanCapakeyArray=${view/getListCapaKey};var proxyUrl='${context/portal_url}/portal_urban/getProxy?url=';var urbanMapWMCUrl='${context/absolute_url}/wmc';">
 	    </script>
 </div>


### PR DESCRIPTION
(more info available in SUP-45019)

On some browsers (mostly Firefox), the `/urban/fullmap` doesn't load at all.
It happens randomly, probably a race condition.

Errors: `Uncaught TypeError: M.parentNode is null`

To test the changes locally, I set up a reverse proxy to serve HTTPS.