### PR TITLE
Urb 3306 implement not admissible notification second tour

### DIFF
--- a/src/Products/urban/browser/cron/notice.py
+++ b/src/Products/urban/browser/cron/notice.py
@@ -66,7 +66,10 @@ class ImportFromNoticeView(BrowserView):
             self._transfert_dossier(detailed_notification)
         if detailed_notification.notice_type == "NOTIF_COMPLETUDE1_INCOMPLET_COMMUNE":
             self.process_incomplete_folder_notification(detailed_notification)
-
+        if detailed_notification.notice_type == "NOTIF_COMPLETUDE2_NON_RECEVABLE_COMMUNE":
+            self.process_not_admissible_folder_notification_second_tour(
+                detailed_notification
+            )
 
     def _transfert_dossier(self, detailed_notification):
         container = detailed_notification.container
@@ -128,4 +131,9 @@ class ImportFromNoticeView(BrowserView):
         license = detailed_notification.licence
         self.update_license(license, detailed_notification, event_type="dossier-incomplet")
         transaction.commit() 
-    
+    def process_not_admissible_folder_notification_second_tour(self, detailed_notification):
+        licence = detailed_notification.licence
+        self.update_licence(licence, detailed_notification, event_type="dossier-irrecevable")
+        transaction.commit()
+        
+        

--- a/src/Products/urban/browser/cron/notice.py
+++ b/src/Products/urban/browser/cron/notice.py
@@ -134,9 +134,8 @@ class ImportFromNoticeView(BrowserView):
         license = detailed_notification.licence
         self.update_license(license, detailed_notification, event_type="dossier-incomplet")
         transaction.commit() 
+
     def process_not_admissible_folder_notification_second_tour(self, detailed_notification):
         licence = detailed_notification.licence
         self.update_license(licence, detailed_notification, event_type="dossier-irrecevable")
         transaction.commit()
-        
-        

--- a/src/Products/urban/browser/cron/notice.py
+++ b/src/Products/urban/browser/cron/notice.py
@@ -67,7 +67,10 @@ class ImportFromNoticeView(BrowserView):
             self._transfert_dossier(detailed_notification)
         if detailed_notification.notice_type == "NOTIF_COMPLETUDE1_INCOMPLET_COMMUNE":
             self.process_incomplete_folder_notification(detailed_notification)
-
+        if detailed_notification.notice_type == "NOTIF_COMPLETUDE2_NON_RECEVABLE_COMMUNE":
+            self.process_not_admissible_folder_notification_second_tour(
+                detailed_notification
+            )
 
     def _transfert_dossier(self, detailed_notification):
         container = detailed_notification.container
@@ -148,4 +151,9 @@ class ImportFromNoticeView(BrowserView):
         license = detailed_notification.licence
         self.update_license(license, detailed_notification, event_type="dossier-incomplet")
         transaction.commit() 
-    
+    def process_not_admissible_folder_notification_second_tour(self, detailed_notification):
+        licence = detailed_notification.licence
+        self.update_licence(licence, detailed_notification, event_type="dossier-irrecevable")
+        transaction.commit()
+        
+        

--- a/src/Products/urban/browser/cron/notice.py
+++ b/src/Products/urban/browser/cron/notice.py
@@ -153,7 +153,7 @@ class ImportFromNoticeView(BrowserView):
         transaction.commit() 
     def process_not_admissible_folder_notification_second_tour(self, detailed_notification):
         licence = detailed_notification.licence
-        self.update_licence(licence, detailed_notification, event_type="dossier-irrecevable")
+        self.update_license(licence, detailed_notification, event_type="dossier-irrecevable")
         transaction.commit()
         
         

--- a/src/Products/urban/browser/cron/notice.py
+++ b/src/Products/urban/browser/cron/notice.py
@@ -4,6 +4,7 @@ from Products.Archetypes.event import ObjectInitializedEvent
 from Products.Five import BrowserView
 from Products.urban import UrbanMessage as _
 from Products.urban.services import notice
+from Products.urban.browser.cron.transitions import EVENT_TYPE_TO_TRANSITION
 from datetime import datetime
 from DateTime import DateTime
 from plone import api
@@ -118,19 +119,27 @@ class ImportFromNoticeView(BrowserView):
         if not event_type:
             return
         event_configs = detailed_notification.event_configs
-        event_config = event_configs.get(event_type)
-        if not event_config:
+        # Normalizing event_type to list
+        if isinstance(event_type, (list, tuple)):
+            event_types = event_type
+        else:
+            event_types = [event_type]   
+        configs = []
+        for etype in event_types:                                         
+            event_config = event_configs.get(etype)
+            if  event_config:
+                configs.append((etype,event_config))
+        if not configs:
             return
-        event_type_to_transition = {"dossier-incomplet": "isincomplete"}
-
         with api.env.adopt_roles(["Manager"]):
-            event = license.createUrbanEvent(event_config)
-            event_date = DateTime(str(detailed_notification.send_date))
-            event.setEventDate(event_date)
-            api.content.transition(event, "close")
-        transition = event_type_to_transition.get(event_type)
-        if transition:
-            api.content.transition(license, transition)
+            for etype, event_config in configs:
+                event = license.createUrbanEvent(event_config)
+                event_date = DateTime(str(detailed_notification.send_date))
+                event.setEventDate(event_date)
+                api.content.transition(event, "close")
+                transition = EVENT_TYPE_TO_TRANSITION.get(etype)
+                if transition:
+                    api.content.transition(license, transition)
 
     def process_incomplete_folder_notification(self, detailed_notification):
         license = detailed_notification.licence

--- a/src/Products/urban/browser/cron/notice.py
+++ b/src/Products/urban/browser/cron/notice.py
@@ -75,6 +75,9 @@ class ImportFromNoticeView(BrowserView):
             container=container, **detailed_notification.serialize()
         )
         licence.noticeId = detailed_notification.noticeId
+        licence.setFoldermanagers(
+            detailed_notification.foldermanagers
+        )  # Must be set manually, serialized value is ignored at creation
         licence._p_changed = 1
         for party in detailed_notification.parties:
             api.content.create(container=licence, **party.serialize())

--- a/src/Products/urban/browser/cron/notice.py
+++ b/src/Products/urban/browser/cron/notice.py
@@ -116,7 +116,10 @@ class ImportFromNoticeView(BrowserView):
         event_config = event_configs.get(event_type)
         if not event_config:
             return
-        event_type_to_transition = {"dossier-incomplet": "isincomplete"}
+        event_type_to_transition = {
+            "dossier-incomplet": "isincomplete",
+            "dossier-irrecevable": "isinacceptable",
+        }
 
         with api.env.adopt_roles(["Manager"]):
             event = license.createUrbanEvent(event_config)
@@ -133,7 +136,7 @@ class ImportFromNoticeView(BrowserView):
         transaction.commit() 
     def process_not_admissible_folder_notification_second_tour(self, detailed_notification):
         licence = detailed_notification.licence
-        self.update_licence(licence, detailed_notification, event_type="dossier-irrecevable")
+        self.update_license(licence, detailed_notification, event_type="dossier-irrecevable")
         transaction.commit()
         
         

--- a/src/Products/urban/browser/cron/notice.py
+++ b/src/Products/urban/browser/cron/notice.py
@@ -37,11 +37,11 @@ class ImportFromNoticeView(BrowserView):
     def _add_error(self, licence, msg, serialized_data):
         """Add an error"""
         error = _(
-            "<p>${msg} for informations: ${data}</p>",
+            u"<p>${msg} for informations: ${data}</p>",
             mapping={
                 "msg": msg,
-                "data": ", ".join(
-                    ["{0}: {1}".format(k, v) for k, v in serialized_data.items()]
+                "data": u", ".join(
+                    [u"{0}: {1}".format(k, v) for k, v in serialized_data.items()]
                 ),
             },
         )

--- a/src/Products/urban/browser/cron/notice.py
+++ b/src/Products/urban/browser/cron/notice.py
@@ -104,7 +104,15 @@ class ImportFromNoticeView(BrowserView):
         # Set title and update reference number
         notify(ObjectInitializedEvent(licence))
         # Change workflow and add deposit event
-        transaction.commit()  # Usefull in case of an error
+        event_config_deposit = detailed_notification.event_config(
+            "Products.urban.interfaces.IDepositEvent"
+        )
+        event = licence.createUrbanEvent(event_config_deposit)
+        event_date = DateTime(str(detailed_notification.send_date))
+        event.setEventDate(event_date)
+        api.content.transition(event, "close")
+
+        transaction.commit()  # Useful in case of an error
     
     def update_license(self, license, detailed_notification, event_type=None):
         if not event_type:

--- a/src/Products/urban/browser/cron/notice.py
+++ b/src/Products/urban/browser/cron/notice.py
@@ -151,9 +151,8 @@ class ImportFromNoticeView(BrowserView):
         license = detailed_notification.licence
         self.update_license(license, detailed_notification, event_type="dossier-incomplet")
         transaction.commit() 
+
     def process_not_admissible_folder_notification_second_tour(self, detailed_notification):
         licence = detailed_notification.licence
         self.update_license(licence, detailed_notification, event_type="dossier-irrecevable")
         transaction.commit()
-        
-        

--- a/src/Products/urban/browser/cron/tests/test_notice.py
+++ b/src/Products/urban/browser/cron/tests/test_notice.py
@@ -216,6 +216,7 @@ class TestNoticeCronPE2(unittest.TestCase):
         # 5.4 assert folder is closed
         self.assertEqual(incomplete_folder.getEventDate().Date(), "2025/07/11")
         self.assertEqual(api.content.get_state(incomplete_folder), "closed")
+    
     def _create_not_admissible_folder(self, suffix, notif_id):
         folder_name = "NOT_ADMISSIBLE{0}".format(suffix)
         notif_file = "{0}_notifications.json".format(notif_id)

--- a/src/Products/urban/browser/cron/tests/test_notice.py
+++ b/src/Products/urban/browser/cron/tests/test_notice.py
@@ -216,7 +216,7 @@ class TestNoticeCronPE2(unittest.TestCase):
         # 5.4 assert folder is closed
         self.assertEqual(incomplete_folder.getEventDate().Date(), "2025/07/11")
         self.assertEqual(api.content.get_state(incomplete_folder), "closed")
-    
+
     def _create_not_admissible_folder(self, suffix, notif_id):
         folder_name = "NOT_ADMISSIBLE{0}".format(suffix)
         notif_file = "{0}_notifications.json".format(notif_id)

--- a/src/Products/urban/browser/cron/tests/test_notice.py
+++ b/src/Products/urban/browser/cron/tests/test_notice.py
@@ -216,4 +216,38 @@ class TestNoticeCronPE2(unittest.TestCase):
         # 5.4 assert folder is closed
         self.assertEqual(incomplete_folder.getEventDate().Date(), "2025/07/11")
         self.assertEqual(api.content.get_state(incomplete_folder), "closed")
-        
+    def _create_not_admissible_folder(self, suffix, notif_id):
+        folder_name = "NOT_ADMISSIBLE{0}".format(suffix)
+        notif_file = "{0}_notifications.json".format(notif_id)
+
+        if notif_id is None:
+            raise ValueError("Vous devez passer un notif_id pour ce test")
+        single_notif_file = "{0}-NOT-ADMISSIBLE-NOTIFICATION.json".format(notif_id)
+        # Load JSON
+        data = load_notif_json(folder_name, notif_file)
+
+        # Mock
+        with mock.patch(
+            "Products.urban.services.notice.WebserviceNotice.get_notifications",
+            return_value=data,
+        ), mock.patch(
+            "Products.urban.services.notice.WebserviceNotice._get_notification",
+            return_value=MockedRequest(load_notif_json(folder_name, single_notif_file)),
+        ):
+            with api.env.adopt_roles(["Manager"]):
+                import_view = self.portal.restrictedTraverse("@@import-from-notice")
+                import_view()
+    
+    def test_not_admissible_notification_second_tour(self):
+        licence_folder = self.portal.urban.envclasstwos
+        licence = licence_folder.values()[-1]
+        licence.reference = "PE2/2025/4"
+        licence.reindexObject()
+
+        # Création folder 2ème tour
+        self._create_not_admissible_folder("2","1443529")
+
+        not_admissible_folder = licence.getLastRefusedNotification()
+        self.assertIsNotNone(not_admissible_folder)
+        self.assertEqual(not_admissible_folder.getEventDate().Date(), "2025/09/19")
+        self.assertEqual(api.content.get_state(not_admissible_folder), "closed")

--- a/src/Products/urban/browser/cron/transitions.py
+++ b/src/Products/urban/browser/cron/transitions.py
@@ -1,0 +1,3 @@
+EVENT_TYPE_TO_TRANSITION = {
+    "dossier-incomplet": "isincomplete",
+}

--- a/src/Products/urban/browser/portlets.py
+++ b/src/Products/urban/browser/portlets.py
@@ -58,6 +58,10 @@ class ToolsRenderer(base.Renderer):
             return True
 
         return False
+    
+    def is_notice_setup(self):
+        site = api.portal.get()
+        return "import-notice" in site.urban.objectIds()
 
 
 class ToolsAddForm(base.AddForm):

--- a/src/Products/urban/browser/portlets.py
+++ b/src/Products/urban/browser/portlets.py
@@ -61,7 +61,14 @@ class ToolsRenderer(base.Renderer):
     
     def is_notice_setup(self):
         site = api.portal.get()
-        return "import-notice" in site.urban.objectIds()
+        urban = getattr(site, "urban", None)
+        if not urban:
+            return False
+        notice = getattr(urban, "import-notice", None)
+        if not notice:
+            return False
+        municipality_id = getattr(notice, "municipality_id", None)
+        return bool(municipality_id)
 
 
 class ToolsAddForm(base.AddForm):

--- a/src/Products/urban/browser/templates/portlet_urbantools.pt
+++ b/src/Products/urban/browser/templates/portlet_urbantools.pt
@@ -23,6 +23,11 @@
                 <img src="../engrenage.png" />
                 <a href="urbanstatsview" i18n:translate="urban_statistics">Statistics</a>
             </li>
+            <li tal:condition="view/is_notice_setup">
+                <img src="../GenericLicence.png"/>
+                <a href="" tal:attributes="href python: view.site_url() + '/urban/import-notice?no_redirect=1'" 
+                   i18n:translate="urban_incoming_notice_licences_descr">Incoming Notice licences</a>
+            </li>
         </ul>
     </dd>
 </dl>

--- a/src/Products/urban/content/licence/EnvironmentLicence.py
+++ b/src/Products/urban/content/licence/EnvironmentLicence.py
@@ -611,6 +611,9 @@ class EnvironmentLicence(BaseFolder, EnvironmentBase, BrowserDefaultMixin):
 
     security.declarePublic("previouslicencesBaseQuery")
 
+    def getLastRefusedNotification(self):
+        return self.getLastEvent(interfaces.IRefusedIncompletenessEvent)
+
     def previouslicencesBaseQuery(self):
         return {"object_provides": IEnvironmentBase.__identifier__}
 

--- a/src/Products/urban/dashboard/config/import_notice.xml
+++ b/src/Products/urban/dashboard/config/import_notice.xml
@@ -1,0 +1,165 @@
+<?xml version="1.0"?>
+<object name="urban" meta_type="ATFolder">
+ <criteria>
+  <criterion name="c1">
+   <property name="widget">sorting</property>
+   <property name="title">Tri</property>
+   <property name="position">top</property>
+   <property name="section">default</property>
+   <property name="hidden">True</property>
+   <property
+      name="vocabulary">eea.faceted.vocabularies.SortingCatalogIndexes</property>
+   <property name="default">created(reverse)</property>
+  </criterion>
+  <criterion name="c2">
+   <property name="widget">collection-link</property>
+   <property name="title">Procédures</property>
+   <property name="position">top</property>
+   <property name="section">default</property>
+   <property name="hidden">True</property>
+   <property name="count"></property>
+   <property name="sortcountable"></property>
+   <property name="hidezerocount"></property>
+   <property
+      name="vocabulary">collective.eeafaceted.collectionwidget.cachedcollectionvocabulary</property>
+   <property name="hidealloption">True</property>
+   <property name="hide_category">True</property>
+   <property name="sortreversed"></property>
+   <property name="default">12ffe12f7dc04b3ba4e82906b83abfbc</property>
+  </criterion>
+  <criterion name="c10">
+   <property name="widget">text</property>
+   <property name="title">Demandeur</property>
+   <property name="position">top</property>
+   <property name="section">advanced</property>
+   <property name="hidden">False</property>
+   <property name="index">applicantInfosIndex</property>
+   <property name="default"></property>
+   <property name="onlyallelements">True</property>
+   <property name="wildcard">True</property>
+  </criterion>
+  <criterion name="c4">
+   <property name="widget">autocomplete</property>
+   <property name="title">Rue</property>
+   <property name="position">top</property>
+   <property name="section">advanced</property>
+   <property name="hidden">False</property>
+   <property name="index">StreetsUID</property>
+   <property name="default"></property>
+   <property name="autocomplete_view">sreets-autocomplete-suggest</property>
+   <property name="onlyallelements">True</property>
+  </criterion>
+  <criterion name="c7">
+   <property name="widget">text</property>
+   <property name="title">N° de police</property>
+   <property name="position">top</property>
+   <property name="section">advanced</property>
+   <property name="hidden">False</property>
+   <property name="index">StreetNumber</property>
+   <property name="default"></property>
+   <property name="onlyallelements">True</property>
+   <property name="wildcard"></property>
+  </criterion>
+  <criterion name="c8">
+   <property name="widget">autocomplete</property>
+   <property name="title">Référence cadastrale</property>
+   <property name="position">top</property>
+   <property name="section">advanced</property>
+   <property name="hidden">False</property>
+   <property name="index">parcelInfosIndex</property>
+   <property name="default"></property>
+   <property
+      name="autocomplete_view">cadastral-autocomplete-suggest</property>
+   <property name="onlyallelements">True</property>
+  </criterion>
+  <criterion name="c9">
+   <property name="widget">daterange</property>
+   <property name="title">Date de décision</property>
+   <property name="position">top</property>
+   <property name="section">advanced</property>
+   <property name="hidden">False</property>
+   <property name="index">getDecisionDate</property>
+   <property name="default"></property>
+   <property name="calYearRange">c-10:c+10</property>
+  </criterion>
+  <criterion name="c99">
+   <property name="widget">daterange</property>
+   <property name="title">Date de validité</property>
+   <property name="position">top</property>
+   <property name="section">advanced</property>
+   <property name="hidden">False</property>
+   <property name="index">getValidityDate</property>
+   <property name="default"></property>
+   <property name="calYearRange">c-10:c+10</property>
+  </criterion>
+  <criterion name="c5">
+   <property name="widget">text</property>
+   <property name="title">Titre, référence</property>
+   <property name="position">center</property>
+   <property name="section">default</property>
+   <property name="hidden">False</property>
+   <property name="index">Title</property>
+   <property name="default"></property>
+   <property name="onlyallelements">True</property>
+   <property name="wildcard">True</property>
+  </criterion>
+  <criterion name="c6">
+   <property name="widget">select</property>
+   <property name="title">Agent traitant</property>
+   <property name="position">center</property>
+   <property name="section">default</property>
+   <property name="hidden">False</property>
+   <property name="count"></property>
+   <property name="sortcountable"></property>
+   <property name="hidezerocount"></property>
+   <property name="index">folder_manager</property>
+   <property name="vocabulary">urban.folder_managers</property>
+   <property name="catalog"></property>
+   <property name="sortreversed"></property>
+   <property name="default"></property>
+  </criterion>
+  <criterion name="c11">
+   <property name="widget">select_to_list</property>
+   <property name="title">Type</property>
+   <property name="position">center</property>
+   <property name="section">default</property>
+   <property name="hidden">False</property>
+   <property name="count"></property>
+   <property name="sortcountable"></property>
+   <property name="hidezerocount"></property>
+   <property name="index">portal_type</property>
+   <property
+      name="vocabulary">urban.vocabularies.procedure_category</property>
+   <property name="catalog"></property>
+   <property name="sortreversed"></property>
+   <property name="default">codt</property>
+  </criterion>
+  <criterion name="c0">
+   <property name="widget">resultsperpage</property>
+   <property name="title">Results per page</property>
+   <property name="position">center</property>
+   <property name="section">default</property>
+   <property name="hidden">False</property>
+   <property name="start">0</property>
+   <property name="end">50</property>
+   <property name="step">10</property>
+   <property name="default">20</property>
+  </criterion>
+ <criterion name="c97">
+   <property name="widget">select2</property>
+   <property name="title">Prorogation complémentaire</property>
+   <property name="index">getComplementary_delay</property>
+   <property
+      name="vocabulary">urban.vocabularies.complementary_delay</property>
+   <property name="catalog"></property>
+   <property name="hidealloption">False</property>
+   <property name="position">center</property>
+   <property name="section">default</property>
+   <property name="hidden">False</property>
+   <property name="count">False</property>
+   <property name="sortcountable">False</property>
+   <property name="hidezerocount">False</property>
+   <property name="sortreversed">False</property>
+  </criterion>
+ </criteria>
+</object>

--- a/src/Products/urban/events/configuration_events.py
+++ b/src/Products/urban/events/configuration_events.py
@@ -6,6 +6,7 @@ from zope.i18n import translate
 from OFS.ObjectManager import BeforeDeleteException
 from Products.urban.interfaces import IGenericLicence
 from Products.urban import UrbanMessage as _
+from zExceptions import Redirect
 
 
 def activate_optional_fields(portal_urban, event):
@@ -70,3 +71,16 @@ def before_street_delete(current_street, event):
                         " : {}".format(licence.reference),
                     )
                 )
+
+
+def folder_manager_object_will_be_moved(folder_manager, event):
+    if event.oldName in ("notice",):
+        api.portal.show_message(
+            _(
+                u"The folder manager '${name}' can't be renamed or removed.",
+                mapping={u"name": event.oldName},
+            ),
+            folder_manager.REQUEST,
+            type="error",
+        )
+        raise Redirect(event.object.aq_parent.absolute_url())

--- a/src/Products/urban/events/configure.zcml
+++ b/src/Products/urban/events/configure.zcml
@@ -274,5 +274,8 @@
                    OFS.interfaces.IObjectWillBeRemovedEvent"
               handler=".configuration_events.before_street_delete" />
 
+  <subscriber for="..interfaces.IFolderManager
+                   OFS.interfaces.IObjectWillBeMovedEvent"
+              handler=".configuration_events.folder_manager_object_will_be_moved" />
 
 </configure>

--- a/src/Products/urban/locales/fr/LC_MESSAGES/urban.po
+++ b/src/Products/urban/locales/fr/LC_MESSAGES/urban.po
@@ -934,6 +934,10 @@ msgstr "L'import des réclamants a bien été enregistré et sera éxécuté cet
 msgid "The field does not exist !!!"
 msgstr "Le champ n'existe pas."
 
+#: ../events/configuration_events.py:79
+msgid "The folder manager '${name}' can't be renamed or removed."
+msgstr "L'agent traitant '${name}' ne peut pas être renommé ou supprimé."
+
 #: ../browser/urbaneventviews.py:368
 msgid "The imported file (${name}) couldn't be read properly. Please verify its structure and try again."
 msgstr "Le fichier importé (${name}) n'a pas pu être lu correctement. Veuillez vérifier sa structure et réessayer."
@@ -2725,6 +2729,11 @@ msgstr "Si coché, un paragraphe supplémentaire apparaîtra dans le permis"
 #: ../browser/urbaneventviews.py:528
 msgid "urban_imported_recipients"
 msgstr "Destinataires importés"
+
+#. Default: "Incoming Notice licences"
+#: ../browser/templates/portlet_urbantools.pt:28
+msgid "urban_incoming_notice_licences_descr"
+msgstr "Permis Notice à traiter"
 
 #. Default: "Dgo4reference"
 #: ParcellingTerm.py

--- a/src/Products/urban/locales/urban.pot
+++ b/src/Products/urban/locales/urban.pot
@@ -923,6 +923,10 @@ msgstr ""
 msgid "The field does not exist !!!"
 msgstr ""
 
+#: ../events/configuration_events.py:79
+msgid "The folder manager '${name}' can't be renamed or removed."
+msgstr ""
+
 #: ../browser/urbaneventviews.py:368
 msgid "The imported file (${name}) couldn't be read properly. Please verify its structure and try again."
 msgstr ""
@@ -2695,6 +2699,11 @@ msgstr ""
 
 #: ../browser/urbaneventviews.py:528
 msgid "urban_imported_recipients"
+msgstr ""
+
+#. Default: "Incoming Notice licences"
+#: ../browser/templates/portlet_urbantools.pt:28
+msgid "urban_incoming_notice_licences_descr"
 msgstr ""
 
 #. Default: "Dgo4reference"

--- a/src/Products/urban/migration/update_290.py
+++ b/src/Products/urban/migration/update_290.py
@@ -1,5 +1,5 @@
 # encoding: utf-8
-
+from Products.urban import URBAN_TYPES
 from Products.urban import UrbanMessage as _
 from Products.CMFCore.utils import getToolByName
 from Products.urban.utils import moveElementAfter
@@ -10,6 +10,7 @@ from plone.registry import Record
 from plone.registry import field
 from plone.registry.interfaces import IRegistry
 from zope.component import getUtility
+from zope.event import notify
 
 import logging
 
@@ -119,3 +120,58 @@ def add_event_config_types_notice(context):
                     setattr(folder_event, "eventType", new_interfaces)
 
             last_urbaneventype_id = id
+
+
+def add_folder_manager_notice(context):
+    from Products.urban.setuphandlers import _activate_dashboard_navigation
+    from collective.eeafaceted.collectionwidget.utils import _updateDefaultCollectionFor
+    from eea.facetednavigation.criteria.interfaces import ICriteria
+    from eea.facetednavigation.events import FacetedGlobalSettingsChangedEvent
+
+    logger = logging.getLogger("urban: Add folder manager for notice import")
+
+    # create folder manager
+    urban_tool = api.portal.get_tool("portal_urban")
+    foldermanagers = getattr(urban_tool, "foldermanagers")
+    if "notice" not in foldermanagers.objectIds():
+        foldermanagers.invokeFactory(
+            "FolderManager",
+            "notice",
+            name1="Import NOTICE",
+            grade="agent-technique",
+            ploneUserId="",
+            manageableLicences=URBAN_TYPES,
+        )
+    notice_folder_manager = foldermanagers.notice
+    notice_folder_manager.reindexObject()
+
+    # create dashboard for incoming notice notifications
+    urban_folder = api.portal.get().urban
+
+    if "import-notice" not in urban_folder.objectIds():
+        import_notice_folder = api.content.create(
+            container=urban_folder,
+            type="Folder",
+            id="import-notice",
+            title="Import NOTICE",
+        )
+
+        _activate_dashboard_navigation(
+            import_notice_folder, "/dashboard/config/import_notice.xml"
+        )
+
+        # no need to create another collection, this one does the job
+        all_licences_collection = getattr(urban_folder, "collection_all_licences")
+        _updateDefaultCollectionFor(import_notice_folder, all_licences_collection.UID())
+
+        # set notice folder manager's UID as default in faceted filter widget
+        criteria = ICriteria(import_notice_folder).criteria
+        for criterion in criteria:
+            if criterion.index == "folder_manager":
+                ICriteria(import_notice_folder).edit(
+                    criterion.__name__,
+                    default=notice_folder_manager.UID(),
+                )
+        notify(FacetedGlobalSettingsChangedEvent(import_notice_folder))
+
+    logger.info("Upgrade done!")

--- a/src/Products/urban/migration/upgrades_notice.zcml
+++ b/src/Products/urban/migration/upgrades_notice.zcml
@@ -18,5 +18,13 @@
         destination="2901"
         handler=".update_290.add_event_config_types_notice"
         profile="Products.urban:default" />
+    
+    <gs:upgradeStep
+        title="Add folder manager for notice import"
+        description=""
+        source="2901"
+        destination="2902"
+        handler=".update_290.add_folder_manager_notice"
+        profile="Products.urban:default" />
 
 </configure>

--- a/src/Products/urban/notice/address.py
+++ b/src/Products/urban/notice/address.py
@@ -1,7 +1,8 @@
 # -*- coding: utf-8 -*-
-
 from Products.urban.notice.base import NoticeElement
 from Products.urban import utils
+
+import re
 
 
 class NoticeAddress(NoticeElement):
@@ -37,10 +38,22 @@ class NoticeAddress(NoticeElement):
         if not self.notice_street:
             return
         term = self.notice_street
-        if self.postCode:
-            term = "{0} {1}".format(term, self.postCode)
+        # skip use of self.postCode; induces more errors than it solves
         if self.locality:
-            term = "{0} {1}".format(term, self.locality)
+            term = u"{0} {1}".format(term, self.locality)
+        elif self.municipality:
+            match = re.search("^(?P<commune>.+?) *\((?P<village>.*?)\)$", self.municipality)
+            if match:
+                term = u"{0} {1}".format(term, match.group("village"))
+            else:
+                term = u"{0} {1}".format(term, self.municipality)
+
+        if u"(" in term:
+            term = term.replace(u"(", u"")
+        if u")" in term:
+            term = term.replace(u")", u"")
+
+        return term  # must be unicode for utils.find_address
 
     @property
     def street(self):
@@ -64,7 +77,7 @@ class NoticeAddress(NoticeElement):
 
     @property
     def notice_street(self):
-        return self._get_data("notice_street")
+        return self._get_data("street")
 
     @property
     def number(self):

--- a/src/Products/urban/notice/notification.py
+++ b/src/Products/urban/notice/notification.py
@@ -123,6 +123,7 @@ class NoticeNotification(NoticeElement):
             "TRANSFERT_DOSSIER": "ns3:TwiceDefaultRequest",
             "DEMANDE_EP": "ns3:PublicSurveyRequest",
             "NOTIF_COMPLETUDE1_INCOMPLET_COMMUNE":"ns3:TwiceDefaultRequest",
+            "NOTIF_COMPLETUDE2_NON_RECEVABLE_COMMUNE":"ns3:TwiceDefaultRequest",
         }
         return self._get_data("specific", specific.get(self.notice_type), "ns3:municipalityReference")
 

--- a/src/Products/urban/notice/notification.py
+++ b/src/Products/urban/notice/notification.py
@@ -15,7 +15,11 @@ class NoticeNotification(NoticeElement):
     """Class that represent a notification from Notice Webservice"""
 
     _notice_keys = (
+        "event_config",
+        "event_configs",
+        "licence",
         "notice_type",
+        "send_date",
         "sender",
         "status",
         "notice_type",
@@ -153,6 +157,24 @@ class NoticeNotification(NoticeElement):
         portal_urban_folder = api.portal.get().urban.portal_urban
         licence_type_folder = getattr(portal_urban_folder, "{0}".format(self.type.lower()))
         return getattr(licence_type_folder, "eventconfigs")
+
+    def event_config(self, interface_identifier):
+        """
+        Return the event config for a given marker interface identifier.
+        """
+        for brain in api.content.find(
+            context=self.event_configs, portal_type="EventConfig", review_state="enabled"
+        ):
+            config = brain.getObject()
+            config_event_types = config.eventType or []
+            if interface_identifier in config_event_types:
+                return config
+        raise ValueError(
+            "No enabled EventConfig found for marker {} of licence type {}".format(
+                interface_identifier,
+                self.type,
+            )
+        )
 
     @property
     def licenceSubject(self):

--- a/src/Products/urban/notice/notification.py
+++ b/src/Products/urban/notice/notification.py
@@ -6,6 +6,7 @@ from Products.urban.notice.document import NoticeDocument
 from Products.urban.notice.parcel import NoticeParcel
 from Products.urban.notice.party import NoticeParty
 from Products.urban.notice.sender import NoticeSender
+from Products.urban.utils import get_rubric_obj
 from datetime import datetime
 from lxml import etree
 from plone import api
@@ -92,16 +93,12 @@ class NoticeNotification(NoticeElement):
                     elif self.notification_subtype == "PE":
                         # PE class is not yet available in TRANSFERT_DOSSIER
                         # => extract it from XML document
-                        penv_classe = None
-                        for document in self.documents:
-                            if (
-                                document.document_mimetype == "application/xml"
-                                and document.document_type_code == "PJ_FORMULAIRE"
-                            ):
-                                tree = etree.parse(document.file)
-                                classe_elements = tree.xpath("/dataStore/item/classe")
-                                if len(classe_elements) == 1:
-                                    penv_classe = classe_elements[0].text
+                        classe_elements = self._pj_formulaire_xml_tree.xpath(
+                            "/dataStore/item/classe"
+                        )
+                        penv_classe = (
+                            classe_elements[0].text if len(classe_elements) == 1 else None
+                        )
                         self._licence_type = {
                             "1": "EnvClassOne",
                             "2": "EnvClassTwo",
@@ -128,6 +125,42 @@ class NoticeNotification(NoticeElement):
             "NOTIF_COMPLETUDE1_INCOMPLET_COMMUNE":"ns3:TwiceDefaultRequest",
         }
         return self._get_data("specific", specific.get(self.notice_type), "ns3:municipalityReference")
+
+    @property
+    def _pj_formulaire_xml_tree(self):
+        """Return XML tree with all data entered by residents in Mon Espace"""
+        for document in self.documents:
+            if (
+                document.document_mimetype == "application/xml"
+                and document.document_type_code == "PJ_FORMULAIRE"
+            ):
+                return etree.parse(document.file)
+        raise ValueError("No PJ_FORMULAIRE XML document found")
+
+    @property
+    def rubrics(self):
+        """Return the rubrics as a list of UIDs, if present"""
+        found_uids = []
+        missing_rubrics = []
+
+        if self.notice_type == "TRANSFERT_DOSSIER":
+            rubrique_elements = self._pj_formulaire_xml_tree.xpath(
+                "/dataStore/projet/rubriques/item"
+            )
+            for rubrique in rubrique_elements:
+                classe = rubrique.xpath("classe/text()")[0]
+                number = rubrique.xpath("numRubrique")[0].text
+                rubric_obj = get_rubric_obj(classe, number)
+                if rubric_obj:
+                    found_uids.append(rubric_obj.UID())
+                else:
+                    missing_rubrics.append("classe {}, {}".format(classe, number))
+
+        if missing_rubrics:
+            raise ValueError(
+                "cannot find these rubrics: {}".format(" | ".join(missing_rubrics))
+            )
+        return found_uids
 
     @property
     def send_date(self):

--- a/src/Products/urban/notice/notification.py
+++ b/src/Products/urban/notice/notification.py
@@ -215,6 +215,13 @@ class NoticeNotification(NoticeElement):
         return self._get_data("subjectNotice")
 
     @property
+    def foldermanagers(self):
+        urban_tool = api.portal.get_tool("portal_urban")
+        foldermanagers = getattr(urban_tool, "foldermanagers")
+        obj = getattr(foldermanagers, "notice")
+        return [obj] if obj else []
+
+    @property
     def sender(self):
         """Return sender"""
         return NoticeSender(self.service, self.json["sender"])

--- a/src/Products/urban/notice/notification.py
+++ b/src/Products/urban/notice/notification.py
@@ -122,6 +122,7 @@ class NoticeNotification(NoticeElement):
             "TRANSFERT_DOSSIER": "ns3:TwiceDefaultRequest",
             "DEMANDE_EP": "ns3:PublicSurveyRequest",
             "NOTIF_COMPLETUDE1_INCOMPLET_COMMUNE":"ns3:TwiceDefaultRequest",
+            "NOTIF_COMPLETUDE2_NON_RECEVABLE_COMMUNE":"ns3:TwiceDefaultRequest",
         }
         return self._get_data("specific", specific.get(self.notice_type), "ns3:municipalityReference")
 

--- a/src/Products/urban/profiles/default/metadata.xml
+++ b/src/Products/urban/profiles/default/metadata.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <metadata>
-  <version>2901</version>
+  <version>2902</version>
   <dependencies>
     <dependency>profile-Products.urban:preinstall</dependency>
   </dependencies>

--- a/src/Products/urban/profiles/testsWithConfig/data.py
+++ b/src/Products/urban/profiles/testsWithConfig/data.py
@@ -461,10 +461,22 @@ EventConfigs = {
     ),
     "envclasstwo": (
         {
+            "id": "dossier-irrecevable",
+            "title": "Dossier irrecevable",
+            "activatedFields": ("transmitDate",),
+            "deadLineDelay": 0,
+            "eventType": ("Products.urban.interfaces.IRefusedIncompletenessEvent",),
+            "isKeyEvent": True,
+            "keyDates": ("eventDate",),
+            "podTemplates": (
+            ),
+
+        },
+        {
             "id": "dossier-incomplet",
             "title": "Dossier incomplet (avec listing des pièces manquantes - article 116 § 1)",
             "activatedFields": (),
-            "deadLineDelay": 15,
+            "deadLineDelay": 15 ,
             "eventType": ("Products.urban.interfaces.IMissingPartEvent",),
             "isKeyEvent": True,
             "keyDates": ("eventDate",),

--- a/src/Products/urban/profiles/testsWithConfig/data.py
+++ b/src/Products/urban/profiles/testsWithConfig/data.py
@@ -470,13 +470,12 @@ EventConfigs = {
             "keyDates": ("eventDate",),
             "podTemplates": (
             ),
-
         },
         {
             "id": "dossier-incomplet",
             "title": "Dossier incomplet (avec listing des pièces manquantes - article 116 § 1)",
             "activatedFields": (),
-            "deadLineDelay": 15 ,
+            "deadLineDelay": 15,
             "eventType": ("Products.urban.interfaces.IMissingPartEvent",),
             "isKeyEvent": True,
             "keyDates": ("eventDate",),

--- a/src/Products/urban/services/tests/NOT_ADMISSIBLE2/1443529-NOT-ADMISSIBLE-NOTIFICATION.json
+++ b/src/Products/urban/services/tests/NOT_ADMISSIBLE2/1443529-NOT-ADMISSIBLE-NOTIFICATION.json
@@ -1,0 +1,365 @@
+{
+  "status": "PROCESSED",
+  "warning": null,
+  "error": null,
+  "notice": {
+    "BO": {
+      "idBO": "10010781",
+      "typeBO": {
+        "code": "PE_PU",
+        "description": [
+          {
+            "_value_1": "Umweltgenehmigung oder Globalgenehmigung",
+            "language": "de"
+          },
+          {
+            "_value_1": "Permis d'environnement ou unique",
+            "language": "fr"
+          }
+        ],
+        "origin": null
+      },
+      "typeBOSubtype": {
+        "code": "PE",
+        "description": [
+          {
+            "_value_1": "Umweltgenehmigung",
+            "language": "de"
+          },
+          {
+            "_value_1": "permis d'environnement",
+            "language": "fr"
+          }
+        ],
+        "origin": null
+      },
+      "noticeIdBO": "NOTIFICATION:51967616",
+      "codeTypeNoticeBO": "NOTIF_COMPLETUDE2_NON_RECEVABLE_COMMUNE",
+      "applicationCodeBO": "TWICE",
+      "fileLanguage": {
+        "code": "FR",
+        "description": [
+          {
+            "_value_1": "FR",
+            "language": "de"
+          },
+          {
+            "_value_1": "FR",
+            "language": "fr"
+          }
+        ]
+      },
+      "fileDate": "2025-09-17T00:00:00+02:00",
+      "noticeLanguage": {
+        "code": "FR",
+        "description": [
+          {
+            "_value_1": "Französisch",
+            "language": "de"
+          },
+          {
+            "_value_1": "Français",
+            "language": "fr"
+          }
+        ]
+      }
+    },
+    "sender": {
+      "noticeInstanceId": "O3080500",
+      "contactName": "Giuseppe MONACHINO",
+      "contactPhone": {
+        "phoneNumber": [
+          {
+            "_value_1": "+3281715344",
+            "type": null
+          }
+        ]
+      },
+      "contactMail": {
+        "email": [
+          {
+            "_value_1": "permis.environnement.namur@spw.wallonie.be",
+            "type": null
+          }
+        ]
+      },
+      "projectType": "Un renouvellement",
+      "motivations": null
+    },
+    "receiver": {
+      "noticeInstanceId": "0216.697.802"
+    },
+    "noticeType": {
+      "code": "PE_DEM_COM_NOTIF_COMPLETUDE2_NON_RECEVABLE",
+      "description": [
+        {
+          "_value_1": "Demande PEPU - Notification à la commune que la demande est non recevable (2e tour)",
+          "language": "de"
+        },
+        {
+          "_value_1": "Demande PEPU - Notification à la commune que la demande est non recevable (2e tour)",
+          "language": "fr"
+        }
+      ]
+    },
+    "subjectNotice": "Renouvellement du permis d'exploiter la station d'épuration de Fouches.",
+    "sendDate": "2025-09-19T00:00:00+02:00",
+    "deadline": null,
+    "dueDate": null,
+    "fileDateMunicipality": "2025-09-11T00:00:00+02:00",
+    "comment": null,
+    "businessReference": null,
+    "addresses": null,
+    "parcels": {
+      "parcel": [
+        {
+          "identifier": "P0001",
+          "municipality": {
+            "code": "81001",
+            "description": [
+              {
+                "_value_1": "ARLON",
+                "language": "de"
+              },
+              {
+                "_value_1": "ARLON",
+                "language": "fr"
+              }
+            ],
+            "origin": null
+          },
+          "division": "ARLON 8 DIV/HACHY/",
+          "codeDivision": "81408",
+          "section": "D",
+          "radical": "0338",
+          "bisTer": "00",
+          "exponent": "C",
+          "power": "000",
+          "part": false,
+          "right": true,
+          "capakey": "81408D0338/00C000",
+          "comment": null
+        },
+        {
+          "identifier": "P002",
+          "municipality": {
+            "code": "92141",
+            "description": [
+              {
+                "_value_1": "LA BRUYERE",
+                "language": "de"
+              },
+              {
+                "_value_1": "LA BRUYÈRE",
+                "language": "fr"
+              }
+            ],
+            "origin": null
+          },
+          "division": "LA BRUYERE 2 DIV/RHISNES/",
+          "codeDivision": "92102",
+          "section": "B",
+          "radical": "0006",
+          "bisTer": "00",
+          "exponent": "_",
+          "power": "000",
+          "part": false,
+          "right": false,
+          "capakey": "92102B0006/00_000",
+          "comment": null
+        },
+        {
+          "identifier": "P003",
+          "municipality": {
+            "code": "92141",
+            "description": [
+              {
+                "_value_1": "LA BRUYERE",
+                "language": "de"
+              },
+              {
+                "_value_1": "LA BRUYÈRE",
+                "language": "fr"
+              }
+            ],
+            "origin": null
+          },
+          "division": "LA BRUYERE 1 DIV/EMINES/",
+          "codeDivision": "92036",
+          "section": "D",
+          "radical": "0069",
+          "bisTer": "00",
+          "exponent": "X",
+          "power": "000",
+          "part": false,
+          "right": false,
+          "capakey": "92036D0069/00X000",
+          "comment": null
+        }
+      ]
+    },
+    "parties": {
+      "part": [
+        {
+          "enterpriseNumber": null,
+          "enterpriseType": null,
+          "legalForm": null,
+          "personNumber": "88010435423",
+          "title": null,
+          "lastname": "Nagant",
+          "firstname": "Aurore Edith Michèle",
+          "language": {
+            "code": "FR",
+            "description": [
+              {
+                "_value_1": "français",
+                "language": "de"
+              },
+              {
+                "_value_1": "français",
+                "language": "fr"
+              }
+            ]
+          },
+          "denomination": null,
+          "mailingAddresses": {
+            "mailingAddress": [
+              {
+                "country": "BE",
+                "addressId": {
+                  "_value_1": null,
+                  "source": "-1"
+                },
+                "street": "Rue Barbe d'Or(AIN)",
+                "houseNumber": "21",
+                "boxNumber": null,
+                "postCode": "4317",
+                "municipality": "FAIMES",
+                "state": "actif",
+                "plainText": [],
+                "locality": {
+                  "code": "4317",
+                  "description": [
+                    {
+                      "_value_1": "FAIMES",
+                      "language": "de"
+                    },
+                    {
+                      "_value_1": "FAIMES",
+                      "language": "fr"
+                    }
+                  ]
+                },
+                "inceptionDate": null,
+                "modificationDate": null,
+                "addressType": null
+              }
+            ]
+          },
+          "phoneNumber": null,
+          "email": null
+        }
+      ]
+    },
+    "documents": {
+      "document": [
+        {
+          "documentData": {
+            "filename": "10010781-NOTIF_COMPLETUDE2_NON_RECEVABLE_COMMUNE-Commune wallonne",
+            "description": null,
+            "type": {
+              "code": "NOTIF_COMPLETUDE2_NONRECEVABLE_COMMUNE",
+              "description": [
+                {
+                  "_value_1": " Notification complétude 2: non recevable, commune",
+                  "language": "de"
+                },
+                {
+                  "_value_1": " Notification complétude 2: non recevable, commune",
+                  "language": "fr"
+                }
+              ]
+            },
+            "language": {
+              "code": "FR",
+              "description": [
+                {
+                  "_value_1": "Französisch",
+                  "language": "de"
+                },
+                {
+                  "_value_1": "Français",
+                  "language": "fr"
+                }
+              ]
+            },
+            "documentId": "6b9e94d5-31c0-42a4-9e9e-71f41c7e2501",
+            "fileSize": 13974,
+            "mimeType": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+            "confidentiality": {
+              "code": "0",
+              "description": [
+                {
+                  "_value_1": "Öffentlichkeit",
+                  "language": "de"
+                },
+                {
+                  "_value_1": "public",
+                  "language": "fr"
+                }
+              ],
+              "domain": "NOTICE_GENERIC_CONFIDENTIALITE"
+            },
+            "principal": true
+          },
+          "content": {
+            "documentContentStorage": "BO"
+          }
+        }
+      ]
+    },
+    "mapSpecification": null,
+    "specific": {
+      "ns3:TwiceDefaultRequest": {
+        "@xmlns": "http://soa.spw.wallonie.be/data/common/code/v1",
+        "@xmlns:ns2": "http://soa.spw.wallonie.be/services/noticeExtensions/messages/v1",
+        "@xmlns:ns3": "http://soa.spw.wallonie.be/services/noticeTwiceExtensions/messages/v1",
+        "@xmlns:ns4": "http://soa.spw.wallonie.be/data/business/environmentalLicence/v2",
+        "@xmlns:ns5": "http://soa.spw.wallonie.be/services/noticeGesperExtensions/messages/v1",
+        "@xmlns:ns6": "http://soa.spw.wallonie.be/data/business/noticeGesperExtensions/v1",
+        "@xmlns:ns7": "http://soa.spw.wallonie.be/data/common/date/v1",
+        "ns2:acceptedResponseNoticeCodes": null,
+        "ns3:municipalityReference": "PE2/2025/4",
+        "ns3:timeLimits": null,
+        "ns3:suspentionPeriods": null
+      }
+    },
+    "status": {
+      "status": [
+        {
+          "code": {
+            "code": "EN_ATTENTE_REPONSE",
+            "description": [
+              {
+                "_value_1": "Warten auf Antwort",
+                "language": "de"
+              },
+              {
+                "_value_1": "En attente de réponse",
+                "language": "fr"
+              }
+            ]
+          },
+          "date": "2025-09-19T10:38:03.482000"
+        }
+      ]
+    },
+    "noticeIdentifier": {
+      "noticeId": "1443529"
+    },
+    "receptionDate": "2025-09-19T10:38:03.384000"
+  },
+  "customerTicket": "4668bcb1-f604-4e96-999d-730f6e3d78c3",
+  "requestId": "ff7ce2b0-36e0-0403-f41c-efd8c8b02575",
+  "inscriptionReference": null
+}

--- a/src/Products/urban/services/tests/NOT_ADMISSIBLE2/1443529_notifications.json
+++ b/src/Products/urban/services/tests/NOT_ADMISSIBLE2/1443529_notifications.json
@@ -1,0 +1,37 @@
+[
+  {
+    "noticeId": "1443529",
+    "noticeType": {
+      "code": "PE_DEM_COM_NOTIF_COMPLETUDE2_NON_RECEVABLE",
+      "description": [
+        {
+          "_value_1": "Demande PEPU - Notification à la commune que la demande est non recevable (2e tour)",
+          "language": "de"
+        },
+        {
+          "_value_1": "Demande PEPU - Notification à la commune que la demande est non recevable (2e tour)",
+          "language": "fr"
+        }
+      ]
+    },
+    "receptionDate": "2025-09-19T10:38:03.384000",
+    "dueDate": null,
+    "noticeInstanceId": "0216.697.802",
+    "status": {
+      "code": {
+        "code": "EN_ATTENTE_REPONSE",
+        "description": [
+          {
+            "_value_1": "Warten auf Antwort",
+            "language": "de"
+          },
+          {
+            "_value_1": "En attente de réponse",
+            "language": "fr"
+          }
+        ]
+      },
+      "date": "2025-09-19T10:38:03.482000"
+    }
+  }
+]

--- a/src/Products/urban/utils.py
+++ b/src/Products/urban/utils.py
@@ -172,6 +172,15 @@ def getLicenceFolder(licencetype):
     return licence_folder
 
 
+def get_rubric_obj(classe, number):
+    rubrics_folder = api.portal.get_tool("portal_urban").rubrics
+    brains = api.content.find(context=rubrics_folder, id=number)
+    for brain in brains:
+        obj = brain.getObject()
+        if obj.getNumber() == number and obj.getExtraValue() == classe:
+            return obj
+
+
 def removeItems(liste, items):
     [liste.remove(i) for i in items if liste.count(i)]
     return liste


### PR DESCRIPTION
Cette pull request implémente le mécanisme de notification non recevable second tour :

- Création et clôture automatique d’un événement Dossier irrecevable.
- Mise à jour de l’état du workflow vers irrecevable.
-  Ajout des tests nécessaires pour valider ce comportement.