### PR TITLE
URB-3303 : Fix incomplete notification

### DIFF
--- a/src/Products/urban/browser/cron/notice.py
+++ b/src/Products/urban/browser/cron/notice.py
@@ -125,7 +125,7 @@ class ImportFromNoticeView(BrowserView):
             api.content.transition(license, transition)
 
     def process_incomplete_folder_notification(self, detailed_notification):
-        license = detailed_notification.license
+        license = detailed_notification.licence
         self.update_license(license, detailed_notification, event_type="dossier-incomplete")
         transaction.commit() 
     


### PR DESCRIPTION
This pull request fixes a typo in `process_incomplete_folder_notification`: the correct attribute is `licence` instead of `license`. 