### PR TITLE
SUP-44868 Add index and filter for rubrics field in env licence

### DIFF
--- a/news/SUP-44868.feature
+++ b/news/SUP-44868.feature
@@ -1,0 +1,2 @@
+Add index and filter for rubrics field in env licence
+[jchandelle]

--- a/src/Products/urban/content/licence/EnvironmentBase.py
+++ b/src/Products/urban/content/licence/EnvironmentBase.py
@@ -46,6 +46,10 @@ from plone import api
 from zope.interface import implements
 
 
+import logging
+
+logger = logging.getLogger("EnvironmentBase.py : ")
+
 optional_fields = [
     "roadTechnicalAdvice",
     "locationTechnicalAdvice",
@@ -544,6 +548,50 @@ class EnvironmentBase(
     def getRubricsConfigPath(self):
         config_path = "/".join(self.getLicenceConfig().rubrics.getPhysicalPath())[1:]
         return config_path
+
+    security.declarePublic("get_rubrics_display")
+
+    def get_rubrics_display(self, class_number=True, number=True, description=False):
+        """
+        Generate an HTML-formatted list of rubric information for the licence.
+
+        :param class_number: Whether to include the class number in the output, defaults to True
+        :type class_number: bool, optional
+        :param number: Whether to include the rubric number, defaults to True
+        :type number: bool, optional
+        :param description: Whether to include the rubric's description as a paragraph under the number, defaults to False
+        :type description: bool, optional
+        :return: An HTML string with the formatted rubric data, or an empty string if `getRubrics` is not available
+        :rtype: str
+        """
+        if not hasattr(self, "getRubrics"):
+            logger.warning("This licence has no getRubrics method")
+            return ""
+        rubrics = self.getRubrics()
+        output = []
+        for rubric in rubrics:
+            rubric_str = ""
+
+            if class_number:
+                rubric_str += "Classe {}".format(rubric.getExtraValue())
+            if class_number and number:
+                rubric_str += ", "
+            if number:
+                rubric_str += "{}".format(rubric.getNumber())
+
+            description_str = rubric.Description()
+            if (class_number or number) and description:
+                rubric_str = "<p>{} :</p>{}".format(rubric_str, description_str)
+            elif description:
+                rubric_str += description_str
+            else:
+                rubric_str = "<p>{}</p>".format(rubric_str)
+
+            if rubric_str:
+                rubric_str = "<li>{}</li>".format(rubric_str)
+                output.append(rubric_str)
+
+        return "<ul>{}</ul>".format("".join(output))
 
     security.declarePrivate("_getConditions")
 

--- a/src/Products/urban/content/licence/EnvironmentBase.py
+++ b/src/Products/urban/content/licence/EnvironmentBase.py
@@ -549,50 +549,6 @@ class EnvironmentBase(
         config_path = "/".join(self.getLicenceConfig().rubrics.getPhysicalPath())[1:]
         return config_path
 
-    security.declarePublic("get_rubrics_display")
-
-    def get_rubrics_display(self, class_number=True, number=True, description=False):
-        """
-        Generate an HTML-formatted list of rubric information for the licence.
-
-        :param class_number: Whether to include the class number in the output, defaults to True
-        :type class_number: bool, optional
-        :param number: Whether to include the rubric number, defaults to True
-        :type number: bool, optional
-        :param description: Whether to include the rubric's description as a paragraph under the number, defaults to False
-        :type description: bool, optional
-        :return: An HTML string with the formatted rubric data, or an empty string if `getRubrics` is not available
-        :rtype: str
-        """
-        if not hasattr(self, "getRubrics"):
-            logger.warning("This licence has no getRubrics method")
-            return ""
-        rubrics = self.getRubrics()
-        output = []
-        for rubric in rubrics:
-            rubric_str = ""
-
-            if class_number:
-                rubric_str += "Classe {}".format(rubric.getExtraValue())
-            if class_number and number:
-                rubric_str += ", "
-            if number:
-                rubric_str += "{}".format(rubric.getNumber())
-
-            description_str = rubric.Description()
-            if (class_number or number) and description:
-                rubric_str = "<p>{} :</p>{}".format(rubric_str, description_str)
-            elif description:
-                rubric_str += description_str
-            else:
-                rubric_str = "<p>{}</p>".format(rubric_str)
-
-            if rubric_str:
-                rubric_str = "<li>{}</li>".format(rubric_str)
-                output.append(rubric_str)
-
-        return "<ul>{}</ul>".format("".join(output))
-
     security.declarePrivate("_getConditions")
 
     def _getConditions(self, restrict=["CI/CS", "CI", "CS", "CS-Eau", "Ville"]):

--- a/src/Products/urban/content/licence/GenericLicence.py
+++ b/src/Products/urban/content/licence/GenericLicence.py
@@ -2126,6 +2126,66 @@ class GenericLicence(OrderedBaseFolder, UrbanBase, BrowserDefaultMixin):
     def legalconditions_base_query(self):
         return {"review_state": ["enabled", "private"]}
 
+    security.declarePublic("get_rubrics_display")
+
+    def get_rubrics_display(self, class_number=True, number=True, description=False, html_list=True):
+        """
+        Generate an HTML-formatted list of rubric information for the licence.
+
+        :param class_number: Whether to include the class number in the output, defaults to True
+        :type class_number: bool, optional
+        :param number: Whether to include the rubric number, defaults to True
+        :type number: bool, optional
+        :param description: Whether to include the rubric's description as a paragraph under
+            the number, defaults to False
+        :type description: bool, optional
+        :param html_list: Whether to wrap the output in HTML list tags, defaults to True
+        :type html_list: bool, optional
+        :return: An HTML string with the formatted rubric data, or an empty string if
+            `getRubrics` is not available
+        :rtype: str
+        """
+        if not hasattr(self, "getRubrics"):
+            logger.warning("This licence has no getRubrics method")
+            return ""
+
+        output = []
+        for rubric in self.getRubrics():
+            parts = []
+            if class_number:
+                parts.append("Classe {}".format(rubric.getExtraValue()))
+            if number:
+                parts.append(str(rubric.getNumber()))
+
+            rubric_str = " - ".join(parts)
+
+            if description:
+                desc = rubric.Description()
+                separator = " :" if rubric_str else ""
+                if html_list:
+                    if rubric_str:
+                        rubric_str = "<p>{}{}</p>{}".format(rubric_str, separator, desc)
+                    else:
+                        rubric_str = desc
+                else:
+                    if rubric_str:
+                        rubric_str = "{} - {}".format(rubric_str, desc)
+                    else:
+                        rubric_str = desc
+
+            if not rubric_str:
+                continue
+
+            if html_list:
+                if description:
+                    rubric_str = "<li>{}</li>".format(rubric_str)
+                else:
+                    rubric_str = "<li><p>{}</p></li>".format(rubric_str)
+            output.append(rubric_str)
+
+        if html_list:
+            return "<ul>{}</ul>".format("".join(output))
+        return ", ".join(output)
 
 registerType(GenericLicence, PROJECTNAME)
 # end of class GenericLicence

--- a/src/Products/urban/dashboard/config/classic/all.xml
+++ b/src/Products/urban/dashboard/config/classic/all.xml
@@ -158,5 +158,20 @@
       <property name="hidezerocount">False</property>
       <property name="sortreversed">False</property>
     </criterion>
-  </criteria>
+    <criterion name="c94">
+     <property name="widget">select2</property>
+     <property name="title">Rubriques</property>
+     <property name="index">rubrics</property>
+     <property name="vocabulary">urban.vocabularies.rubrics</property>
+     <property name="hidealloption">False</property>
+     <property name="position">top</property>
+     <property name="section">advanced</property>
+     <property name="hidden">False</property>
+     <property name="custom_css"></property>
+     <property name="count">False</property>
+     <property name="sortcountable">False</property>
+     <property name="hidezerocount">False</property>
+     <property name="sortreversed">False</property>
+    </criterion>
+ </criteria>
 </object>

--- a/src/Products/urban/dashboard/config/classic/article127s.xml
+++ b/src/Products/urban/dashboard/config/classic/article127s.xml
@@ -170,5 +170,20 @@
       <property name="hidezerocount">False</property>
       <property name="sortreversed">False</property>
     </criterion>
-  </criteria>
+    <criterion name="c94">
+     <property name="widget">select2</property>
+     <property name="title">Rubriques</property>
+     <property name="index">rubrics</property>
+     <property name="vocabulary">urban.vocabularies.rubrics</property>
+     <property name="hidealloption">False</property>
+     <property name="position">top</property>
+     <property name="section">advanced</property>
+     <property name="hidden">False</property>
+     <property name="custom_css"></property>
+     <property name="count">False</property>
+     <property name="sortcountable">False</property>
+     <property name="hidezerocount">False</property>
+     <property name="sortreversed">False</property>
+    </criterion>
+ </criteria>
 </object>

--- a/src/Products/urban/dashboard/config/classic/buildlicences.xml
+++ b/src/Products/urban/dashboard/config/classic/buildlicences.xml
@@ -182,5 +182,20 @@
       <property name="hidezerocount">False</property>
       <property name="sortreversed">False</property>
     </criterion>
-  </criteria>
+    <criterion name="c94">
+     <property name="widget">select2</property>
+     <property name="title">Rubriques</property>
+     <property name="index">rubrics</property>
+     <property name="vocabulary">urban.vocabularies.rubrics</property>
+     <property name="hidealloption">False</property>
+     <property name="position">top</property>
+     <property name="section">advanced</property>
+     <property name="hidden">False</property>
+     <property name="custom_css"></property>
+     <property name="count">False</property>
+     <property name="sortcountable">False</property>
+     <property name="hidezerocount">False</property>
+     <property name="sortreversed">False</property>
+    </criterion>
+ </criteria>
 </object>

--- a/src/Products/urban/dashboard/config/classic/codt_article127s.xml
+++ b/src/Products/urban/dashboard/config/classic/codt_article127s.xml
@@ -182,5 +182,20 @@
       <property name="hidezerocount">False</property>
       <property name="sortreversed">False</property>
     </criterion>
-  </criteria>
+    <criterion name="c94">
+     <property name="widget">select2</property>
+     <property name="title">Rubriques</property>
+     <property name="index">rubrics</property>
+     <property name="vocabulary">urban.vocabularies.rubrics</property>
+     <property name="hidealloption">False</property>
+     <property name="position">top</property>
+     <property name="section">advanced</property>
+     <property name="hidden">False</property>
+     <property name="custom_css"></property>
+     <property name="count">False</property>
+     <property name="sortcountable">False</property>
+     <property name="hidezerocount">False</property>
+     <property name="sortreversed">False</property>
+    </criterion>
+ </criteria>
 </object>

--- a/src/Products/urban/dashboard/config/classic/codt_buildlicences.xml
+++ b/src/Products/urban/dashboard/config/classic/codt_buildlicences.xml
@@ -192,5 +192,20 @@
       <property name="hidezerocount">False</property>
       <property name="sortreversed">False</property>
     </criterion>
-  </criteria>
+    <criterion name="c94">
+     <property name="widget">select2</property>
+     <property name="title">Rubriques</property>
+     <property name="index">rubrics</property>
+     <property name="vocabulary">urban.vocabularies.rubrics</property>
+     <property name="hidealloption">False</property>
+     <property name="position">top</property>
+     <property name="section">advanced</property>
+     <property name="hidden">False</property>
+     <property name="custom_css"></property>
+     <property name="count">False</property>
+     <property name="sortcountable">False</property>
+     <property name="hidezerocount">False</property>
+     <property name="sortreversed">False</property>
+    </criterion>
+ </criteria>
 </object>

--- a/src/Products/urban/dashboard/config/classic/codt_commerciallicences.xml
+++ b/src/Products/urban/dashboard/config/classic/codt_commerciallicences.xml
@@ -181,5 +181,20 @@
       <property name="hidezerocount">False</property>
       <property name="sortreversed">False</property>
     </criterion>
-  </criteria>
+    <criterion name="c94">
+     <property name="widget">select2</property>
+     <property name="title">Rubriques</property>
+     <property name="index">rubrics</property>
+     <property name="vocabulary">urban.vocabularies.rubrics</property>
+     <property name="hidealloption">False</property>
+     <property name="position">top</property>
+     <property name="section">advanced</property>
+     <property name="hidden">False</property>
+     <property name="custom_css"></property>
+     <property name="count">False</property>
+     <property name="sortcountable">False</property>
+     <property name="hidezerocount">False</property>
+     <property name="sortreversed">False</property>
+    </criterion>
+ </criteria>
 </object>

--- a/src/Products/urban/dashboard/config/classic/codt_integratedlicences.xml
+++ b/src/Products/urban/dashboard/config/classic/codt_integratedlicences.xml
@@ -181,5 +181,20 @@
       <property name="hidezerocount">False</property>
       <property name="sortreversed">False</property>
     </criterion>
-  </criteria>
+    <criterion name="c94">
+     <property name="widget">select2</property>
+     <property name="title">Rubriques</property>
+     <property name="index">rubrics</property>
+     <property name="vocabulary">urban.vocabularies.rubrics</property>
+     <property name="hidealloption">False</property>
+     <property name="position">top</property>
+     <property name="section">advanced</property>
+     <property name="hidden">False</property>
+     <property name="custom_css"></property>
+     <property name="count">False</property>
+     <property name="sortcountable">False</property>
+     <property name="hidezerocount">False</property>
+     <property name="sortreversed">False</property>
+    </criterion>
+ </criteria>
 </object>

--- a/src/Products/urban/dashboard/config/classic/codt_notaryletters.xml
+++ b/src/Products/urban/dashboard/config/classic/codt_notaryletters.xml
@@ -171,5 +171,20 @@
       <property name="hidezerocount">False</property>
       <property name="sortreversed">False</property>
     </criterion>
-  </criteria>
+    <criterion name="c94">
+     <property name="widget">select2</property>
+     <property name="title">Rubriques</property>
+     <property name="index">rubrics</property>
+     <property name="vocabulary">urban.vocabularies.rubrics</property>
+     <property name="hidealloption">False</property>
+     <property name="position">top</property>
+     <property name="section">advanced</property>
+     <property name="hidden">False</property>
+     <property name="custom_css"></property>
+     <property name="count">False</property>
+     <property name="sortcountable">False</property>
+     <property name="hidezerocount">False</property>
+     <property name="sortreversed">False</property>
+    </criterion>
+ </criteria>
 </object>

--- a/src/Products/urban/dashboard/config/classic/codt_parceloutlicences.xml
+++ b/src/Products/urban/dashboard/config/classic/codt_parceloutlicences.xml
@@ -181,5 +181,20 @@
       <property name="hidezerocount">False</property>
       <property name="sortreversed">False</property>
     </criterion>
-  </criteria>
+    <criterion name="c94">
+     <property name="widget">select2</property>
+     <property name="title">Rubriques</property>
+     <property name="index">rubrics</property>
+     <property name="vocabulary">urban.vocabularies.rubrics</property>
+     <property name="hidealloption">False</property>
+     <property name="position">top</property>
+     <property name="section">advanced</property>
+     <property name="hidden">False</property>
+     <property name="custom_css"></property>
+     <property name="count">False</property>
+     <property name="sortcountable">False</property>
+     <property name="hidezerocount">False</property>
+     <property name="sortreversed">False</property>
+    </criterion>
+ </criteria>
 </object>

--- a/src/Products/urban/dashboard/config/classic/codt_uniquelicences.xml
+++ b/src/Products/urban/dashboard/config/classic/codt_uniquelicences.xml
@@ -181,5 +181,20 @@
       <property name="hidezerocount">False</property>
       <property name="sortreversed">False</property>
     </criterion>
-  </criteria>
+    <criterion name="c94">
+     <property name="widget">select2</property>
+     <property name="title">Rubriques</property>
+     <property name="index">rubrics</property>
+     <property name="vocabulary">urban.vocabularies.rubrics</property>
+     <property name="hidealloption">False</property>
+     <property name="position">top</property>
+     <property name="section">advanced</property>
+     <property name="hidden">False</property>
+     <property name="custom_css"></property>
+     <property name="count">False</property>
+     <property name="sortcountable">False</property>
+     <property name="hidezerocount">False</property>
+     <property name="sortreversed">False</property>
+    </criterion>
+ </criteria>
 </object>

--- a/src/Products/urban/dashboard/config/classic/codt_urbancertificateones.xml
+++ b/src/Products/urban/dashboard/config/classic/codt_urbancertificateones.xml
@@ -171,5 +171,20 @@
       <property name="hidezerocount">False</property>
       <property name="sortreversed">False</property>
     </criterion>
-  </criteria>
+    <criterion name="c94">
+     <property name="widget">select2</property>
+     <property name="title">Rubriques</property>
+     <property name="index">rubrics</property>
+     <property name="vocabulary">urban.vocabularies.rubrics</property>
+     <property name="hidealloption">False</property>
+     <property name="position">top</property>
+     <property name="section">advanced</property>
+     <property name="hidden">False</property>
+     <property name="custom_css"></property>
+     <property name="count">False</property>
+     <property name="sortcountable">False</property>
+     <property name="hidezerocount">False</property>
+     <property name="sortreversed">False</property>
+    </criterion>
+ </criteria>
 </object>

--- a/src/Products/urban/dashboard/config/classic/codt_urbancertificatetwos.xml
+++ b/src/Products/urban/dashboard/config/classic/codt_urbancertificatetwos.xml
@@ -181,5 +181,20 @@
       <property name="hidezerocount">False</property>
       <property name="sortreversed">False</property>
     </criterion>
-  </criteria>
+    <criterion name="c94">
+     <property name="widget">select2</property>
+     <property name="title">Rubriques</property>
+     <property name="index">rubrics</property>
+     <property name="vocabulary">urban.vocabularies.rubrics</property>
+     <property name="hidealloption">False</property>
+     <property name="position">top</property>
+     <property name="section">advanced</property>
+     <property name="hidden">False</property>
+     <property name="custom_css"></property>
+     <property name="count">False</property>
+     <property name="sortcountable">False</property>
+     <property name="hidezerocount">False</property>
+     <property name="sortreversed">False</property>
+    </criterion>
+ </criteria>
 </object>

--- a/src/Products/urban/dashboard/config/classic/declarations.xml
+++ b/src/Products/urban/dashboard/config/classic/declarations.xml
@@ -91,5 +91,20 @@
       <property name="hidezerocount">False</property>
       <property name="sortreversed">False</property>
     </criterion>
-  </criteria>
+    <criterion name="c94">
+     <property name="widget">select2</property>
+     <property name="title">Rubriques</property>
+     <property name="index">rubrics</property>
+     <property name="vocabulary">urban.vocabularies.rubrics</property>
+     <property name="hidealloption">False</property>
+     <property name="position">top</property>
+     <property name="section">advanced</property>
+     <property name="hidden">False</property>
+     <property name="custom_css"></property>
+     <property name="count">False</property>
+     <property name="sortcountable">False</property>
+     <property name="hidezerocount">False</property>
+     <property name="sortreversed">False</property>
+    </criterion>
+ </criteria>
 </object>

--- a/src/Products/urban/dashboard/config/classic/divisions.xml
+++ b/src/Products/urban/dashboard/config/classic/divisions.xml
@@ -171,5 +171,20 @@
       <property name="hidezerocount">False</property>
       <property name="sortreversed">False</property>
     </criterion>
-  </criteria>
+    <criterion name="c94">
+     <property name="widget">select2</property>
+     <property name="title">Rubriques</property>
+     <property name="index">rubrics</property>
+     <property name="vocabulary">urban.vocabularies.rubrics</property>
+     <property name="hidealloption">False</property>
+     <property name="position">top</property>
+     <property name="section">advanced</property>
+     <property name="hidden">False</property>
+     <property name="custom_css"></property>
+     <property name="count">False</property>
+     <property name="sortcountable">False</property>
+     <property name="hidezerocount">False</property>
+     <property name="sortreversed">False</property>
+    </criterion>
+ </criteria>
 </object>

--- a/src/Products/urban/dashboard/config/classic/envclassborderings.xml
+++ b/src/Products/urban/dashboard/config/classic/envclassborderings.xml
@@ -181,5 +181,20 @@
       <property name="hidezerocount">False</property>
       <property name="sortreversed">False</property>
     </criterion>
-  </criteria>
+    <criterion name="c94">
+     <property name="widget">select2</property>
+     <property name="title">Rubriques</property>
+     <property name="index">rubrics</property>
+     <property name="vocabulary">urban.vocabularies.rubrics</property>
+     <property name="hidealloption">False</property>
+     <property name="position">top</property>
+     <property name="section">advanced</property>
+     <property name="hidden">False</property>
+     <property name="custom_css"></property>
+     <property name="count">False</property>
+     <property name="sortcountable">False</property>
+     <property name="hidezerocount">False</property>
+     <property name="sortreversed">False</property>
+    </criterion>
+ </criteria>
 </object>

--- a/src/Products/urban/dashboard/config/classic/envclassones.xml
+++ b/src/Products/urban/dashboard/config/classic/envclassones.xml
@@ -181,5 +181,20 @@
       <property name="hidezerocount">False</property>
       <property name="sortreversed">False</property>
     </criterion>
-  </criteria>
+    <criterion name="c94">
+     <property name="widget">select2</property>
+     <property name="title">Rubriques</property>
+     <property name="index">rubrics</property>
+     <property name="vocabulary">urban.vocabularies.rubrics</property>
+     <property name="hidealloption">False</property>
+     <property name="position">top</property>
+     <property name="section">advanced</property>
+     <property name="hidden">False</property>
+     <property name="custom_css"></property>
+     <property name="count">False</property>
+     <property name="sortcountable">False</property>
+     <property name="hidezerocount">False</property>
+     <property name="sortreversed">False</property>
+    </criterion>
+ </criteria>
 </object>

--- a/src/Products/urban/dashboard/config/classic/envclassthrees.xml
+++ b/src/Products/urban/dashboard/config/classic/envclassthrees.xml
@@ -160,5 +160,20 @@
       <property name="hidezerocount">False</property>
       <property name="sortreversed">False</property>
     </criterion>
-  </criteria>
+    <criterion name="c94">
+     <property name="widget">select2</property>
+     <property name="title">Rubriques</property>
+     <property name="index">rubrics</property>
+     <property name="vocabulary">urban.vocabularies.rubrics</property>
+     <property name="hidealloption">False</property>
+     <property name="position">top</property>
+     <property name="section">advanced</property>
+     <property name="hidden">False</property>
+     <property name="custom_css"></property>
+     <property name="count">False</property>
+     <property name="sortcountable">False</property>
+     <property name="hidezerocount">False</property>
+     <property name="sortreversed">False</property>
+    </criterion>
+ </criteria>
 </object>

--- a/src/Products/urban/dashboard/config/classic/envclasstwos.xml
+++ b/src/Products/urban/dashboard/config/classic/envclasstwos.xml
@@ -181,5 +181,20 @@
       <property name="hidezerocount">False</property>
       <property name="sortreversed">False</property>
     </criterion>
-  </criteria>
+    <criterion name="c94">
+     <property name="widget">select2</property>
+     <property name="title">Rubriques</property>
+     <property name="index">rubrics</property>
+     <property name="vocabulary">urban.vocabularies.rubrics</property>
+     <property name="hidealloption">False</property>
+     <property name="position">top</property>
+     <property name="section">advanced</property>
+     <property name="hidden">False</property>
+     <property name="custom_css"></property>
+     <property name="count">False</property>
+     <property name="sortcountable">False</property>
+     <property name="hidezerocount">False</property>
+     <property name="sortreversed">False</property>
+    </criterion>
+ </criteria>
 </object>

--- a/src/Products/urban/dashboard/config/classic/explosivespossessions.xml
+++ b/src/Products/urban/dashboard/config/classic/explosivespossessions.xml
@@ -170,5 +170,20 @@
       <property name="hidezerocount">False</property>
       <property name="sortreversed">False</property>
     </criterion>
-  </criteria>
+    <criterion name="c94">
+     <property name="widget">select2</property>
+     <property name="title">Rubriques</property>
+     <property name="index">rubrics</property>
+     <property name="vocabulary">urban.vocabularies.rubrics</property>
+     <property name="hidealloption">False</property>
+     <property name="position">top</property>
+     <property name="section">advanced</property>
+     <property name="hidden">False</property>
+     <property name="custom_css"></property>
+     <property name="count">False</property>
+     <property name="sortcountable">False</property>
+     <property name="hidezerocount">False</property>
+     <property name="sortreversed">False</property>
+    </criterion>
+ </criteria>
 </object>

--- a/src/Products/urban/dashboard/config/classic/housings.xml
+++ b/src/Products/urban/dashboard/config/classic/housings.xml
@@ -155,5 +155,20 @@
       <property name="step">10</property>
       <property name="default">20</property>
     </criterion>
-  </criteria>
+    <criterion name="c94">
+     <property name="widget">select2</property>
+     <property name="title">Rubriques</property>
+     <property name="index">rubrics</property>
+     <property name="vocabulary">urban.vocabularies.rubrics</property>
+     <property name="hidealloption">False</property>
+     <property name="position">top</property>
+     <property name="section">advanced</property>
+     <property name="hidden">False</property>
+     <property name="custom_css"></property>
+     <property name="count">False</property>
+     <property name="sortcountable">False</property>
+     <property name="hidezerocount">False</property>
+     <property name="sortreversed">False</property>
+    </criterion>
+ </criteria>
 </object>

--- a/src/Products/urban/dashboard/config/classic/import_notice.xml
+++ b/src/Products/urban/dashboard/config/classic/import_notice.xml
@@ -158,5 +158,20 @@
       <property name="hidezerocount">False</property>
       <property name="sortreversed">False</property>
     </criterion>
-  </criteria>
+    <criterion name="c94">
+     <property name="widget">select2</property>
+     <property name="title">Rubriques</property>
+     <property name="index">rubrics</property>
+     <property name="vocabulary">urban.vocabularies.rubrics</property>
+     <property name="hidealloption">False</property>
+     <property name="position">top</property>
+     <property name="section">advanced</property>
+     <property name="hidden">False</property>
+     <property name="custom_css"></property>
+     <property name="count">False</property>
+     <property name="sortcountable">False</property>
+     <property name="hidezerocount">False</property>
+     <property name="sortreversed">False</property>
+    </criterion>
+ </criteria>
 </object>

--- a/src/Products/urban/dashboard/config/classic/inspections.xml
+++ b/src/Products/urban/dashboard/config/classic/inspections.xml
@@ -170,5 +170,20 @@
       <property name="hidezerocount">False</property>
       <property name="sortreversed">False</property>
     </criterion>
-  </criteria>
+    <criterion name="c94">
+     <property name="widget">select2</property>
+     <property name="title">Rubriques</property>
+     <property name="index">rubrics</property>
+     <property name="vocabulary">urban.vocabularies.rubrics</property>
+     <property name="hidealloption">False</property>
+     <property name="position">top</property>
+     <property name="section">advanced</property>
+     <property name="hidden">False</property>
+     <property name="custom_css"></property>
+     <property name="count">False</property>
+     <property name="sortcountable">False</property>
+     <property name="hidezerocount">False</property>
+     <property name="sortreversed">False</property>
+    </criterion>
+ </criteria>
 </object>

--- a/src/Products/urban/dashboard/config/classic/integratedlicences.xml
+++ b/src/Products/urban/dashboard/config/classic/integratedlicences.xml
@@ -170,5 +170,20 @@
       <property name="hidezerocount">False</property>
       <property name="sortreversed">False</property>
     </criterion>
-  </criteria>
+    <criterion name="c94">
+     <property name="widget">select2</property>
+     <property name="title">Rubriques</property>
+     <property name="index">rubrics</property>
+     <property name="vocabulary">urban.vocabularies.rubrics</property>
+     <property name="hidealloption">False</property>
+     <property name="position">top</property>
+     <property name="section">advanced</property>
+     <property name="hidden">False</property>
+     <property name="custom_css"></property>
+     <property name="count">False</property>
+     <property name="sortcountable">False</property>
+     <property name="hidezerocount">False</property>
+     <property name="sortreversed">False</property>
+    </criterion>
+ </criteria>
 </object>

--- a/src/Products/urban/dashboard/config/classic/miscdemands.xml
+++ b/src/Products/urban/dashboard/config/classic/miscdemands.xml
@@ -171,5 +171,20 @@
       <property name="hidezerocount">False</property>
       <property name="sortreversed">False</property>
     </criterion>
-  </criteria>
+    <criterion name="c94">
+     <property name="widget">select2</property>
+     <property name="title">Rubriques</property>
+     <property name="index">rubrics</property>
+     <property name="vocabulary">urban.vocabularies.rubrics</property>
+     <property name="hidealloption">False</property>
+     <property name="position">top</property>
+     <property name="section">advanced</property>
+     <property name="hidden">False</property>
+     <property name="custom_css"></property>
+     <property name="count">False</property>
+     <property name="sortcountable">False</property>
+     <property name="hidezerocount">False</property>
+     <property name="sortreversed">False</property>
+    </criterion>
+ </criteria>
 </object>

--- a/src/Products/urban/dashboard/config/classic/notaryletters.xml
+++ b/src/Products/urban/dashboard/config/classic/notaryletters.xml
@@ -160,5 +160,20 @@
       <property name="hidezerocount">False</property>
       <property name="sortreversed">False</property>
     </criterion>
-  </criteria>
+    <criterion name="c94">
+     <property name="widget">select2</property>
+     <property name="title">Rubriques</property>
+     <property name="index">rubrics</property>
+     <property name="vocabulary">urban.vocabularies.rubrics</property>
+     <property name="hidealloption">False</property>
+     <property name="position">top</property>
+     <property name="section">advanced</property>
+     <property name="hidden">False</property>
+     <property name="custom_css"></property>
+     <property name="count">False</property>
+     <property name="sortcountable">False</property>
+     <property name="hidezerocount">False</property>
+     <property name="sortreversed">False</property>
+    </criterion>
+ </criteria>
 </object>

--- a/src/Products/urban/dashboard/config/classic/parceloutlicences.xml
+++ b/src/Products/urban/dashboard/config/classic/parceloutlicences.xml
@@ -91,5 +91,20 @@
       <property name="hidezerocount">False</property>
       <property name="sortreversed">False</property>
     </criterion>
-  </criteria>
+    <criterion name="c94">
+     <property name="widget">select2</property>
+     <property name="title">Rubriques</property>
+     <property name="index">rubrics</property>
+     <property name="vocabulary">urban.vocabularies.rubrics</property>
+     <property name="hidealloption">False</property>
+     <property name="position">top</property>
+     <property name="section">advanced</property>
+     <property name="hidden">False</property>
+     <property name="custom_css"></property>
+     <property name="count">False</property>
+     <property name="sortcountable">False</property>
+     <property name="hidezerocount">False</property>
+     <property name="sortreversed">False</property>
+    </criterion>
+ </criteria>
 </object>

--- a/src/Products/urban/dashboard/config/classic/patrimonycertificates.xml
+++ b/src/Products/urban/dashboard/config/classic/patrimonycertificates.xml
@@ -171,5 +171,20 @@
       <property name="hidezerocount">False</property>
       <property name="sortreversed">False</property>
     </criterion>
-  </criteria>
+    <criterion name="c94">
+     <property name="widget">select2</property>
+     <property name="title">Rubriques</property>
+     <property name="index">rubrics</property>
+     <property name="vocabulary">urban.vocabularies.rubrics</property>
+     <property name="hidealloption">False</property>
+     <property name="position">top</property>
+     <property name="section">advanced</property>
+     <property name="hidden">False</property>
+     <property name="custom_css"></property>
+     <property name="count">False</property>
+     <property name="sortcountable">False</property>
+     <property name="hidezerocount">False</property>
+     <property name="sortreversed">False</property>
+    </criterion>
+ </criteria>
 </object>

--- a/src/Products/urban/dashboard/config/classic/preliminarynotices.xml
+++ b/src/Products/urban/dashboard/config/classic/preliminarynotices.xml
@@ -171,5 +171,20 @@
       <property name="hidezerocount">False</property>
       <property name="sortreversed">False</property>
     </criterion>
-  </criteria>
+    <criterion name="c94">
+     <property name="widget">select2</property>
+     <property name="title">Rubriques</property>
+     <property name="index">rubrics</property>
+     <property name="vocabulary">urban.vocabularies.rubrics</property>
+     <property name="hidealloption">False</property>
+     <property name="position">top</property>
+     <property name="section">advanced</property>
+     <property name="hidden">False</property>
+     <property name="custom_css"></property>
+     <property name="count">False</property>
+     <property name="sortcountable">False</property>
+     <property name="hidezerocount">False</property>
+     <property name="sortreversed">False</property>
+    </criterion>
+ </criteria>
 </object>

--- a/src/Products/urban/dashboard/config/classic/projectmeetings.xml
+++ b/src/Products/urban/dashboard/config/classic/projectmeetings.xml
@@ -171,5 +171,20 @@
       <property name="hidezerocount">False</property>
       <property name="sortreversed">False</property>
     </criterion>
-  </criteria>
+    <criterion name="c94">
+     <property name="widget">select2</property>
+     <property name="title">Rubriques</property>
+     <property name="index">rubrics</property>
+     <property name="vocabulary">urban.vocabularies.rubrics</property>
+     <property name="hidealloption">False</property>
+     <property name="position">top</property>
+     <property name="section">advanced</property>
+     <property name="hidden">False</property>
+     <property name="custom_css"></property>
+     <property name="count">False</property>
+     <property name="sortcountable">False</property>
+     <property name="hidezerocount">False</property>
+     <property name="sortreversed">False</property>
+    </criterion>
+ </criteria>
 </object>

--- a/src/Products/urban/dashboard/config/classic/roaddecrees.xml
+++ b/src/Products/urban/dashboard/config/classic/roaddecrees.xml
@@ -159,5 +159,20 @@
       <property name="hidezerocount">False</property>
       <property name="sortreversed">False</property>
     </criterion>
-  </criteria>
+    <criterion name="c94">
+     <property name="widget">select2</property>
+     <property name="title">Rubriques</property>
+     <property name="index">rubrics</property>
+     <property name="vocabulary">urban.vocabularies.rubrics</property>
+     <property name="hidealloption">False</property>
+     <property name="position">top</property>
+     <property name="section">advanced</property>
+     <property name="hidden">False</property>
+     <property name="custom_css"></property>
+     <property name="count">False</property>
+     <property name="sortcountable">False</property>
+     <property name="hidezerocount">False</property>
+     <property name="sortreversed">False</property>
+    </criterion>
+ </criteria>
 </object>

--- a/src/Products/urban/dashboard/config/classic/tickets.xml
+++ b/src/Products/urban/dashboard/config/classic/tickets.xml
@@ -170,5 +170,20 @@
       <property name="hidezerocount">False</property>
       <property name="sortreversed">False</property>
     </criterion>
-  </criteria>
+    <criterion name="c94">
+     <property name="widget">select2</property>
+     <property name="title">Rubriques</property>
+     <property name="index">rubrics</property>
+     <property name="vocabulary">urban.vocabularies.rubrics</property>
+     <property name="hidealloption">False</property>
+     <property name="position">top</property>
+     <property name="section">advanced</property>
+     <property name="hidden">False</property>
+     <property name="custom_css"></property>
+     <property name="count">False</property>
+     <property name="sortcountable">False</property>
+     <property name="hidezerocount">False</property>
+     <property name="sortreversed">False</property>
+    </criterion>
+ </criteria>
 </object>

--- a/src/Products/urban/dashboard/config/classic/uniquelicences.xml
+++ b/src/Products/urban/dashboard/config/classic/uniquelicences.xml
@@ -170,5 +170,20 @@
       <property name="hidezerocount">False</property>
       <property name="sortreversed">False</property>
     </criterion>
-  </criteria>
+    <criterion name="c94">
+     <property name="widget">select2</property>
+     <property name="title">Rubriques</property>
+     <property name="index">rubrics</property>
+     <property name="vocabulary">urban.vocabularies.rubrics</property>
+     <property name="hidealloption">False</property>
+     <property name="position">top</property>
+     <property name="section">advanced</property>
+     <property name="hidden">False</property>
+     <property name="custom_css"></property>
+     <property name="count">False</property>
+     <property name="sortcountable">False</property>
+     <property name="hidezerocount">False</property>
+     <property name="sortreversed">False</property>
+    </criterion>
+ </criteria>
 </object>

--- a/src/Products/urban/dashboard/config/classic/urbancertificateones.xml
+++ b/src/Products/urban/dashboard/config/classic/urbancertificateones.xml
@@ -160,5 +160,20 @@
       <property name="hidezerocount">False</property>
       <property name="sortreversed">False</property>
     </criterion>
-  </criteria>
+    <criterion name="c94">
+     <property name="widget">select2</property>
+     <property name="title">Rubriques</property>
+     <property name="index">rubrics</property>
+     <property name="vocabulary">urban.vocabularies.rubrics</property>
+     <property name="hidealloption">False</property>
+     <property name="position">top</property>
+     <property name="section">advanced</property>
+     <property name="hidden">False</property>
+     <property name="custom_css"></property>
+     <property name="count">False</property>
+     <property name="sortcountable">False</property>
+     <property name="hidezerocount">False</property>
+     <property name="sortreversed">False</property>
+    </criterion>
+ </criteria>
 </object>

--- a/src/Products/urban/dashboard/config/classic/urbancertificatetwos.xml
+++ b/src/Products/urban/dashboard/config/classic/urbancertificatetwos.xml
@@ -170,5 +170,20 @@
       <property name="hidezerocount">False</property>
       <property name="sortreversed">False</property>
     </criterion>
-  </criteria>
+    <criterion name="c94">
+     <property name="widget">select2</property>
+     <property name="title">Rubriques</property>
+     <property name="index">rubrics</property>
+     <property name="vocabulary">urban.vocabularies.rubrics</property>
+     <property name="hidealloption">False</property>
+     <property name="position">top</property>
+     <property name="section">advanced</property>
+     <property name="hidden">False</property>
+     <property name="custom_css"></property>
+     <property name="count">False</property>
+     <property name="sortcountable">False</property>
+     <property name="hidezerocount">False</property>
+     <property name="sortreversed">False</property>
+    </criterion>
+ </criteria>
 </object>

--- a/src/Products/urban/dashboard/config/liege/all.xml
+++ b/src/Products/urban/dashboard/config/liege/all.xml
@@ -237,5 +237,20 @@
    <property name="sortreversed">False</property>
    <property name="default"></property>
   </criterion>
+  <criterion name="c94">
+   <property name="widget">select2</property>
+   <property name="title">Rubriques</property>
+   <property name="index">rubrics</property>
+   <property name="vocabulary">urban.vocabularies.rubrics</property>
+   <property name="hidealloption">False</property>
+   <property name="position">top</property>
+   <property name="section">advanced</property>
+   <property name="hidden">False</property>
+   <property name="custom_css"></property>
+   <property name="count">False</property>
+   <property name="sortcountable">False</property>
+   <property name="hidezerocount">False</property>
+   <property name="sortreversed">False</property>
+  </criterion>
  </criteria>
 </object>

--- a/src/Products/urban/dashboard/config/liege/article127s.xml
+++ b/src/Products/urban/dashboard/config/liege/article127s.xml
@@ -170,5 +170,20 @@
    <property name="index">getValidityDate</property>
    <property name="calYearRange">c-10:c+10</property>
   </criterion>
+  <criterion name="c94">
+   <property name="widget">select2</property>
+   <property name="title">Rubriques</property>
+   <property name="index">rubrics</property>
+   <property name="vocabulary">urban.vocabularies.rubrics</property>
+   <property name="hidealloption">False</property>
+   <property name="position">top</property>
+   <property name="section">advanced</property>
+   <property name="hidden">False</property>
+   <property name="custom_css"></property>
+   <property name="count">False</property>
+   <property name="sortcountable">False</property>
+   <property name="hidezerocount">False</property>
+   <property name="sortreversed">False</property>
+  </criterion>
  </criteria>
 </object>

--- a/src/Products/urban/dashboard/config/liege/buildlicences.xml
+++ b/src/Products/urban/dashboard/config/liege/buildlicences.xml
@@ -179,5 +179,20 @@
    <property name="index">getValidityDate</property>
    <property name="calYearRange">c-10:c+10</property>
   </criterion>
+  <criterion name="c94">
+   <property name="widget">select2</property>
+   <property name="title">Rubriques</property>
+   <property name="index">rubrics</property>
+   <property name="vocabulary">urban.vocabularies.rubrics</property>
+   <property name="hidealloption">False</property>
+   <property name="position">top</property>
+   <property name="section">advanced</property>
+   <property name="hidden">False</property>
+   <property name="custom_css"></property>
+   <property name="count">False</property>
+   <property name="sortcountable">False</property>
+   <property name="hidezerocount">False</property>
+   <property name="sortreversed">False</property>
+  </criterion>
  </criteria>
 </object>

--- a/src/Products/urban/dashboard/config/liege/codt_article127s.xml
+++ b/src/Products/urban/dashboard/config/liege/codt_article127s.xml
@@ -225,5 +225,20 @@
    <property name="sortreversed">False</property>
    <property name="default"></property>
   </criterion>
+  <criterion name="c94">
+   <property name="widget">select2</property>
+   <property name="title">Rubriques</property>
+   <property name="index">rubrics</property>
+   <property name="vocabulary">urban.vocabularies.rubrics</property>
+   <property name="hidealloption">False</property>
+   <property name="position">top</property>
+   <property name="section">advanced</property>
+   <property name="hidden">False</property>
+   <property name="custom_css"></property>
+   <property name="count">False</property>
+   <property name="sortcountable">False</property>
+   <property name="hidezerocount">False</property>
+   <property name="sortreversed">False</property>
+  </criterion>
  </criteria>
 </object>

--- a/src/Products/urban/dashboard/config/liege/codt_buildlicences.xml
+++ b/src/Products/urban/dashboard/config/liege/codt_buildlicences.xml
@@ -215,5 +215,20 @@
    <property name="sortreversed">False</property>
    <property name="default"></property>
   </criterion>
+  <criterion name="c94">
+   <property name="widget">select2</property>
+   <property name="title">Rubriques</property>
+   <property name="index">rubrics</property>
+   <property name="vocabulary">urban.vocabularies.rubrics</property>
+   <property name="hidealloption">False</property>
+   <property name="position">top</property>
+   <property name="section">advanced</property>
+   <property name="hidden">False</property>
+   <property name="custom_css"></property>
+   <property name="count">False</property>
+   <property name="sortcountable">False</property>
+   <property name="hidezerocount">False</property>
+   <property name="sortreversed">False</property>
+  </criterion>
  </criteria>
 </object>

--- a/src/Products/urban/dashboard/config/liege/codt_commerciallicences.xml
+++ b/src/Products/urban/dashboard/config/liege/codt_commerciallicences.xml
@@ -215,5 +215,20 @@
    <property name="sortreversed">False</property>
    <property name="default"></property>
   </criterion>
+  <criterion name="c94">
+   <property name="widget">select2</property>
+   <property name="title">Rubriques</property>
+   <property name="index">rubrics</property>
+   <property name="vocabulary">urban.vocabularies.rubrics</property>
+   <property name="hidealloption">False</property>
+   <property name="position">top</property>
+   <property name="section">advanced</property>
+   <property name="hidden">False</property>
+   <property name="custom_css"></property>
+   <property name="count">False</property>
+   <property name="sortcountable">False</property>
+   <property name="hidezerocount">False</property>
+   <property name="sortreversed">False</property>
+  </criterion>
  </criteria>
 </object>

--- a/src/Products/urban/dashboard/config/liege/codt_integratedlicences.xml
+++ b/src/Products/urban/dashboard/config/liege/codt_integratedlicences.xml
@@ -215,5 +215,20 @@
    <property name="sortreversed">False</property>
    <property name="default"></property>
   </criterion>
+  <criterion name="c94">
+   <property name="widget">select2</property>
+   <property name="title">Rubriques</property>
+   <property name="index">rubrics</property>
+   <property name="vocabulary">urban.vocabularies.rubrics</property>
+   <property name="hidealloption">False</property>
+   <property name="position">top</property>
+   <property name="section">advanced</property>
+   <property name="hidden">False</property>
+   <property name="custom_css"></property>
+   <property name="count">False</property>
+   <property name="sortcountable">False</property>
+   <property name="hidezerocount">False</property>
+   <property name="sortreversed">False</property>
+  </criterion>
  </criteria>
 </object>

--- a/src/Products/urban/dashboard/config/liege/codt_notaryletters.xml
+++ b/src/Products/urban/dashboard/config/liege/codt_notaryletters.xml
@@ -226,5 +226,20 @@
    <property name="sortreversed">False</property>
    <property name="default"></property>
   </criterion>
+  <criterion name="c94">
+   <property name="widget">select2</property>
+   <property name="title">Rubriques</property>
+   <property name="index">rubrics</property>
+   <property name="vocabulary">urban.vocabularies.rubrics</property>
+   <property name="hidealloption">False</property>
+   <property name="position">top</property>
+   <property name="section">advanced</property>
+   <property name="hidden">False</property>
+   <property name="custom_css"></property>
+   <property name="count">False</property>
+   <property name="sortcountable">False</property>
+   <property name="hidezerocount">False</property>
+   <property name="sortreversed">False</property>
+  </criterion>
  </criteria>
 </object>

--- a/src/Products/urban/dashboard/config/liege/codt_parceloutlicences.xml
+++ b/src/Products/urban/dashboard/config/liege/codt_parceloutlicences.xml
@@ -173,5 +173,20 @@
    <property name="hidezerocount">False</property>
    <property name="sortreversed">False</property>
   </criterion>
+  <criterion name="c94">
+   <property name="widget">select2</property>
+   <property name="title">Rubriques</property>
+   <property name="index">rubrics</property>
+   <property name="vocabulary">urban.vocabularies.rubrics</property>
+   <property name="hidealloption">False</property>
+   <property name="position">top</property>
+   <property name="section">advanced</property>
+   <property name="hidden">False</property>
+   <property name="custom_css"></property>
+   <property name="count">False</property>
+   <property name="sortcountable">False</property>
+   <property name="hidezerocount">False</property>
+   <property name="sortreversed">False</property>
+  </criterion>
  </criteria>
 </object>

--- a/src/Products/urban/dashboard/config/liege/codt_uniquelicences.xml
+++ b/src/Products/urban/dashboard/config/liege/codt_uniquelicences.xml
@@ -215,5 +215,20 @@
    <property name="sortreversed">False</property>
    <property name="default"></property>
   </criterion>
+  <criterion name="c94">
+   <property name="widget">select2</property>
+   <property name="title">Rubriques</property>
+   <property name="index">rubrics</property>
+   <property name="vocabulary">urban.vocabularies.rubrics</property>
+   <property name="hidealloption">False</property>
+   <property name="position">top</property>
+   <property name="section">advanced</property>
+   <property name="hidden">False</property>
+   <property name="custom_css"></property>
+   <property name="count">False</property>
+   <property name="sortcountable">False</property>
+   <property name="hidezerocount">False</property>
+   <property name="sortreversed">False</property>
+  </criterion>
  </criteria>
 </object>

--- a/src/Products/urban/dashboard/config/liege/codt_urbancertificateones.xml
+++ b/src/Products/urban/dashboard/config/liege/codt_urbancertificateones.xml
@@ -226,5 +226,20 @@
    <property name="sortreversed">False</property>
    <property name="default"></property>
   </criterion>
+  <criterion name="c94">
+   <property name="widget">select2</property>
+   <property name="title">Rubriques</property>
+   <property name="index">rubrics</property>
+   <property name="vocabulary">urban.vocabularies.rubrics</property>
+   <property name="hidealloption">False</property>
+   <property name="position">top</property>
+   <property name="section">advanced</property>
+   <property name="hidden">False</property>
+   <property name="custom_css"></property>
+   <property name="count">False</property>
+   <property name="sortcountable">False</property>
+   <property name="hidezerocount">False</property>
+   <property name="sortreversed">False</property>
+  </criterion>
  </criteria>
 </object>

--- a/src/Products/urban/dashboard/config/liege/codt_urbancertificatetwos.xml
+++ b/src/Products/urban/dashboard/config/liege/codt_urbancertificatetwos.xml
@@ -227,5 +227,20 @@
    <property name="sortreversed">False</property>
    <property name="default"></property>
   </criterion>
+  <criterion name="c94">
+   <property name="widget">select2</property>
+   <property name="title">Rubriques</property>
+   <property name="index">rubrics</property>
+   <property name="vocabulary">urban.vocabularies.rubrics</property>
+   <property name="hidealloption">False</property>
+   <property name="position">top</property>
+   <property name="section">advanced</property>
+   <property name="hidden">False</property>
+   <property name="custom_css"></property>
+   <property name="count">False</property>
+   <property name="sortcountable">False</property>
+   <property name="hidezerocount">False</property>
+   <property name="sortreversed">False</property>
+  </criterion>
  </criteria>
 </object>

--- a/src/Products/urban/dashboard/config/liege/declarations.xml
+++ b/src/Products/urban/dashboard/config/liege/declarations.xml
@@ -147,5 +147,20 @@
    <property name="onlyallelements">True</property>
    <property name="wildcard">True</property>
   </criterion>
+  <criterion name="c94">
+   <property name="widget">select2</property>
+   <property name="title">Rubriques</property>
+   <property name="index">rubrics</property>
+   <property name="vocabulary">urban.vocabularies.rubrics</property>
+   <property name="hidealloption">False</property>
+   <property name="position">top</property>
+   <property name="section">advanced</property>
+   <property name="hidden">False</property>
+   <property name="custom_css"></property>
+   <property name="count">False</property>
+   <property name="sortcountable">False</property>
+   <property name="hidezerocount">False</property>
+   <property name="sortreversed">False</property>
+  </criterion>
  </criteria>
 </object>

--- a/src/Products/urban/dashboard/config/liege/divisions.xml
+++ b/src/Products/urban/dashboard/config/liege/divisions.xml
@@ -227,5 +227,20 @@
    <property name="sortreversed">False</property>
    <property name="default"></property>
   </criterion>
+  <criterion name="c94">
+   <property name="widget">select2</property>
+   <property name="title">Rubriques</property>
+   <property name="index">rubrics</property>
+   <property name="vocabulary">urban.vocabularies.rubrics</property>
+   <property name="hidealloption">False</property>
+   <property name="position">top</property>
+   <property name="section">advanced</property>
+   <property name="hidden">False</property>
+   <property name="custom_css"></property>
+   <property name="count">False</property>
+   <property name="sortcountable">False</property>
+   <property name="hidezerocount">False</property>
+   <property name="sortreversed">False</property>
+  </criterion>
  </criteria>
 </object>

--- a/src/Products/urban/dashboard/config/liege/envclassborderings.xml
+++ b/src/Products/urban/dashboard/config/liege/envclassborderings.xml
@@ -217,5 +217,20 @@
    <property name="sortreversed">False</property>
    <property name="default"></property>
   </criterion>
+  <criterion name="c94">
+   <property name="widget">select2</property>
+   <property name="title">Rubriques</property>
+   <property name="index">rubrics</property>
+   <property name="vocabulary">urban.vocabularies.rubrics</property>
+   <property name="hidealloption">False</property>
+   <property name="position">top</property>
+   <property name="section">advanced</property>
+   <property name="hidden">False</property>
+   <property name="custom_css"></property>
+   <property name="count">False</property>
+   <property name="sortcountable">False</property>
+   <property name="hidezerocount">False</property>
+   <property name="sortreversed">False</property>
+  </criterion>
  </criteria>
 </object>

--- a/src/Products/urban/dashboard/config/liege/envclassones.xml
+++ b/src/Products/urban/dashboard/config/liege/envclassones.xml
@@ -225,5 +225,20 @@
    <property name="sortreversed">False</property>
    <property name="default"></property>
   </criterion>
+  <criterion name="c94">
+   <property name="widget">select2</property>
+   <property name="title">Rubriques</property>
+   <property name="index">rubrics</property>
+   <property name="vocabulary">urban.vocabularies.rubrics</property>
+   <property name="hidealloption">False</property>
+   <property name="position">top</property>
+   <property name="section">advanced</property>
+   <property name="hidden">False</property>
+   <property name="custom_css"></property>
+   <property name="count">False</property>
+   <property name="sortcountable">False</property>
+   <property name="hidezerocount">False</property>
+   <property name="sortreversed">False</property>
+  </criterion>
  </criteria>
 </object>

--- a/src/Products/urban/dashboard/config/liege/envclassthrees.xml
+++ b/src/Products/urban/dashboard/config/liege/envclassthrees.xml
@@ -225,5 +225,20 @@
    <property name="sortreversed">False</property>
    <property name="default"></property>
   </criterion>
+  <criterion name="c94">
+   <property name="widget">select2</property>
+   <property name="title">Rubriques</property>
+   <property name="index">rubrics</property>
+   <property name="vocabulary">urban.vocabularies.rubrics</property>
+   <property name="hidealloption">False</property>
+   <property name="position">top</property>
+   <property name="section">advanced</property>
+   <property name="hidden">False</property>
+   <property name="custom_css"></property>
+   <property name="count">False</property>
+   <property name="sortcountable">False</property>
+   <property name="hidezerocount">False</property>
+   <property name="sortreversed">False</property>
+  </criterion>
  </criteria>
 </object>

--- a/src/Products/urban/dashboard/config/liege/envclasstwos.xml
+++ b/src/Products/urban/dashboard/config/liege/envclasstwos.xml
@@ -240,5 +240,20 @@
    <property name="hidezerocount">False</property>
    <property name="sortreversed">False</property>
   </criterion>
+  <criterion name="c94">
+   <property name="widget">select2</property>
+   <property name="title">Rubriques</property>
+   <property name="index">rubrics</property>
+   <property name="vocabulary">urban.vocabularies.rubrics</property>
+   <property name="hidealloption">False</property>
+   <property name="position">top</property>
+   <property name="section">advanced</property>
+   <property name="hidden">False</property>
+   <property name="custom_css"></property>
+   <property name="count">False</property>
+   <property name="sortcountable">False</property>
+   <property name="hidezerocount">False</property>
+   <property name="sortreversed">False</property>
+  </criterion>
  </criteria>
 </object>

--- a/src/Products/urban/dashboard/config/liege/envclasstwos.xml
+++ b/src/Products/urban/dashboard/config/liege/envclasstwos.xml
@@ -225,5 +225,20 @@
    <property name="sortreversed">False</property>
    <property name="default"></property>
   </criterion>
+  <criterion name="c94">
+   <property name="widget">select2</property>
+   <property name="title">Rubriques</property>
+   <property name="index">rubrics</property>
+   <property name="vocabulary">urban.vocabularies.rubrics</property>
+   <property name="hidealloption">False</property>
+   <property name="position">top</property>
+   <property name="section">advanced</property>
+   <property name="hidden">False</property>
+   <property name="custom_css"></property>
+   <property name="count">False</property>
+   <property name="sortcountable">False</property>
+   <property name="hidezerocount">False</property>
+   <property name="sortreversed">False</property>
+  </criterion>
  </criteria>
 </object>

--- a/src/Products/urban/dashboard/config/liege/explosivespossessions.xml
+++ b/src/Products/urban/dashboard/config/liege/explosivespossessions.xml
@@ -217,5 +217,20 @@
    <property name="sortreversed">False</property>
    <property name="default"></property>
   </criterion>
+  <criterion name="c94">
+   <property name="widget">select2</property>
+   <property name="title">Rubriques</property>
+   <property name="index">rubrics</property>
+   <property name="vocabulary">urban.vocabularies.rubrics</property>
+   <property name="hidealloption">False</property>
+   <property name="position">top</property>
+   <property name="section">advanced</property>
+   <property name="hidden">False</property>
+   <property name="custom_css"></property>
+   <property name="count">False</property>
+   <property name="sortcountable">False</property>
+   <property name="hidezerocount">False</property>
+   <property name="sortreversed">False</property>
+  </criterion>
  </criteria>
 </object>

--- a/src/Products/urban/dashboard/config/liege/housings.xml
+++ b/src/Products/urban/dashboard/config/liege/housings.xml
@@ -155,5 +155,20 @@
       <property name="step">10</property>
       <property name="default">20</property>
     </criterion>
+    <criterion name="c94">
+    <property name="widget">select2</property>
+    <property name="title">Rubriques</property>
+    <property name="index">rubrics</property>
+    <property name="vocabulary">urban.vocabularies.rubrics</property>
+    <property name="hidealloption">False</property>
+    <property name="position">top</property>
+    <property name="section">advanced</property>
+    <property name="hidden">False</property>
+    <property name="custom_css"></property>
+    <property name="count">False</property>
+    <property name="sortcountable">False</property>
+    <property name="hidezerocount">False</property>
+    <property name="sortreversed">False</property>
+    </criterion>
   </criteria>
 </object>

--- a/src/Products/urban/dashboard/config/liege/inspections.xml
+++ b/src/Products/urban/dashboard/config/liege/inspections.xml
@@ -217,5 +217,20 @@
    <property name="sortreversed">False</property>
    <property name="default"></property>
   </criterion>
+  <criterion name="c94">
+   <property name="widget">select2</property>
+   <property name="title">Rubriques</property>
+   <property name="index">rubrics</property>
+   <property name="vocabulary">urban.vocabularies.rubrics</property>
+   <property name="hidealloption">False</property>
+   <property name="position">top</property>
+   <property name="section">advanced</property>
+   <property name="hidden">False</property>
+   <property name="custom_css"></property>
+   <property name="count">False</property>
+   <property name="sortcountable">False</property>
+   <property name="hidezerocount">False</property>
+   <property name="sortreversed">False</property>
+  </criterion>
  </criteria>
 </object>

--- a/src/Products/urban/dashboard/config/liege/integratedlicences.xml
+++ b/src/Products/urban/dashboard/config/liege/integratedlicences.xml
@@ -175,5 +175,20 @@
    <property name="hidezerocount">False</property>
    <property name="sortreversed">False</property>
   </criterion>
+  <criterion name="c94">
+   <property name="widget">select2</property>
+   <property name="title">Rubriques</property>
+   <property name="index">rubrics</property>
+   <property name="vocabulary">urban.vocabularies.rubrics</property>
+   <property name="hidealloption">False</property>
+   <property name="position">top</property>
+   <property name="section">advanced</property>
+   <property name="hidden">False</property>
+   <property name="custom_css"></property>
+   <property name="count">False</property>
+   <property name="sortcountable">False</property>
+   <property name="hidezerocount">False</property>
+   <property name="sortreversed">False</property>
+  </criterion>
  </criteria>
 </object>

--- a/src/Products/urban/dashboard/config/liege/integratedlicences.xml
+++ b/src/Products/urban/dashboard/config/liege/integratedlicences.xml
@@ -160,5 +160,20 @@
    <property name="index">getValidityDate</property>
    <property name="calYearRange">c-10:c+10</property>
   </criterion>
+  <criterion name="c94">
+   <property name="widget">select2</property>
+   <property name="title">Rubriques</property>
+   <property name="index">rubrics</property>
+   <property name="vocabulary">urban.vocabularies.rubrics</property>
+   <property name="hidealloption">False</property>
+   <property name="position">top</property>
+   <property name="section">advanced</property>
+   <property name="hidden">False</property>
+   <property name="custom_css"></property>
+   <property name="count">False</property>
+   <property name="sortcountable">False</property>
+   <property name="hidezerocount">False</property>
+   <property name="sortreversed">False</property>
+  </criterion>
  </criteria>
 </object>

--- a/src/Products/urban/dashboard/config/liege/miscdemands.xml
+++ b/src/Products/urban/dashboard/config/liege/miscdemands.xml
@@ -216,5 +216,20 @@
    <property name="sortreversed">False</property>
    <property name="default"></property>
   </criterion>
+  <criterion name="c94">
+   <property name="widget">select2</property>
+   <property name="title">Rubriques</property>
+   <property name="index">rubrics</property>
+   <property name="vocabulary">urban.vocabularies.rubrics</property>
+   <property name="hidealloption">False</property>
+   <property name="position">top</property>
+   <property name="section">advanced</property>
+   <property name="hidden">False</property>
+   <property name="custom_css"></property>
+   <property name="count">False</property>
+   <property name="sortcountable">False</property>
+   <property name="hidezerocount">False</property>
+   <property name="sortreversed">False</property>
+  </criterion>
  </criteria>
 </object>

--- a/src/Products/urban/dashboard/config/liege/notaryletters.xml
+++ b/src/Products/urban/dashboard/config/liege/notaryletters.xml
@@ -143,5 +143,20 @@
    <property name="index">getValidityDate</property>
    <property name="calYearRange">c-10:c+10</property>
   </criterion>
+  <criterion name="c94">
+   <property name="widget">select2</property>
+   <property name="title">Rubriques</property>
+   <property name="index">rubrics</property>
+   <property name="vocabulary">urban.vocabularies.rubrics</property>
+   <property name="hidealloption">False</property>
+   <property name="position">top</property>
+   <property name="section">advanced</property>
+   <property name="hidden">False</property>
+   <property name="custom_css"></property>
+   <property name="count">False</property>
+   <property name="sortcountable">False</property>
+   <property name="hidezerocount">False</property>
+   <property name="sortreversed">False</property>
+  </criterion>
  </criteria>
 </object>

--- a/src/Products/urban/dashboard/config/liege/parceloutlicences.xml
+++ b/src/Products/urban/dashboard/config/liege/parceloutlicences.xml
@@ -146,5 +146,20 @@
    <property name="sortreversed">False</property>
    <property name="default" />
   </criterion>
+  <criterion name="c94">
+   <property name="widget">select2</property>
+   <property name="title">Rubriques</property>
+   <property name="index">rubrics</property>
+   <property name="vocabulary">urban.vocabularies.rubrics</property>
+   <property name="hidealloption">False</property>
+   <property name="position">top</property>
+   <property name="section">advanced</property>
+   <property name="hidden">False</property>
+   <property name="custom_css"></property>
+   <property name="count">False</property>
+   <property name="sortcountable">False</property>
+   <property name="hidezerocount">False</property>
+   <property name="sortreversed">False</property>
+  </criterion>
  </criteria>
 </object>

--- a/src/Products/urban/dashboard/config/liege/patrimonycertificates.xml
+++ b/src/Products/urban/dashboard/config/liege/patrimonycertificates.xml
@@ -225,5 +225,20 @@
    <property name="sortreversed">False</property>
    <property name="default"></property>
   </criterion>
+  <criterion name="c94">
+   <property name="widget">select2</property>
+   <property name="title">Rubriques</property>
+   <property name="index">rubrics</property>
+   <property name="vocabulary">urban.vocabularies.rubrics</property>
+   <property name="hidealloption">False</property>
+   <property name="position">top</property>
+   <property name="section">advanced</property>
+   <property name="hidden">False</property>
+   <property name="custom_css"></property>
+   <property name="count">False</property>
+   <property name="sortcountable">False</property>
+   <property name="hidezerocount">False</property>
+   <property name="sortreversed">False</property>
+  </criterion>
  </criteria>
 </object>

--- a/src/Products/urban/dashboard/config/liege/preliminarynotices.xml
+++ b/src/Products/urban/dashboard/config/liege/preliminarynotices.xml
@@ -215,5 +215,20 @@
    <property name="sortreversed">False</property>
    <property name="default"></property>
   </criterion>
+  <criterion name="c94">
+   <property name="widget">select2</property>
+   <property name="title">Rubriques</property>
+   <property name="index">rubrics</property>
+   <property name="vocabulary">urban.vocabularies.rubrics</property>
+   <property name="hidealloption">False</property>
+   <property name="position">top</property>
+   <property name="section">advanced</property>
+   <property name="hidden">False</property>
+   <property name="custom_css"></property>
+   <property name="count">False</property>
+   <property name="sortcountable">False</property>
+   <property name="hidezerocount">False</property>
+   <property name="sortreversed">False</property>
+  </criterion>
  </criteria>
 </object>

--- a/src/Products/urban/dashboard/config/liege/projectmeetings.xml
+++ b/src/Products/urban/dashboard/config/liege/projectmeetings.xml
@@ -144,5 +144,20 @@
    <property name="index">getValidityDate</property>
    <property name="calYearRange">c-10:c+10</property>
   </criterion>
+  <criterion name="c94">
+   <property name="widget">select2</property>
+   <property name="title">Rubriques</property>
+   <property name="index">rubrics</property>
+   <property name="vocabulary">urban.vocabularies.rubrics</property>
+   <property name="hidealloption">False</property>
+   <property name="position">top</property>
+   <property name="section">advanced</property>
+   <property name="hidden">False</property>
+   <property name="custom_css"></property>
+   <property name="count">False</property>
+   <property name="sortcountable">False</property>
+   <property name="hidezerocount">False</property>
+   <property name="sortreversed">False</property>
+  </criterion>
  </criteria>
 </object>

--- a/src/Products/urban/dashboard/config/liege/roaddecrees.xml
+++ b/src/Products/urban/dashboard/config/liege/roaddecrees.xml
@@ -217,5 +217,20 @@
    <property name="sortreversed">False</property>
    <property name="default"></property>
   </criterion>
+  <criterion name="c94">
+   <property name="widget">select2</property>
+   <property name="title">Rubriques</property>
+   <property name="index">rubrics</property>
+   <property name="vocabulary">urban.vocabularies.rubrics</property>
+   <property name="hidealloption">False</property>
+   <property name="position">top</property>
+   <property name="section">advanced</property>
+   <property name="hidden">False</property>
+   <property name="custom_css"></property>
+   <property name="count">False</property>
+   <property name="sortcountable">False</property>
+   <property name="hidezerocount">False</property>
+   <property name="sortreversed">False</property>
+  </criterion>
  </criteria>
 </object>

--- a/src/Products/urban/dashboard/config/liege/tickets.xml
+++ b/src/Products/urban/dashboard/config/liege/tickets.xml
@@ -217,5 +217,20 @@
    <property name="sortreversed">False</property>
    <property name="default"></property>
   </criterion>
+  <criterion name="c94">
+   <property name="widget">select2</property>
+   <property name="title">Rubriques</property>
+   <property name="index">rubrics</property>
+   <property name="vocabulary">urban.vocabularies.rubrics</property>
+   <property name="hidealloption">False</property>
+   <property name="position">top</property>
+   <property name="section">advanced</property>
+   <property name="hidden">False</property>
+   <property name="custom_css"></property>
+   <property name="count">False</property>
+   <property name="sortcountable">False</property>
+   <property name="hidezerocount">False</property>
+   <property name="sortreversed">False</property>
+  </criterion>
  </criteria>
 </object>

--- a/src/Products/urban/dashboard/config/liege/uniquelicences.xml
+++ b/src/Products/urban/dashboard/config/liege/uniquelicences.xml
@@ -160,5 +160,20 @@
    <property name="index">getValidityDate</property>
    <property name="calYearRange">c-10:c+10</property>
   </criterion>
+  <criterion name="c94">
+   <property name="widget">select2</property>
+   <property name="title">Rubriques</property>
+   <property name="index">rubrics</property>
+   <property name="vocabulary">urban.vocabularies.rubrics</property>
+   <property name="hidealloption">False</property>
+   <property name="position">top</property>
+   <property name="section">advanced</property>
+   <property name="hidden">False</property>
+   <property name="custom_css"></property>
+   <property name="count">False</property>
+   <property name="sortcountable">False</property>
+   <property name="hidezerocount">False</property>
+   <property name="sortreversed">False</property>
+  </criterion>
  </criteria>
 </object>

--- a/src/Products/urban/dashboard/config/liege/urbancertificateones.xml
+++ b/src/Products/urban/dashboard/config/liege/urbancertificateones.xml
@@ -159,5 +159,20 @@
    <property name="index">getValidityDate</property>
    <property name="calYearRange">c-10:c+10</property>
   </criterion>
+  <criterion name="c94">
+   <property name="widget">select2</property>
+   <property name="title">Rubriques</property>
+   <property name="index">rubrics</property>
+   <property name="vocabulary">urban.vocabularies.rubrics</property>
+   <property name="hidealloption">False</property>
+   <property name="position">top</property>
+   <property name="section">advanced</property>
+   <property name="hidden">False</property>
+   <property name="custom_css"></property>
+   <property name="count">False</property>
+   <property name="sortcountable">False</property>
+   <property name="hidezerocount">False</property>
+   <property name="sortreversed">False</property>
+  </criterion>
  </criteria>
 </object>

--- a/src/Products/urban/dashboard/config/liege/urbancertificatetwos.xml
+++ b/src/Products/urban/dashboard/config/liege/urbancertificatetwos.xml
@@ -159,5 +159,20 @@
    <property name="index">getValidityDate</property>
    <property name="calYearRange">c-10:c+10</property>
   </criterion>
+  <criterion name="c94">
+   <property name="widget">select2</property>
+   <property name="title">Rubriques</property>
+   <property name="index">rubrics</property>
+   <property name="vocabulary">urban.vocabularies.rubrics</property>
+   <property name="hidealloption">False</property>
+   <property name="position">top</property>
+   <property name="section">advanced</property>
+   <property name="hidden">False</property>
+   <property name="custom_css"></property>
+   <property name="count">False</property>
+   <property name="sortcountable">False</property>
+   <property name="hidezerocount">False</property>
+   <property name="sortreversed">False</property>
+  </criterion>
  </criteria>
 </object>

--- a/src/Products/urban/index.zcml
+++ b/src/Products/urban/index.zcml
@@ -124,6 +124,10 @@
       factory=".indexes.additional_reference"
       name="getAdditionalReference"
       />
+  <adapter
+      factory=".indexes.rubrics_indexer"
+      name="rubrics"
+      />
 
   <!-- Unindex UrbanEvent, UrbanDoc, Applicant and PortionOut -->
 

--- a/src/Products/urban/indexes.py
+++ b/src/Products/urban/indexes.py
@@ -448,3 +448,8 @@ def additional_reference(object):
         return object.getAdditionalReference()
     except KeyError:
         raise AttributeError()
+
+
+@indexer(interfaces.IEnvironmentBase)
+def rubrics_indexer(context):
+    return context.getField("rubrics").getRaw(context)

--- a/src/Products/urban/migration/update_270.py
+++ b/src/Products/urban/migration/update_270.py
@@ -9,7 +9,6 @@ from Products.urban.interfaces import IGenericLicence
 from Products.urban.migration.utils import refresh_workflow_permissions
 from Products.urban.setuphandlers import createFolderDefaultValues
 from Products.urban.setuphandlers import createVocabularyFolder
-from imio.helpers.catalog import reindexIndexes
 from eea.facetednavigation.interfaces import ICriteria
 from imio.schedule.content.object_factories import MacroCreationConditionObject
 from imio.schedule.content.object_factories import MacroEndConditionObject
@@ -578,51 +577,4 @@ def add_additional_delay_option(context):
         criterion.add(wid="select2", position="top", section="advanced", **data)
         logger.info("Type {}, query widget add".format(urban_type))
 
-    logger.info("upgrade step done!")
-
-
-def add_rubrics_index_and_filters(context):
-    logger = logging.getLogger("urban: Add rubrics index and filters")
-    logger.info("starting upgrade steps")
-    setup_tool = api.portal.get_tool("portal_setup")
-    setup_tool.runImportStepFromProfile("profile-Products.urban:urbantypes", "catalog")
-    reindexIndexes(None, ["rubrics"])
-    URBAN_ENVIRONMENT_TYPES = [
-        "EnvClassOne",
-        "EnvClassTwo",
-        "EnvClassThree",
-        "ExplosivesPossession",
-        "EnvClassBordering",
-        "CODT_UniqueLicence",
-        "CODT_IntegratedLicence",
-        "CODT_CommercialLicence",
-        "UniqueLicence",
-    ]
-    portal_urban = api.portal.get_tool("portal_urban")
-    urban_folder = api.portal.get().urban
-    data = {
-        "_cid_": u"c94",
-        "title": u"Rubriques",
-        "hidden": False,
-        "index": u"rubrics",
-        "vocabulary": u"urban.vocabularies.rubrics",
-    }
-    urban_folder_criterion = ICriteria(urban_folder)
-    if urban_folder_criterion is not None:
-        urban_folder_criterion.add(
-            wid="select2", position="top", section="advanced", **data
-        )
-    for urban_type in URBAN_ENVIRONMENT_TYPES:
-        licence_config = portal_urban.get(urban_type.lower(), None)
-        if licence_config is None:
-            continue
-        # Add query widget
-        licence_folder = getattr(urban_folder, "{}s".format(urban_type.lower()), None)
-        if licence_folder is None:
-            continue
-        criterion = ICriteria(licence_folder)
-        if criterion is None:
-            continue
-
-        criterion.add(wid="select2", position="top", section="advanced", **data)
     logger.info("upgrade step done!")

--- a/src/Products/urban/migration/update_270.py
+++ b/src/Products/urban/migration/update_270.py
@@ -9,6 +9,7 @@ from Products.urban.interfaces import IGenericLicence
 from Products.urban.migration.utils import refresh_workflow_permissions
 from Products.urban.setuphandlers import createFolderDefaultValues
 from Products.urban.setuphandlers import createVocabularyFolder
+from imio.helpers.catalog import reindexIndexes
 from eea.facetednavigation.interfaces import ICriteria
 from imio.schedule.content.object_factories import MacroCreationConditionObject
 from imio.schedule.content.object_factories import MacroEndConditionObject
@@ -577,4 +578,51 @@ def add_additional_delay_option(context):
         criterion.add(wid="select2", position="top", section="advanced", **data)
         logger.info("Type {}, query widget add".format(urban_type))
 
+    logger.info("upgrade step done!")
+
+
+def add_rubrics_index_and_filters(context):
+    logger = logging.getLogger("urban: Add rubrics index and filters")
+    logger.info("starting upgrade steps")
+    setup_tool = api.portal.get_tool("portal_setup")
+    setup_tool.runImportStepFromProfile("profile-Products.urban:urbantypes", "catalog")
+    reindexIndexes(None, ["rubrics"])
+    URBAN_ENVIRONMENT_TYPES = [
+        "EnvClassOne",
+        "EnvClassTwo",
+        "EnvClassThree",
+        "ExplosivesPossession",
+        "EnvClassBordering",
+        "CODT_UniqueLicence",
+        "CODT_IntegratedLicence",
+        "CODT_CommercialLicence",
+        "UniqueLicence",
+    ]
+    portal_urban = api.portal.get_tool("portal_urban")
+    urban_folder = api.portal.get().urban
+    data = {
+        "_cid_": u"c94",
+        "title": u"Rubriques",
+        "hidden": False,
+        "index": u"rubrics",
+        "vocabulary": u"urban.vocabularies.rubrics",
+    }
+    urban_folder_criterion = ICriteria(urban_folder)
+    if urban_folder_criterion is not None:
+        urban_folder_criterion.add(
+            wid="select2", position="top", section="advanced", **data
+        )
+    for urban_type in URBAN_ENVIRONMENT_TYPES:
+        licence_config = portal_urban.get(urban_type.lower(), None)
+        if licence_config is None:
+            continue
+        # Add query widget
+        licence_folder = getattr(urban_folder, "{}s".format(urban_type.lower()), None)
+        if licence_folder is None:
+            continue
+        criterion = ICriteria(licence_folder)
+        if criterion is None:
+            continue
+
+        criterion.add(wid="select2", position="top", section="advanced", **data)
     logger.info("upgrade step done!")

--- a/src/Products/urban/migration/update_300.py
+++ b/src/Products/urban/migration/update_300.py
@@ -1,7 +1,10 @@
 # -*- coding: utf-8 -*-
 
+from eea.facetednavigation.interfaces import ICriteria
+from imio.helpers.catalog import reindexIndexes
 from Products.urban.interfaces import IBaseBuildLicence
 from Products.urban.browser.create_list_file import GenerateParcelList
+from Products.urban.config import URBAN_TYPES
 from Products.urban.migration.to_DX.migration_utils import UrbanLicenceToFileWalker
 from Products.urban.utils import set_default_optional_field
 from Products.urban.utils import set_eventconfig_optional_field
@@ -306,3 +309,41 @@ def fix_parcel_integer_number(context):
     walker.generate_file = GenerateParcelList(None, None)
     walker.go()
     logger.info("Upgrade done!")
+
+
+def add_rubrics_index_and_filters(context):
+    logger = logging.getLogger("urban: Add rubrics index and filters")
+    logger.info("starting upgrade steps")
+    setup_tool = api.portal.get_tool("portal_setup")
+    setup_tool.runImportStepFromProfile("profile-Products.urban:urbantypes", "catalog")
+
+    reindexIndexes(None, ["rubrics"])
+
+    portal_urban = api.portal.get_tool("portal_urban")
+    urban_folder = api.portal.get().urban
+    data = {
+        "_cid_": u"c94",
+        "title": u"Rubriques",
+        "hidden": False,
+        "index": u"rubrics",
+        "vocabulary": u"urban.vocabularies.rubrics",
+    }
+    urban_folder_criterion = ICriteria(urban_folder)
+    if urban_folder_criterion is not None:
+        urban_folder_criterion.add(
+            wid="select2", position="top", section="advanced", **data
+        )
+    for urban_type in URBAN_TYPES:
+        licence_config = portal_urban.get(urban_type.lower(), None)
+        if licence_config is None:
+            continue
+        # Add query widget
+        licence_folder = getattr(urban_folder, "{}s".format(urban_type.lower()), None)
+        if licence_folder is None:
+            continue
+        criterion = ICriteria(licence_folder)
+        if criterion is None:
+            continue
+
+        criterion.add(wid="select2", position="top", section="advanced", **data)
+    logger.info("upgrade step done!")

--- a/src/Products/urban/migration/upgrades.zcml
+++ b/src/Products/urban/migration/upgrades.zcml
@@ -876,4 +876,12 @@
       handler=".update_280.add_building_procedure"
       />
 
+      <gs:upgradeStep
+        title="Add rubrics index and filters"
+        description=""
+        source="1166"
+        destination="1167"
+        handler=".update_270.add_rubrics_index_and_filters"
+        profile="Products.urban:default"
+        />
 </configure>

--- a/src/Products/urban/migration/upgrades.zcml
+++ b/src/Products/urban/migration/upgrades.zcml
@@ -876,12 +876,4 @@
       handler=".update_280.add_building_procedure"
       />
 
-      <gs:upgradeStep
-        title="Add rubrics index and filters"
-        description=""
-        source="1166"
-        destination="1167"
-        handler=".update_270.add_rubrics_index_and_filters"
-        profile="Products.urban:default"
-        />
 </configure>

--- a/src/Products/urban/migration/upgrades_300.zcml
+++ b/src/Products/urban/migration/upgrades_300.zcml
@@ -159,4 +159,13 @@
       profile="Products.urban:default"
       />
 
+  <gs:upgradeStep
+    title="Add rubrics index and filters"
+    description=""
+    source="3003"
+    destination="3004"
+    handler=".update_300.add_rubrics_index_and_filters"
+    profile="Products.urban:default"
+    />
+
 </configure>

--- a/src/Products/urban/profiles/default/metadata.xml
+++ b/src/Products/urban/profiles/default/metadata.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <metadata>
-  <version>3003</version>
+  <version>3004</version>
   <dependencies>
     <dependency>profile-Products.urban:preinstall</dependency>
   </dependencies>

--- a/src/Products/urban/profiles/urban_types/catalog.xml
+++ b/src/Products/urban/profiles/urban_types/catalog.xml
@@ -184,5 +184,10 @@
     <indexed_attr value="getComplementary_delay" />
   </index>
   <column value="getComplementary_delay" />
-  <!-- ##/code-section FOOT -->
+
+  <column value="rubrics"/>
+  <index name="rubrics" meta_type="KeywordIndex">
+    <indexed_attr value="rubrics"/>
+  </index>
+<!-- ##/code-section FOOT -->
 </object>

--- a/src/Products/urban/vocabularies.py
+++ b/src/Products/urban/vocabularies.py
@@ -456,3 +456,47 @@ class ComplementaryDelayVocabulary(object):
 
 
 ComplementaryDelayFactory = ComplementaryDelayVocabulary()
+
+
+class RubricsVocabulary(object):
+    implements(IVocabularyFactory)
+
+    def get_rubrics_vocabularies(self):
+        portal = api.portal.get()
+        rubrics_folder = portal.portal_urban.rubrics
+        return self.recursive_get_term(rubrics_folder)
+
+    def recursive_get_term(self, element, rubrics=[], check_id=[]):
+        if element.portal_type == "Folder":
+            for item in element.values():
+                rubrics = self.recursive_get_term(item, rubrics)
+        if element.portal_type == "EnvironmentRubricTerm":
+            if element.UID() in check_id:
+                return rubrics
+            rubrics.append(
+                {
+                    "id": element.UID(),
+                    "title": "Classe {}, {} : {}".format(
+                        element.getExtraValue(),
+                        element.getNumber(),
+                        element.description.getRaw(),
+                    ),
+                    "enabled": api.content.get_state(
+                        obj=element.values()[0].values()[0]
+                    )
+                    == "enabled",
+                }
+            )
+            check_id.append(element.UID())
+        return rubrics
+
+    def __call__(self, context):
+        terms = self.get_rubrics_vocabularies()
+        voc_terms = [
+            SimpleTerm(t["id"], t["id"], t["title"]) for t in terms if t["enabled"]
+        ]
+        voc_terms.sort(lambda a, b: cmp(a.title, b.title))
+        return SimpleVocabulary(voc_terms)
+
+
+RubricsFactory = RubricsVocabulary()

--- a/src/Products/urban/vocabulary.zcml
+++ b/src/Products/urban/vocabulary.zcml
@@ -106,4 +106,9 @@
       component=".vocabularies.ComplementaryDelayFactory"
       />
 
+  <utility
+    component=".vocabularies.RubricsFactory"
+    name="urban.vocabularies.rubrics"
+    provides="zope.schema.interfaces.IVocabularyFactory"
+  />
 </configure>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a “Rubriques” filter to dashboards across available licence and permit views.
  * Enabled searching and filtering by rubric through the new indexed field and selectable rubric vocabulary.
  * Added formatted rubric displays for licence details, supporting HTML lists, descriptions, and configurable numbering.
* **Migration**
  * Existing installations are upgraded automatically so the new rubric index and dashboard filters are available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->