### PR TITLE
URBBDC-3204: [WIP] Migrate to the latest version of `imio.dashboard` (tests)

### DIFF
--- a/src/Products/urban/setuphandlers.py
+++ b/src/Products/urban/setuphandlers.py
@@ -46,7 +46,7 @@ from Products.urban.utils import getUrbanOnlyLicenceFolderIds
 
 from datetime import date
 from eea.facetednavigation.layout.interfaces import IFacetedLayout
-from imio.dashboard.utils import _updateDefaultCollectionFor
+from collective.eeafaceted.collectionwidget.utils import _updateDefaultCollectionFor
 
 from plone import api
 from plone.portlets.interfaces import IPortletManager
@@ -74,6 +74,8 @@ from zope import event
 
 import pickle
 import transaction
+
+logger = logging.getLogger("urban: setuphandlers")
 
 OBJECTS_COUNT = 0
 
@@ -252,6 +254,7 @@ def extraPostInstall(context):
     logger.info("set_file_system_configuration : Done")
     logger.info("addUrbanVocabularies : starting...")
     addUrbanVocabularies(context)
+    transaction.commit()
     logger.info("addUrbanVocabularies : Done")
     logger.info("addEnvironmentRubrics : starting...")
     addEnvironmentRubrics(context)
@@ -265,6 +268,9 @@ def extraPostInstall(context):
     logger.info("Setup default schedule configuration: starting...")
     addScheduleConfigs(context)
     logger.info("Setup default schedule configuration : Done")
+    logger.info("Configure CKEditor: starting...")
+    configureCKEditor(context)
+    logger.info("Configure CKEditor: Done")
 
 
 def testExtraPostInstall(context):
@@ -298,6 +304,10 @@ def updateVocabularyConfig(context):
     attribute = "default_values"
     module = __import__(module_name, fromlist=[attribute])
     default_values = getattr(module, attribute)
+
+    global_vocabularies = default_values["global"]
+    createVocabularyFolders(container=tool, vocabularies=global_vocabularies, site=site)
+    createVocabularies(container=tool, vocabularies=global_vocabularies)
 
     for urban_type in URBAN_TYPES:
         licenceConfigId = urban_type.lower()
@@ -447,6 +457,10 @@ def getSharedVocabularies(urban_type, licence_vocabularies):
 
 def createVocabularies(container, vocabularies):
     for voc_name, vocabulary in vocabularies.iteritems():
+        if voc_name not in container:
+            # We are in a special usecase, nothing should be done
+            # This can happend when multiple upgrade steps have not be applied
+            continue
         voc_folder = getattr(container, voc_name)
         createFolderDefaultValues(voc_folder, vocabulary)
 
@@ -481,6 +495,13 @@ def addUrbanConfigFolders(context):
             # no mutator available because the field is defined with 'read only' property
             config_folder.licencePortalType = urban_type
             config_folder.setUsedAttributes(config_folder.listUsedAttributes().keys())
+            states_voc = queryUtility(IVocabularyFactory, "urban.licence_state")(
+                config_folder
+            )
+            default_end_states = [
+                st for st in states_voc.by_value.keys() if st in LICENCE_FINAL_STATES
+            ]
+            config_folder.setStates_to_end_all_tasks(default_end_states)
             config_folder.reindexObject()
         else:
             config_folder = getattr(tool, licenceConfigId)
@@ -492,21 +513,21 @@ def addUrbanConfigFolders(context):
 
         # we just created the urbanConfig, proceed with other parameters...
         # parameters for every LicenceConfigs
-        # add UrbanEventTypes folder
-        if not hasattr(aq_base(config_folder), "urbaneventtypes"):
+        # add EventConfigs folder
+        if not hasattr(aq_base(config_folder), "eventconfigs"):
             config_folder.invokeFactory(
                 "Folder",
-                id="urbaneventtypes",
-                title=_("urbaneventtypes_folder_title", "urban"),
+                id="eventconfigs",
+                title=_("eventconfigs_folder_title", "urban"),
             )
-        eventtypes_folder = getattr(config_folder, "urbaneventtypes")
+        eventconfigs_folder = getattr(config_folder, "eventconfigs")
         if urban_type in ["Inspection", "Ticket"]:
             setFolderAllowedTypes(
-                eventtypes_folder, ["UrbanEventType", "FollowUpEventType"]
+                eventconfigs_folder, ["EventConfig", "FollowUpEventConfig"]
             )
         else:
             setFolderAllowedTypes(
-                eventtypes_folder, ["UrbanEventType", "OpinionRequestEventType"]
+                eventconfigs_folder, ["EventConfig", "OpinionEventConfig"]
             )
 
         licence_vocabularies = default_values.get(urban_type, {})
@@ -606,8 +627,9 @@ def addRubricValues(context, config_folder):
         if category_id in config_folder.objectIds():
             rubric_folder = getattr(config_folder, category_id)
         else:
-            rubricfolder_id = config_folder.invokeFactory("Folder", **category)
-            rubric_folder = getattr(config_folder, rubricfolder_id)
+            rubric_folder = api.content.create(
+                container=config_folder, type="Folder", **category
+            )
             rubric_folder.setConstrainTypesMode(1)
             rubric_folder.setLocallyAllowedTypes(["EnvironmentRubricTerm"])
             rubric_folder.setImmediatelyAddableTypes(["EnvironmentRubricTerm"])
@@ -624,8 +646,8 @@ def addRubricValues(context, config_folder):
 
             rubric_id = rubric["id"]
             if rubric_id not in rubric_folder:
-                rubric_id = rubric_folder.invokeFactory(
-                    "EnvironmentRubricTerm", **rubric
+                new_rubric = api.content.create(
+                    container=rubric_folder, type="EnvironmentRubricTerm", **rubric
                 )
                 print "created rubric %ss" % rubric_id
             else:
@@ -635,7 +657,7 @@ def addRubricValues(context, config_folder):
                     field = old_rubric.getField(fieldname)
                     mutator = field.getMutator(old_rubric)
                     mutator(newvalue)
-            new_rubric = getattr(rubric_folder, rubric_id)
+                new_rubric = getattr(rubric_folder, rubric_id)
             new_rubric.processForm()
 
             conditions_uid = []
@@ -755,6 +777,8 @@ def setDefaultApplicationSecurity(context):
     site.portal_urban.manage_addLocalRoles(
         "urban_managers",
         (
+            "Contributor",
+            "Reviewer",
             "Editor",
             "Reader",
         ),
@@ -860,6 +884,7 @@ def setDefaultApplicationSecurity(context):
             folder.manage_addLocalRoles("urban_editors", ("Editor", "Contributor"))
             folder.manage_addLocalRoles("environment_readers", ("Reader",))
             folder.manage_addLocalRoles("environment_editors", ("Contributor",))
+            folder.manage_addLocalRoles("opinions_editors", ("Reader",))
             # mark them with IContactFolder interface use some view methods, like 'getemails', on it
             alsoProvides(folder, IContactFolder)
 
@@ -989,6 +1014,15 @@ def adaptDefaultPortal(context):
     try:
         site.portal_actions.document_actions.sendto.manage_changeProperties(
             visible=False
+        )
+    except AttributeError:
+        # the 'front-page' object does not exist...
+        pass
+    # ignore acquisition for external edit action
+    # set visible = 0
+    try:
+        site.portal_actions.document_actions.extedit.manage_changeProperties(
+            available_expr="python: object.externalEditorEnabled()"
         )
     except AttributeError:
         # the 'front-page' object does not exist...
@@ -1203,6 +1237,14 @@ def setupImioDashboard(context):
 
     urban_folder.moveObjectToPosition(all_licences_collection_id, 0)
     all_licences_collection = getattr(urban_folder, all_licences_collection_id)
+    # always reupdate the listed types to URBAN_TYPES
+    all_licences_collection.query = [
+        {
+            "i": "portal_type",
+            "o": "plone.app.querystring.operation.selection.is",
+            "v": [type for type in URBAN_TYPES],
+        }
+    ]
     _updateDefaultCollectionFor(urban_folder, all_licences_collection.UID())
 
     for urban_type in URBAN_TYPES:
@@ -1211,6 +1253,8 @@ def setupImioDashboard(context):
             folder, "/dashboard/config/%ss.xml" % urban_type.lower()
         )
         collection_id = "collection_%s" % urban_type.lower()
+        no_deposit = ["PatrimonyCertificate", "Inspection"]
+        with_deposit_date = urban_type not in no_deposit
         if collection_id not in folder.objectIds():
             setFolderAllowedTypes(folder, "DashboardCollection")
             _create_dashboard_collection(
@@ -1225,7 +1269,26 @@ def setupImioDashboard(context):
         _updateDefaultCollectionFor(folder, collection.UID())
 
 
-def _create_dashboard_collection(container, id, title, filter_type):
+def _create_dashboard_collection(
+    container, id, title, filter_type, with_deposit_date=True
+):
+    if with_deposit_date:
+        fields = (
+            "sortable_title",
+            "CreationDate",
+            "getDepositDate",
+            "folder_manager",
+            "actions",
+            "select_row",
+        )
+    else:
+        fields = (
+            "sortable_title",
+            "CreationDate",
+            "folder_manager",
+            "actions",
+            "select_row",
+        )
     collection_id = container.invokeFactory(
         "DashboardCollection",
         id=id,
@@ -1237,13 +1300,7 @@ def _create_dashboard_collection(container, id, title, filter_type):
                 "v": filter_type,
             }
         ],
-        customViewFields=(
-            "sortable_title",
-            "CreationDate",
-            "folder_manager",
-            "actions",
-            "select_row",
-        ),
+        customViewFields=fields,
         sort_on=u"created",
         sort_reversed=True,
         b_size=30,
@@ -1275,6 +1332,7 @@ def setupSchedule(context):
     if not hasattr(urban_folder, "schedule"):
         urban_folder.invokeFactory("Folder", id="schedule")
     schedule_folder = getattr(urban_folder, "schedule")
+    schedule_folder.setTitle("Échéancier")
     # block parents portlet
     manager = queryUtility(IPortletManager, name="plone.leftcolumn")
     blacklist = getMultiAdapter(
@@ -1295,7 +1353,7 @@ def setupSchedule(context):
             u"pretty_link",
             u"address_column",
             u"parcelreferences_column",
-            u"assigned_user_column",
+            u"assigned_user",
             u"status",
             u"due_date",
             u"task_actions_column",
@@ -1382,7 +1440,7 @@ def addTestUsers(site):
         _addTestUser(site, *user_info)
 
 
-def _addTestUser(site, username, groupname, external_editor=False):
+def _addTestUser(site, username, groupnames, external_editor=False):
     is_mountpoint = len(site.absolute_url_path().split("/")) > 2
     try:
         password = username
@@ -1391,8 +1449,9 @@ def _addTestUser(site, username, groupname, external_editor=False):
         member = site.portal_registration.addMember(id=username, password=password)
         if external_editor:
             member.setMemberProperties({"ext_editor": True})
-        site.acl_users.source_groups.addPrincipalToGroup(username, groupname)
-    except:
+        for groupname in groupnames:
+            site.acl_users.source_groups.addPrincipalToGroup(username, groupname)
+    except Exception:
         # if something wrong happens (one object already exists), we pass...
         pass
 
@@ -1656,39 +1715,35 @@ def createLicence(site, licence_type, data):
     # call post script
     licence.at_post_create_script()
     # add a dummy portion out
-    division_code = division = ""
+    division = ""
     if services.cadastre.can_connect():
         session = services.cadastre.new_session()
         division_code = division = str(session.get_all_divisions()[0][0])
         session.close()
-    portionout_data = {
-        "divisionCode": division_code,
+    parcel_data = {
         "division": division,
         "section": "A",
         "radical": "84",
         "exposant": "C",
         "partie": False,
     }
-    if "portionout_data" in data:
-        portionout_data = data["portionout_data"]
-    portionout_id = licence.invokeFactory(
-        "PortionOut", id=site.generateUniqueId("parcelle"), **portionout_data
+    if "parcel_data" in data:
+        parcel_data = data["parcel_data"]
+    parcel = api.content.create(
+        container=licence,
+        type="Parcel",
+        id=site.generateUniqueId("parcelle"),
+        **parcel_data
     )
-    portionout = getattr(licence, portionout_id)
-    # portionout._renameAfterCreation()
-    portionout.updateTitle()
-    portionout.reindexObject()
+    parcel.updateTitle()
+    parcel.reindexObject()
     licence.reindexObject(idxs=["parcelInfosIndex"])
     # generate all the urban events
     logger.info("   test %s --> create all the events" % licence_type)
-    eventtypes = [
-        brain.getObject()
-        for brain in urban_tool.listEventTypes(
-            licence, urbanConfigId=licence_type.lower()
-        )
-    ]
-    for event_type in eventtypes:
-        licence.createUrbanEvent(event_type)
+    event_configs = licence.getLicenceConfig().getEventConfigs()
+    for event_config in event_configs:
+        if event_config.canBeCreatedInLicence(licence):
+            licence.createUrbanEvent(event_config)
     # fill each event with dummy data and generate all its documents
     logger.info("   test %s --> generate all the documents" % licence_type)
     for urban_event in licence.objectValues(
@@ -1745,6 +1800,7 @@ def configurePMWSClientForUrban(context):
         {"expression": u"python:context.Title().upper()", "field_name": u"title"},
         {"expression": u"context/Title", "field_name": u"description"},
         {"expression": u"context/getDecisionText", "field_name": u"decision"},
+        {"expression": u"context/getMotivationText", "field_name": u"motivation"},
     ]
 
     # validation on vocabulary cannot be done since we are not connected to plone meeting yet
@@ -1789,19 +1845,22 @@ def setupExtra(context):
     else:
         logger.info("user password policy unchanged")
 
+
+def configureCKEditor(context):
     # we apply a method of CPUtils to configure CKeditor
-    logger.info("Configuring CKeditor")
+    properties_tool = api.portal.get_tool("portal_properties")
+    ckprops = properties_tool.ckeditor_properties
+    ckprops.manage_changeProperties(enableScaytOnStartup=True)
     try:
         from Products.CPUtils.Extensions.utils import configure_ckeditor
 
+        portal = api.portal.get()
         if (
             not hasattr(portal.portal_properties, "ckeditor_properties")
             or portal.portal_properties.site_properties.default_editor != "CKeditor"
         ):
             configure_ckeditor(portal, custom="urban")
-            properties_tool = api.portal.get_tool("portal_properties")
-            custom_menu_style = u"[\n/* Styles Urban */\n{ name : 'Urban Body'\t\t, element : 'p', attributes : { 'class' : 'UrbanBody' } }, \n{ name : 'Urban title'\t       , element : 'p', attributes : { 'class' : 'UrbanTitle' } }, \n{ name : 'Urabn title 2'\t, element : 'p', attributes : { 'class' : 'UrbanTitle2' } }, \n{ name : 'Urban title 3'\t, element : 'p', attributes : { 'class' : 'UrbanTitle3' } }, \n{ name : 'Urban address'\t, element : 'p', attributes : { 'class' : 'UrbanAddress' } }, \n{ name : 'Urban table'\t       , element : 'p', attributes : { 'class' : 'UrbanTable' } }, \n/* Block Styles */\n{ name : 'Grey Title'\t\t, element : 'h2', styles : { 'color' : '#888' } }, \n{ name : 'Grey Sub Title'\t, element : 'h3', styles : { 'color' : '#888' } }, \n{ name : 'Discreet bloc'\t, element : 'p', attributes : { 'class' : 'discreet' } }, \n/* Inline styles */\n{ name : 'Discreet text'\t, element : 'span', attributes : { 'class' : 'discreet' } }, \n{ name : 'Marker: Yellow'\t, element : 'span', styles : { 'background-color' : 'Yellow' } }, \n{ name : 'Typewriter'\t\t, element : 'tt' }, \n{ name : 'Computer Code'\t, element : 'code' }, \n{ name : 'Keyboard Phrase'\t, element : 'kbd' }, \n{ name : 'Sample Text'\t\t, element : 'samp' }, \n{ name : 'Variable'\t\t, element : 'var' }, \n{ name : 'Deleted Text'\t\t, element : 'del' }, \n{ name : 'Inserted Text'\t, element : 'ins' }, \n{ name : 'Cited Work'\t\t, element : 'cite' }, \n{ name : 'Inline Quotation'\t, element : 'q' }, \n{ name : 'Language: RTL'\t, element : 'span', attributes : { 'dir' : 'rtl' } }, \n{ name : 'Language: LTR'\t, element : 'span', attributes : { 'dir' : 'ltr' } }, \n/* Objects styles */\n{ name : 'Image on right'\t, element : 'img', attributes : { 'class' : 'image-right' } }, \n{ name : 'Image on left'\t, element : 'img', attributes : { 'class' : 'image-left' } }, \n{ name : 'Image centered'\t, element : 'img', attributes : { 'class' : 'image-inline' } }, \n{ name : 'Borderless Table'    , element : 'table', styles: { 'border-style': 'hidden', 'background-color' : '#E6E6FA' } }, \n{ name : 'Square Bulleted List', element : 'ul', styles : { 'list-style-type' : 'square' } }\n\n]\n"
-            ckprops = properties_tool.ckeditor_properties
+            custom_menu_style = u"[\n/* Styles Urban */\n{ name : 'Urban Body'\t\t, element : 'p', attributes : { 'class' : 'UrbanBody' } }, \n{ name : 'Urban title'\t       , element : 'p', attributes : { 'class' : 'UrbanTitle' } }, \n{ name : 'Urabn title 2'\t, element : 'p', attributes : { 'class' : 'UrbanTitle2' } }, \n{ name : 'Urban title 3'\t, element : 'p', attributes : { 'class' : 'UrbanTitle3' } }, \n{ name : 'Urban address'\t, element : 'p', attributes : { 'class' : 'UrbanAddress' } }, \n{ name : 'Urban table'\t       , element : 'p', attributes : { 'class' : 'UrbanTable' } }, \n/* Block Styles */\n{ name : 'Grey Title'\t\t, element : 'h2', styles : { 'color' : '# 888' } }, \n{ name : 'Grey Sub Title'\t, element : 'h3', styles : { 'color' : '# 888' } }, \n{ name : 'Discreet bloc'\t, element : 'p', attributes : { 'class' : 'discreet' } }, \n/* Inline styles */\n{ name : 'Discreet text'\t, element : 'span', attributes : { 'class' : 'discreet' } }, \n{ name : 'Marker: Yellow'\t, element : 'span', styles : { 'background-color' : 'Yellow' } }, \n{ name : 'Typewriter'\t\t, element : 'tt' }, \n{ name : 'Computer Code'\t, element : 'code' }, \n{ name : 'Keyboard Phrase'\t, element : 'kbd' }, \n{ name : 'Sample Text'\t\t, element : 'samp' }, \n{ name : 'Variable'\t\t, element : 'var' }, \n{ name : 'Deleted Text'\t\t, element : 'del' }, \n{ name : 'Inserted Text'\t, element : 'ins' }, \n{ name : 'Cited Work'\t\t, element : 'cite' }, \n{ name : 'Inline Quotation'\t, element : 'q' }, \n{ name : 'Language: RTL'\t, element : 'span', attributes : { 'dir' : 'rtl' } }, \n{ name : 'Language: LTR'\t, element : 'span', attributes : { 'dir' : 'ltr' } }, \n/* Objects styles */\n{ name : 'Image on right'\t, element : 'img', attributes : { 'class' : 'image-right' } }, \n{ name : 'Image on left'\t, element : 'img', attributes : { 'class' : 'image-left' } }, \n{ name : 'Image centered'\t, element : 'img', attributes : { 'class' : 'image-inline' } }, \n{ name : 'Borderless Table'    , element : 'table', styles: { 'border-style': 'hidden', 'background-color' : '# E6E6FA' } }, \n{ name : 'Square Bulleted List', element : 'ul', styles : { 'list-style-type' : 'square' } }\n\n]\n"
             ckprops.manage_changeProperties(menuStyles=custom_menu_style)
 
     except ImportError:
@@ -1823,8 +1882,9 @@ def setHTMLContentType(folder, fieldName):
 
 def _create_task_configs(container, taskconfigs):
     """ """
+    last_id = None
     for taskconfig_kwargs in taskconfigs:
-        subtasks = taskconfig_kwargs.pop("subtasks", [])
+        subtasks = taskconfig_kwargs.get("subtasks", [])
         task_config_id = taskconfig_kwargs["id"]
 
         if task_config_id not in container.objectIds():
@@ -1832,12 +1892,14 @@ def _create_task_configs(container, taskconfigs):
 
             task_config_id = container.invokeFactory(**taskconfig_kwargs)
             task_config = getattr(container, task_config_id)
+            if last_id:
+                moveElementAfter(task_config, container, "id", last_id)
 
             # set custom view fields
             task_config.dashboard_collection.customViewFields = (
                 u"sortable_title",
                 u"address_column",
-                u"assigned_user_column",
+                u"assigned_user",
                 u"status",
                 u"due_date",
                 u"task_actions_column",
@@ -1852,3 +1914,30 @@ def _create_task_configs(container, taskconfigs):
             _create_task_configs(container=task_config, taskconfigs=subtasks)
 
         checkPoint()
+
+def reindex_catalog(context):
+    """
+    Clear and rebuild the calalog.
+    """
+    if isNoturbanProfile(context):
+        return
+    catalog = api.portal.get_tool("portal_catalog")
+    catalog.clearFindAndRebuild()
+
+
+def activateAnnouncementArticlesText(context):
+    """Activate 'announcementArticlesText' oprional field"""
+    if context.readDataFile("fixes_marker.txt") is None:
+        return
+    portal_urban = api.portal.get_tool("portal_urban")
+    for licence_config in portal_urban.objectValues("LicenceConfig"):
+        if licence_config.id in [
+            "codt_buildlicence",
+            "codt_parceloutlicence",
+            "codt_article127",
+            "codt_urbancertificatetwo",
+        ]:
+            if "announcementArticlesText" not in licence_config.usedAttributes:
+                licence_config.usedAttributes = licence_config.usedAttributes + (
+                    "announcementArticlesText",
+                )

--- a/src/Products/urban/setuphandlers.py
+++ b/src/Products/urban/setuphandlers.py
@@ -513,21 +513,21 @@ def addUrbanConfigFolders(context):
 
         # we just created the urbanConfig, proceed with other parameters...
         # parameters for every LicenceConfigs
-        # add EventConfigs folder
-        if not hasattr(aq_base(config_folder), "eventconfigs"):
+        # add UrbanEventTypes folder
+        if not hasattr(aq_base(config_folder), "urbaneventtypes"):
             config_folder.invokeFactory(
                 "Folder",
-                id="eventconfigs",
-                title=_("eventconfigs_folder_title", "urban"),
+                id="urbaneventtypes",
+                title=_("urbaneventtypes_folder_title", "urban"),
             )
-        eventconfigs_folder = getattr(config_folder, "eventconfigs")
+        eventtypes_folder = getattr(config_folder, "urbaneventtypes")
         if urban_type in ["Inspection", "Ticket"]:
             setFolderAllowedTypes(
-                eventconfigs_folder, ["EventConfig", "FollowUpEventConfig"]
+                eventtypes_folder, ["UrbanEventType", "FollowUpEventType"]
             )
         else:
             setFolderAllowedTypes(
-                eventconfigs_folder, ["EventConfig", "OpinionEventConfig"]
+                eventtypes_folder, ["UrbanEventType", "OpinionRequestEventType"]
             )
 
         licence_vocabularies = default_values.get(urban_type, {})
@@ -1715,36 +1715,39 @@ def createLicence(site, licence_type, data):
     # call post script
     licence.at_post_create_script()
     # add a dummy portion out
-    division = ""
+    division_code = division = ""
     if services.cadastre.can_connect():
         session = services.cadastre.new_session()
         division_code = division = str(session.get_all_divisions()[0][0])
         session.close()
-    parcel_data = {
+    portionout_data = {
+        "divisionCode": division_code,
         "division": division,
         "section": "A",
         "radical": "84",
         "exposant": "C",
         "partie": False,
     }
-    if "parcel_data" in data:
-        parcel_data = data["parcel_data"]
-    parcel = api.content.create(
-        container=licence,
-        type="Parcel",
-        id=site.generateUniqueId("parcelle"),
-        **parcel_data
+    if "portionout_data" in data:
+        portionout_data = data["portionout_data"]
+    portionout_id = licence.invokeFactory(
+        "PortionOut", id=site.generateUniqueId("parcelle"), **portionout_data
     )
-    parcel.updateTitle()
-    parcel.reindexObject()
+    portionout = getattr(licence, portionout_id)
+    # portionout._renameAfterCreation()
+    portionout.updateTitle()
+    portionout.reindexObject()
     licence.reindexObject(idxs=["parcelInfosIndex"])
     # generate all the urban events
     logger.info("   test %s --> create all the events" % licence_type)
-    event_configs = licence.getLicenceConfig().getEventConfigs()
-    for event_config in event_configs:
-        if event_config.canBeCreatedInLicence(licence):
-            licence.createUrbanEvent(event_config)
-    # fill each event with dummy data and generate all its documents
+    eventtypes = [
+        brain.getObject()
+        for brain in urban_tool.listEventTypes(
+            licence, urbanConfigId=licence_type.lower()
+        )
+    ]
+    for event_type in eventtypes:
+        licence.createUrbanEvent(event_type)    # fill each event with dummy data and generate all its documents
     logger.info("   test %s --> generate all the documents" % licence_type)
     for urban_event in licence.objectValues(
         ["UrbanEvent", "UrbanEventInquiry", "UrbanEventOpinionRequest"]

--- a/src/Products/urban/testing.py
+++ b/src/Products/urban/testing.py
@@ -1,4 +1,7 @@
 # -*- coding: utf-8 -*-
+
+from Products.GenericSetup.tool import DEPENDENCY_STRATEGY_NEW
+from Products.urban.utils import run_entry_points
 from Products.urban.utils import run_entry_points
 from plone import api
 from plone.app.robotframework.testing import REMOTE_LIBRARY_BUNDLE_FIXTURE
@@ -7,6 +10,7 @@ from plone.app.testing import IntegrationTesting
 from plone.app.testing import PloneWithPackageLayer
 from plone.app.testing import helpers
 from plone.testing import z2
+from zope.globalrequest import setRequest
 from zope.globalrequest import setLocal
 
 import Products.urban
@@ -21,6 +25,12 @@ class UrbanLayer(PloneWithPackageLayer):
         setattr(portal.REQUEST, "URL", "")
         setLocal("request", portal.REQUEST)
         transaction.commit()
+        super(UrbanLayer, self).setUpPloneSite(portal)
+
+
+class UrbanLayer(PloneWithPackageLayer):
+    def setUpPloneSite(self, portal):
+        setRequest(portal.REQUEST)
         super(UrbanLayer, self).setUpPloneSite(portal)
 
 
@@ -64,8 +74,9 @@ class UrbanWithUsersLayer(IntegrationTesting):
             portal_urban = portal.portal_urban
             cache_view = portal_urban.unrestrictedTraverse("urban_vocabulary_cache")
             cache_view.reset_all_cache()
-            Products.urban.exportimport.NIS = "93088"  # mock NIS code
+            Products.urban.config.NIS = "92000"  # mock NIS code
             portal.setupCurrentSkin(portal.REQUEST)
+            setRequest(portal.REQUEST)
             from Products.urban.setuphandlers import addTestUsers
 
             addTestUsers(portal)
@@ -88,7 +99,7 @@ class UrbanConfigLayer(UrbanWithUsersLayer):
         super(UrbanConfigLayer, self).setUp()
         with helpers.ploneSite() as portal:
             portal.setupCurrentSkin(portal.REQUEST)
-            setLocal("request", portal.REQUEST)
+            setRequest(portal.REQUEST)
             helpers.applyProfile(portal, "Products.urban:testsWithConfig")
 
 
@@ -109,7 +120,7 @@ class UrbanLicencesLayer(UrbanConfigLayer):
         super(UrbanLicencesLayer, self).setUp()
         with helpers.ploneSite() as portal:
             portal.setupCurrentSkin(portal.REQUEST)
-            setLocal("request", portal.REQUEST)
+            setRequest(portal.REQUEST)
             helpers.applyProfile(portal, "Products.urban:testsWithLicences")
 
 
@@ -128,7 +139,8 @@ class UrbanImportsLayer(IntegrationTesting):
         super(UrbanImportsLayer, self).setUp()
         with helpers.ploneSite() as portal:
             portal.setupCurrentSkin(portal.REQUEST)
-            setLocal("request", portal.REQUEST)
+            setRequest(portal.REQUEST)
+            Products.urban.config.NIS = "92000"  # mock NIS code
             helpers.applyProfile(portal, "Products.urban:tests-imports")
 
 
@@ -158,9 +170,12 @@ class UrbanWithUsersFunctionalLayer(FunctionalTesting):
         super(UrbanWithUsersLayer, self).setUpPloneSite(portal)
 
     def setUp(self):
-        super(UrbanWithUsersFunctionalLayer, self).setUp()
+        Products.urban.config.NIS = "92000"  # mock NIS code
+        # monkey patch to avoid running upgrade steps when reisntalling urban
+        Products.GenericSetup.tool.DEFAULT_DEPENDENCY_STRATEGY = DEPENDENCY_STRATEGY_NEW
         with helpers.ploneSite() as portal:
             portal.setupCurrentSkin(portal.REQUEST)
+            setRequest(portal.REQUEST)
             from Products.urban.setuphandlers import addTestUsers
             api.user.create(
                 email="adminurba@urban.be",
@@ -187,7 +202,7 @@ class UrbanConfigFunctionalLayer(UrbanWithUsersFunctionalLayer):
         super(UrbanConfigFunctionalLayer, self).setUp()
         with helpers.ploneSite() as portal:
             portal.setupCurrentSkin(portal.REQUEST)
-            setLocal("request", portal.REQUEST)
+            setRequest(portal.REQUEST)
             helpers.applyProfile(portal, "Products.urban:testsWithConfig")
 
 
@@ -208,7 +223,7 @@ class UrbanLicencesFunctionalLayer(UrbanConfigFunctionalLayer):
         super(UrbanLicencesFunctionalLayer, self).setUp()
         with helpers.ploneSite() as portal:
             portal.setupCurrentSkin(portal.REQUEST)
-            setLocal("request", portal.REQUEST)
+            setRequest(portal.REQUEST)
             helpers.applyProfile(portal, "Products.urban:testsWithLicences")
 
 

--- a/src/Products/urban/tests/helpers.py
+++ b/src/Products/urban/tests/helpers.py
@@ -1,8 +1,7 @@
 # -*- coding: utf-8 -*-
 
-from plone import api
-
 from Products.urban.testing import URBAN_TESTS_INTEGRATION
+from plone import api
 
 import unittest
 

--- a/src/Products/urban/tests/test_BuildLicence.py
+++ b/src/Products/urban/tests/test_BuildLicence.py
@@ -1,13 +1,15 @@
 # -*- coding: utf-8 -*-
+
 from Products.urban import utils
 from Products.urban.testing import URBAN_TESTS_INTEGRATION
 from Products.urban.testing import URBAN_TESTS_LICENCES_FUNCTIONAL
 from Products.urban.tests.helpers import SchemaFieldsTestCase
-
 from plone import api
 from plone.app.testing import login
 from plone.testing.z2 import Browser
 from time import sleep
+from zope.globalrequest import getRequest
+from zope.globalrequest import setRequest
 
 import transaction
 import unittest
@@ -23,6 +25,8 @@ class TestBuildLicence(unittest.TestCase):
         self.buildlicence = portal.urban.buildlicences.objectValues("BuildLicence")[0]
         self.portal_urban = portal.portal_urban
         login(portal, "urbaneditor")
+        if not getRequest():
+            setRequest(self.portal.REQUEST)
 
     def testLicenceTitleUpdate(self):
         # verify that the licence title update correctly when we add or remove applicants/proprietaries
@@ -30,7 +34,7 @@ class TestBuildLicence(unittest.TestCase):
         licence = self.buildlicence
         self.assertTrue(
             licence.Title().endswith(
-                "1 - Exemple Permis Urbanisme - Mes Smith & Wesson"
+                "/1 - Exemple Permis Urbanisme - Mes Smith & Wesson"
             )
         )
         # remove the applicant
@@ -38,7 +42,7 @@ class TestBuildLicence(unittest.TestCase):
         licence.manage_delObjects([applicant_id])
         self.assertTrue(
             licence.Title().endswith(
-                "1 - Exemple Permis Urbanisme - no_applicant_defined"
+                "/1 - Exemple Permis Urbanisme - no_applicant_defined"
             )
         )
         # add an applicant back
@@ -47,9 +51,76 @@ class TestBuildLicence(unittest.TestCase):
         )
         self.assertTrue(
             licence.Title().endswith(
-                "1 - Exemple Permis Urbanisme -  Quentin Tinchimiloupète"
+                "/1 - Exemple Permis Urbanisme -  Quentin Tinchimiloupète"
             )
         )
+
+    def test_LicenceUpdateTitleForCodt_buildlicence(self):
+        # check that the licence updateTitle method add all applicants or proprietaries or notaries to the Licence Title
+        licence = self.buildlicence
+        self.assertTrue(
+            licence.Title().endswith(
+                "/1 - Exemple Permis Urbanisme - Mes Smith & Wesson"
+            )
+        )
+        # add another applicant
+        licence.invokeFactory(
+            "Applicant", "new_applicant", name1="Chuck", name2="Norris"
+        )
+        # call updateTitle()
+        licence.updateTitle()
+        # add applicant with invokeFactory add a space before the name of the applicant => 2spaces
+        self.assertTrue(
+            licence.Title().endswith(
+                "/1 - Exemple Permis Urbanisme - Mes Smith & Wesson,  Chuck Norris"
+            )
+        )
+
+    def test_LicenceUpdateTitleForInspection(self):
+        # check that the licence updateTitle method add all proprietaries on inspections titles
+        inspection_expl = self.portal.urban.inspections.objectValues("Inspection")[0]
+        # for the inspection the proprietary is before inspection name
+        self.assertTrue(
+            inspection_expl.Title().endswith(
+                "/1 - Mes Smith & Wesson - Exemple Inspection"
+            )
+        )
+        # add proprietary
+        inspection_expl.invokeFactory(
+            "Proprietary", "new_proprietary", name1="Chuck", name2="Norris"
+        )
+        # call updateTitle()
+        inspection_expl.updateTitle()
+        self.assertTrue(
+            inspection_expl.Title().endswith(
+                "/1 - Mes Smith & Wesson,  Chuck Norris - Exemple Inspection"
+            )
+        )
+
+    def test_LicenceUpdateTitleForNotaryLetter(self):
+        # check that the licence updateTitle method add all proprietaries and notaries on notary letters titles
+        licence = self.portal.urban.notaryletters.objectValues()[1]
+        self.assertTrue(
+            licence.Title().endswith(
+                "/1 - Mes Smith & Wesson -  NotaryName1 NotarySurname1"
+            )
+        )
+        notaries = self.portal.urban.notaries.objectValues()
+        notaries = list(notaries)
+        # add all notaries to the licence and add a proprietary
+        licence.setNotaryContact(notaries)
+        licence.invokeFactory(
+            "Proprietary", id="proprietary2", name1="Aeron", name2="Lorelei"
+        )
+        licence.updateTitle()
+
+        titleparts = licence.Title().split(" - ")
+        notarieslist = titleparts[2].split(", ")
+        notariesset = set(notarieslist)
+        testnotariesset = set([" André Sanfrapper", " NotaryName1 NotarySurname1"])
+        self.assertEqual(notariesset, testnotariesset)
+        testproprietaries = "Mes Smith & Wesson,  Aeron Lorelei"
+        self.assertEqual(titleparts[1], testproprietaries)
 
     def testGetLastEventWithoutEvent(self):
         buildlicences = self.portal.urban.buildlicences
@@ -165,6 +236,7 @@ class TestBuildLicenceFields(SchemaFieldsTestCase):
         default_password = self.layer.default_password
         login(self.portal, default_user)
         self.licences = []
+        # create 'BuildLicence' and 'ParcelOutLicence'
         for content_type in ["BuildLicence", "ParcelOutLicence"]:
             licence_folder = utils.getLicenceFolder(content_type)
             testlicence_id = "test_{}".format(content_type.lower())
@@ -172,14 +244,45 @@ class TestBuildLicenceFields(SchemaFieldsTestCase):
             transaction.commit()
             test_licence = getattr(licence_folder, testlicence_id)
             self.licences.append(test_licence)
-        self.test_buildlicence = self.licences[0]
-        self.licence = self.test_buildlicence
+        self.licence = self.licences[0]
+        # create a CODT_BuildLicence
+        licence_folder_codtbuildlicences = utils.getLicenceFolder("CODT_BuildLicence")
+        codtbuildlicence_testlicence_id = "test_{}".format("CODT_BuildLicence".lower())
+        licence_folder_codtbuildlicences.invokeFactory(
+            "CODT_BuildLicence", id=codtbuildlicence_testlicence_id
+        )
+        transaction.commit()
+        self.licences.append(
+            getattr(licence_folder_codtbuildlicences, codtbuildlicence_testlicence_id)
+        )
+
+        # create a CODT_ParcelOutLicence
+        licence_folder_codtparceloutlicences = utils.getLicenceFolder(
+            "CODT_ParcelOutLicence"
+        )
+        codtparceloutlicence_testlicence_id = "test_{}".format(
+            "CODT_ParcelOutLicence".lower()
+        )
+        licence_folder_codtparceloutlicences.invokeFactory(
+            "CODT_ParcelOutLicence", id=codtparceloutlicence_testlicence_id
+        )
+        transaction.commit()
+        self.licences.append(
+            getattr(
+                licence_folder_codtparceloutlicences,
+                codtparceloutlicence_testlicence_id,
+            )
+        )
 
         self.browser = Browser(self.portal)
         self.browserLogin(default_user, default_password)
+        if not getRequest():
+            setRequest(self.portal.REQUEST)
 
     def tearDown(self):
         with api.env.adopt_roles(["Manager"]):
+            if not getRequest():
+                setRequest(self.portal.REQUEST)
             for licence in self.licences:
                 api.content.delete(licence)
         transaction.commit()
@@ -272,7 +375,7 @@ class TestBuildLicenceFields(SchemaFieldsTestCase):
             msg = "field 'impactStudy' not visible on {}".format(
                 licence.getPortalTypeName()
             )
-            self._is_field_visible("<span>Etude d'incidences?</span>:", licence, msg)
+            self._is_field_visible("<span>Étude d'incidences ?</span>:", licence, msg)
 
     def test_has_attribute_implantation(self):
         field_name = "implantation"
@@ -287,9 +390,14 @@ class TestBuildLicenceFields(SchemaFieldsTestCase):
             msg = "field 'implantation' not visible on {}".format(
                 licence.getPortalTypeName()
             )
-            self._is_field_visible(
-                "<span>Implantation (art. 137)</span>:", licence, msg
-            )
+            if ICODT_BaseBuildLicence.providedBy(licence):
+                self._is_field_visible(
+                    "<span>Implantation (art D.IV.72)</span>:", licence, msg
+                )
+            else:
+                self._is_field_visible(
+                    "<span>Implantation (art. 137)</span>:", licence, msg
+                )
 
     def test_has_attribute_pebType(self):
         field_name = "pebType"
@@ -308,3 +416,24 @@ class TestBuildLicenceFields(SchemaFieldsTestCase):
     def test_pebDetails_is_visible(self):
         msg = "field 'pebDetails' not visible on BuildLicence"
         self._is_field_visible("<span>Détails concernant le PEB</span>:", msg=msg)
+
+    def test_has_attribute_representativeContacts(self):
+        field_name = "representativeContacts"
+        msg = "field '{}' not on class ParcelOutLicence".format(field_name)
+        self.assertTrue(self.licences[1].getField("representativeContacts"), msg)
+        msg = "field '{}' not on class CODT ParcelOutLicence".format(field_name)
+        self.assertTrue(self.licences[3].getField("representativeContacts"), msg)
+
+    def test_representativeContacts_is_visible(self):
+        msg = "field 'representativeContacts' not visible on CODT ParcelOutLicence"
+        self._is_field_visible(
+            "<legend>Architecte(s) ou géomètre(s)</legend>",
+            obj=self.licences[3],
+            msg=msg,
+        )
+        msg = "field 'representativeContacts' not visible on CODT BuildLicence"
+        self._is_field_visible(
+            "<legend>Architecte(s) ou géomètre(s)</legend>",
+            obj=self.licences[2],
+            msg=msg,
+        )

--- a/src/Products/urban/tests/test_Contact.py
+++ b/src/Products/urban/tests/test_Contact.py
@@ -1,15 +1,15 @@
 # -*- coding: utf-8 -*-
 
-from Products.urban.testing import URBAN_TESTS_LICENCES_FUNCTIONAL
 from Products.urban.testing import URBAN_TESTS_INTEGRATION
+from Products.urban.testing import URBAN_TESTS_LICENCES_FUNCTIONAL
 from Products.urban.tests.helpers import BrowserTestCase
 from Products.urban.tests.helpers import SchemaFieldsTestCase
-
 from plone import api
 from plone.app.testing import login
 from plone.testing.z2 import Browser
-
 from zope.event import notify
+from zope.globalrequest import getRequest
+from zope.globalrequest import setRequest
 from zope.lifecycleevent import ObjectModifiedEvent
 
 import transaction
@@ -41,8 +41,13 @@ class TestContactFields(SchemaFieldsTestCase):
         self.browser = Browser(self.portal)
         self.browserLogin(default_user, default_password)
 
+        if getRequest() is None:
+            setRequest(self.portal.REQUEST)
+
     def tearDown(self):
         with api.env.adopt_roles(["Manager"]):
+            if getRequest() is None:
+                setRequest(self.portal.REQUEST)
             api.content.delete(self.licence)
         transaction.commit()
 
@@ -198,6 +203,9 @@ class TestContactEvents(unittest.TestCase):
         # create a test BuildLicence licence for Applicant contact
         login(self.portal, "urbaneditor")
 
+        if getRequest() is None:
+            setRequest(self.portal.REQUEST)
+
     def test_licence_title_is_updated_when_applicant_modified(self):
         """ """
 
@@ -227,8 +235,13 @@ class TestApplicantFields(SchemaFieldsTestCase):
         self.browser = Browser(self.portal)
         self.browserLogin(default_user, default_password)
 
+        if getRequest() is None:
+            setRequest(self.portal.REQUEST)
+
     def tearDown(self):
         with api.env.adopt_roles(["Manager"]):
+            if getRequest() is None:
+                setRequest(self.portal.REQUEST)
             api.content.delete(self.licence)
         transaction.commit()
 
@@ -279,6 +292,9 @@ class TestApplicant(BrowserTestCase):
 
         self.browser = Browser(self.portal)
         self.browserLogin("urbaneditor")
+
+        if getRequest() is None:
+            setRequest(self.portal.REQUEST)
 
     def test_address_display_when_sameAddressAsWorks_is_checked(self):
         self.applicant.setStreet("Rue kikoulo")
@@ -366,8 +382,13 @@ class TestCorporationFields(SchemaFieldsTestCase):
         self.browser = Browser(self.portal)
         self.browserLogin(default_user, default_password)
 
+        if getRequest() is None:
+            setRequest(self.portal.REQUEST)
+
     def tearDown(self):
         with api.env.adopt_roles(["Manager"]):
+            if getRequest() is None:
+                setRequest(self.portal.REQUEST)
             api.content.delete(self.licence)
         transaction.commit()
 
@@ -445,6 +466,9 @@ class TestCorporation(BrowserTestCase):
 
         self.browser = Browser(self.portal)
         self.browserLogin(default_user, default_password)
+
+        if getRequest() is None:
+            setRequest(self.portal.REQUEST)
 
     def test_address_display_when_sameAddressAsWorks_is_checked(self):
         self.corporation.setStreet("Rue kikoulo")

--- a/src/Products/urban/tests/test_DefaultValues.py
+++ b/src/Products/urban/tests/test_DefaultValues.py
@@ -9,6 +9,7 @@ from Products.CMFCore.utils import getToolByName
 from Products.urban.config import URBAN_TYPES
 from Products.urban.content import UrbanEventInquiry
 from Products.urban.interfaces import IUrbanEvent
+from zope.lifecycleevent import ObjectCreatedEvent
 from Products.urban.UrbanVocabularyTerm import UrbanVocabulary
 from zope.event import notify
 from Products.Archetypes.event import EditBegunEvent
@@ -142,8 +143,8 @@ class TestDefaultValues(unittest.TestCase):
         licence_config = self.site.portal_urban.buildlicence
         # set the default text value fotr the fdescription field
         default_text = "<p>Bla bla</p>"
-        licence_config.setTextDefaultValues(
-            ({"text": default_text, "fieldname": "description"},)
+        licence_config.textDefaultValues = (
+            {"text": default_text, "fieldname": "description"},
         )
         # any new licence should have this text as value for the description field
         newlicence = self.createNewLicence()
@@ -247,35 +248,37 @@ class TestEventDefaultValues(unittest.TestCase):
         # text field 'decisionText' should be empty by default
         event = self.licence.createUrbanEvent("rapport-du-college")
         decision_text = event.getDecisionText()
-        self.failUnless(decision_text == "<p></p>")
+        self.assertEqual(decision_text, "<p></p>")
 
     def testTextValueConfigured(self):
-        eventtypes = self.portal_urban.buildlicence.urbaneventtypes
+        eventtypes = self.portal_urban.buildlicence.eventconfigs
         event_type = getattr(eventtypes, "rapport-du-college")
         # set a a default text for the field 'decsionText'
         default_text = "<p>Kill bill!</p>"
-        event_type.setTextDefaultValues(
-            [{"text": default_text, "fieldname": "decisionText"}]
-        )
+        event_type.textDefaultValues = [
+            {"text": default_text, "fieldname": "decisionText"}
+        ]
         # the created event should have this text in its field 'decisionText'
         event = self.licence.createUrbanEvent(event_type)
+        notify(ObjectCreatedEvent(event))
         decision_text = event.getDecisionText()
-        self.failUnless(decision_text == default_text)
+        self.assertEqual(decision_text, default_text)
 
     def testTextValueConfiguredWithPythonExpression(self):
-        eventtypes = self.portal_urban.buildlicence.urbaneventtypes
+        eventtypes = self.portal_urban.buildlicence.eventconfigs
         event_type = getattr(eventtypes, "rapport-du-college")
         # set a a default text for the field 'decsionText'
         default_text = '<p>Kill <b tal:replace="self/Title"></b> and <b tal:replace="event/getId"></b> </p>'
-        event_type.setTextDefaultValues(
-            [{"text": default_text, "fieldname": "decisionText"}]
-        )
+        event_type.textDefaultValues = [
+            {"text": default_text, "fieldname": "decisionText"}
+        ]
         # the created event should have this text in its field 'decisionText'
         event = self.licence.createUrbanEvent(event_type)
+        notify(ObjectCreatedEvent(event))
         decision_text = event.getDecisionText()
 
         expected_text = "<p>Kill %s and %s </p>" % (self.licence.Title(), event.getId())
-        self.assertTrue(decision_text == expected_text)
+        self.assertEqual(decision_text, expected_text)
 
     def testDefaultTextMethodIsDefinedForEachTextField(self):
         # each text field  should have the 'getDefaultText' method defined on it, else the default value system wont
@@ -285,3 +288,57 @@ class TestEventDefaultValues(unittest.TestCase):
                 field, "defaut_content_type"
             ) and field.default_content_type.startswith("text"):
                 self.assertEquals(field.default_method, "getDefaultText")
+
+
+class TestParcelApplicantDefaultValue(unittest.TestCase):
+    """
+    Tests for the text default values
+    """
+
+    layer = URBAN_TESTS_CONFIG
+
+    def setUp(self):
+        portal = self.layer["portal"]
+        self.portal_urban = portal.portal_urban
+        self.site = portal
+        login(portal, self.layer.default_user)
+        # create a licence
+        buildlicences = portal.urban.buildlicences
+        buildlicences.invokeFactory(
+            "BuildLicence",
+            id="newlicence",
+            title="blabla",
+        )
+        buildlicence = buildlicences.newlicence
+        self.licence = buildlicence
+
+    def test_parcel_applicant_default_personTitle(self):
+        searchparcelview = self.licence.restrictedTraverse("searchparcels")
+        parcel_data = {
+            "puissance": "",
+            "division": "62006",
+            "worklocations": (),
+            "partie": "",
+            "radical": "552",
+            "section": "A",
+            "outdated": "False",
+            "bis": "",
+            "exposant": "V",
+        }
+        owners = {
+            u"64122514647": {
+                "city": u"AWANS",
+                "name": u"Macours",
+                "firstname": u"Jo\xeblle",
+                "country": u"BE",
+                "zipcode": u"4340",
+                "number": u"61",
+                "street": u"Rue de Bruxelles",
+            }
+        }
+        searchparcelview.createParcelAndProprietary(parcel_data, owners)
+        applicants = self.licence.getApplicants()
+        applicant = applicants[0]
+        self.assertEquals("madam_or_mister", applicant.getPersonTitle())
+        display_view = applicant.restrictedTraverse("document_generation_helper_view")
+        self.assertEquals(u"Madame/Monsieur", display_view.personTitle)

--- a/src/Products/urban/tests/test_EnvClassOne.py
+++ b/src/Products/urban/tests/test_EnvClassOne.py
@@ -1,13 +1,14 @@
 # -*- coding: utf-8 -*-
 
+from Products.urban import utils
 from Products.urban.testing import URBAN_TESTS_INTEGRATION
 from Products.urban.tests.helpers import BrowserTestCase
 from Products.urban.tests.helpers import SchemaFieldsTestCase
-from Products.urban import utils
-
 from plone import api
 from plone.app.testing import login
 from plone.testing.z2 import Browser
+from zope.globalrequest import getRequest
+from zope.globalrequest import setRequest
 
 import transaction
 import urllib2
@@ -25,6 +26,8 @@ class TestEnvClassOneInstall(BrowserTestCase):
         default_user = self.layer.environment_default_user
         default_password = self.layer.environment_default_password
         self.browserLogin(default_user, default_password)
+        if not getRequest():
+            setRequest(self.portal.REQUEST)
 
     def test_envclassone_config_folder_exists(self):
         msg = "envclassone config folder not created"
@@ -68,10 +71,10 @@ class TestEnvClassOneInstall(BrowserTestCase):
         contents = self.browser.contents
         self.assertTrue("Permis d'environnement classe 1" in contents)
 
-    def test_EnvClassOne_is_under_licence_workflow(self):
+    def test_EnvClassOne_is_under_env_licence_workflow(self):
         workflow_tool = api.portal.get_tool("portal_workflow")
         envclassone_workflow = workflow_tool.getChainForPortalType("EnvClassOne")
-        self.assertTrue("urban_licence_workflow" in envclassone_workflow)
+        self.assertTrue("env_licence_workflow" in envclassone_workflow)
 
 
 class TestEnvClassOneInstance(SchemaFieldsTestCase):
@@ -94,11 +97,15 @@ class TestEnvClassOneInstance(SchemaFieldsTestCase):
 
         self.browser = Browser(self.portal)
         self.browserLogin(default_user, default_password)
+        if not getRequest():
+            setRequest(self.portal.REQUEST)
 
     def tearDown(self):
         if self.licence.wl_isLocked():
             self.licence.wl_clearLocks()
         with api.env.adopt_roles(["Manager"]):
+            if not getRequest():
+                setRequest(self.portal.REQUEST)
             api.content.delete(self.licence)
         transaction.commit()
 
@@ -194,14 +201,11 @@ class TestEnvClassOneInstance(SchemaFieldsTestCase):
 
     def test_envclassone_referenceDGATLP_translation(self):
         """
-        Field referenceDGATLP should be translated as 'reference DGO4'
+        Field referenceDGATLP should be translated as 'reference ARNE'
         """
-        self._is_field_visible("Référence DGO3")
-        self._is_field_visible_in_edit("Référence DGO3")
+        self._is_field_visible("Référence ARNE")
+        self._is_field_visible_in_edit("Référence ARNE")
 
     def test_envclassone_workLocation_translation(self):
-        """
-        Field referenceDGATLP should be translated as 'reference DGO3'
-        """
         self._is_field_visible("Situation")
         self._is_field_visible_in_edit("Situation")

--- a/src/Products/urban/tests/test_EnvClassTwo.py
+++ b/src/Products/urban/tests/test_EnvClassTwo.py
@@ -1,13 +1,14 @@
 # -*- coding: utf-8 -*-
 
+from Products.urban import utils
 from Products.urban.testing import URBAN_TESTS_INTEGRATION
 from Products.urban.tests.helpers import BrowserTestCase
 from Products.urban.tests.helpers import SchemaFieldsTestCase
-from Products.urban import utils
-
 from plone import api
 from plone.app.testing import login
 from plone.testing.z2 import Browser
+from zope.globalrequest import getRequest
+from zope.globalrequest import setRequest
 
 import transaction
 import urllib2
@@ -25,6 +26,8 @@ class TestEnvClassTwoInstall(BrowserTestCase):
         default_user = self.layer.environment_default_user
         default_password = self.layer.environment_default_password
         self.browserLogin(default_user, default_password)
+        if not getRequest():
+            setRequest(self.portal.REQUEST)
 
     def test_envclasstwo_config_folder_exists(self):
         msg = "envclasstwo config folder not created"
@@ -68,10 +71,10 @@ class TestEnvClassTwoInstall(BrowserTestCase):
         contents = self.browser.contents
         self.assertTrue("Permis d'environnement classe 2" in contents)
 
-    def test_EnvClassTwo_is_under_licence_workflow(self):
+    def test_EnvClassTwo_is_under_env_licence_workflow(self):
         workflow_tool = api.portal.get_tool("portal_workflow")
         envclasstwo_workflow = workflow_tool.getChainForPortalType("EnvClassTwo")
-        self.assertTrue("urban_licence_workflow" in envclasstwo_workflow)
+        self.assertTrue("env_licence_workflow" in envclasstwo_workflow)
 
 
 class TestEnvClassTwoInstance(SchemaFieldsTestCase):
@@ -94,11 +97,15 @@ class TestEnvClassTwoInstance(SchemaFieldsTestCase):
 
         self.browser = Browser(self.portal)
         self.browserLogin(default_user, default_password)
+        if not getRequest():
+            setRequest(self.portal.REQUEST)
 
     def tearDown(self):
         if self.licence.wl_isLocked():
             self.licence.wl_clearLocks()
         with api.env.adopt_roles(["Manager"]):
+            if not getRequest():
+                setRequest(self.portal.REQUEST)
             api.content.delete(self.licence)
         transaction.commit()
 
@@ -203,14 +210,11 @@ class TestEnvClassTwoInstance(SchemaFieldsTestCase):
 
     def test_envclasstwo_referenceDGATLP_translation(self):
         """
-        Field referenceDGATLP should be translated as 'reference DGO3'
+        Field referenceDGATLP should be translated as 'reference ARNE'
         """
-        self._is_field_visible("Référence DGO3")
-        self._is_field_visible_in_edit("Référence DGO3")
+        self._is_field_visible("Référence ARNE")
+        self._is_field_visible_in_edit("Référence ARNE")
 
     def test_envclasstwo_workLocation_translation(self):
-        """
-        Field referenceDGATLP should be translated as 'reference DGO3'
-        """
         self._is_field_visible("Situation")
         self._is_field_visible_in_edit("Situation")

--- a/src/Products/urban/tests/test_GenericLicence.py
+++ b/src/Products/urban/tests/test_GenericLicence.py
@@ -1,13 +1,15 @@
 # -*- coding: utf-8 -*-
+
+from Products.urban import interfaces
 from Products.urban.config import URBAN_TYPES
 from Products.urban.testing import URBAN_TESTS_INTEGRATION
 from Products.urban.tests.helpers import SchemaFieldsTestCase
-from Products.urban import interfaces
 from Products.urban import utils
-
 from plone import api
 from plone.app.testing import login
 from plone.testing.z2 import Browser
+from zope.globalrequest import getRequest
+from zope.globalrequest import setRequest
 
 import transaction
 
@@ -28,6 +30,8 @@ class TestGenericLicenceFields(SchemaFieldsTestCase):
         login(self.portal, default_user)
         self.licences = []
         exceptions = ["ExplosivesPossession", "Inspection", "Ticket"]
+        if not getRequest():
+            setRequest(self.portal.REQUEST)
         for content_type in URBAN_TYPES:
             if content_type in exceptions:
                 continue
@@ -43,6 +47,8 @@ class TestGenericLicenceFields(SchemaFieldsTestCase):
 
     def tearDown(self):
         with api.env.adopt_roles(["Manager"]):
+            if not getRequest():
+                setRequest(self.portal.REQUEST)
             for licence in self.licences:
                 api.content.delete(licence)
         default_user = self.layer.default_user
@@ -95,9 +101,10 @@ class TestGenericLicenceFields(SchemaFieldsTestCase):
             self.browser.open(licence.absolute_url())
             contents = self.browser.contents
             reference_is_visible = (
-                "<span>Référence DGO6</span>:" in contents
-                or "<span>Référence DGO4</span>:" in contents
-                or "<span>Référence DGO3</span>:" in contents
+                "<span>Référence FD (TLPE)</span>:" in contents
+                or "<span>Référence SPW Economie, Emploi, Recherche</span>:" in contents
+                or "<span>Référence ARNE</span>:" in contents
+                or "<span>Référence notaire</span>:" in contents
             )
             self.assertTrue(reference_is_visible, msg)
 
@@ -345,7 +352,7 @@ class TestGenericLicenceFields(SchemaFieldsTestCase):
                 licence.getPortalTypeName()
             )
             self._is_field_visible(
-                "<span>Risque d'inondations (Fiche Voirie)</span>:", licence, msg
+                "<span>Zone inondable (Fiche Voirie)</span>:", licence, msg
             )
 
     def test_has_attribute_floodingLevelDetails(self):
@@ -362,7 +369,7 @@ class TestGenericLicenceFields(SchemaFieldsTestCase):
                 licence.getPortalTypeName()
             )
             self._is_field_visible(
-                "<span>Détails concernant le risque d'inondations</span>:", licence, msg
+                "<span>Détails concernant la zone inondable</span>:", licence, msg
             )
 
     def test_has_attribute_equipmentAndRoadRequirements(self):
@@ -483,7 +490,7 @@ class TestGenericLicenceFields(SchemaFieldsTestCase):
                 licence.getPortalTypeName()
             )
             self._is_field_visible(
-                "<span>Risque d'inondations (Fiche Urbanisme)</span>:", licence, msg
+                "<span>Zone inondable (Fiche Urbanisme)</span>:", licence, msg
             )
 
     def test_has_attribute_locationTechnicalRemarks(self):
@@ -522,9 +529,10 @@ class TestGenericLicenceFields(SchemaFieldsTestCase):
             msg = "field 'isInPCA' not visible on {}".format(
                 licence.getPortalTypeName()
             )
-            self._is_field_visible(
-                "<span>Plan Communal d'Aménagement</span>:", licence, msg
-            )
+            expected_field = "<span>Schéma d'Orientation Local</span>"
+            if licence.portal_type in URBAN_CODT_TYPES:
+                expected_field = "<span>SOL</span>"
+            self._is_field_visible(expected_field, licence, msg)
 
     def test_has_attribute_pca(self):
         field_name = "pca"
@@ -543,9 +551,10 @@ class TestGenericLicenceFields(SchemaFieldsTestCase):
             ):
                 continue
             msg = "field 'pca' not visible on {}".format(licence.getPortalTypeName())
-            self._is_field_visible(
-                "<span>Plan Communal d'Aménagement</span>:", licence, msg
-            )
+            expected_field = "<span>Schéma d'Orientation Local</span>"
+            if licence.portal_type in URBAN_CODT_TYPES:
+                expected_field = "<span>SOL</span>"
+            self._is_field_visible(expected_field, licence, msg)
 
     def test_has_attribute_solicitRoadOpinionsTo(self):
         field_name = "solicitRoadOpinionsTo"
@@ -584,7 +593,9 @@ class TestGenericLicenceFields(SchemaFieldsTestCase):
                 licence.getPortalTypeName()
             )
             self._is_field_visible(
-                "<span>Le bien se situe dans un lotissement</span>:", licence, msg
+                "<span>Le bien se situe dans un permis d'urbanisation</span>:",
+                licence,
+                msg,
             )
 
     def test_has_attribute_subdivisionDetails(self):
@@ -607,16 +618,20 @@ class TestGenericLicenceFields(SchemaFieldsTestCase):
                 licence.getPortalTypeName()
             )
             self._is_field_visible(
-                "<span>Le bien se situe dans un lotissement</span>:", licence, msg
+                "<span>Le bien se situe dans un permis d'urbanisation</span>:",
+                licence,
+                msg,
             )
 
     def test_has_attribute_protectedBuilding(self):
         field_name = "protectedBuilding"
         for licence in self.licences:
-            msg = "field '{}' not on class {}".format(
-                field_name, licence.getPortalTypeName()
-            )
-            self.assertTrue(licence.getField(field_name), msg)
+            config = licence.getLicenceConfig()
+            if "patrimony" in [line["value"] for line in config.getActiveTabs()]:
+                msg = "field '{}' not on class {}".format(
+                    field_name, licence.getPortalTypeName()
+                )
+                self.assertTrue(licence.getField(field_name), msg)
 
     def test_protectedBuilding(self):
         for licence in self.licences:
@@ -634,10 +649,12 @@ class TestGenericLicenceFields(SchemaFieldsTestCase):
     def test_has_attribute_protectedBuildingDetails(self):
         field_name = "protectedBuildingDetails"
         for licence in self.licences:
-            msg = "field '{}' not on class {}".format(
-                field_name, licence.getPortalTypeName()
-            )
-            self.assertTrue(licence.getField(field_name), msg)
+            config = licence.getLicenceConfig()
+            if "patrimony" in [line["value"] for line in config.getActiveTabs()]:
+                msg = "field '{}' not on class {}".format(
+                    field_name, licence.getPortalTypeName()
+                )
+                self.assertTrue(licence.getField(field_name), msg)
 
     def test_protectedBuildingDetails(self):
         for licence in self.licences:

--- a/src/Products/urban/tests/test_Inquiries.py
+++ b/src/Products/urban/tests/test_Inquiries.py
@@ -1,11 +1,14 @@
-# -*- coding: utf-8 -*-
+#  -*- coding: utf-8 -*-
+
 from OFS.ObjectManager import BeforeDeleteException
-
 from Products.urban.testing import URBAN_TESTS_CONFIG_FUNCTIONAL
-
+from Products.urban.testing import URBAN_TESTS_LICENCES
+from Products.urban.tests.helpers import BrowserTestCase
 from plone import api
 from plone.app.testing import login
-from zope.component import createObject
+from plone.testing.z2 import Browser
+from zope.globalrequest import getRequest
+from zope.globalrequest import setRequest
 
 import transaction
 import unittest
@@ -27,9 +30,11 @@ class TestBuildLicenceInquiries(unittest.TestCase):
         buildlicence_folder.invokeFactory("BuildLicence", id=testlicence_id)
         self.licence = getattr(buildlicence_folder, testlicence_id)
 
-        # create un inquiry event
-        createObject("UrbanEventInquiry", "enquete-publique", self.licence)
+        #  create un inquiry event
+        self.licence.createUrbanEvent("enquete-publique")
         transaction.commit()
+        if not getRequest():
+            setRequest(self.portal.REQUEST)
 
     def _addInquiry(self):
         """
@@ -60,15 +65,13 @@ class TestBuildLicenceInquiries(unittest.TestCase):
         licence = self.licence
         # by default, an inquiry is already defined defined on the licence
         self.assertEquals(len(licence.getUrbanEventInquiries()), 1)
-        # we can not add a second urbanEventInquiry if only one inquiry
-        # is defined
-        self.assertRaises(
-            ValueError, createObject, "UrbanEventInquiry", "enquete-publique", licence
-        )
+        #  we can not add a second urbanEventInquiry if only one inquiry
+        #  is defined
+        self.assertRaises(ValueError, licence.createUrbanEvent, "enquete-publique")
         # after adding a second Inquiry...
         self._addInquiry()
         # ... we can add a supplementary UrbanEventInquiry
-        createObject("UrbanEventInquiry", "enquete-publique", licence)
+        licence.createUrbanEvent("enquete-publique")
         self.assertEquals(len(licence.getUrbanEventInquiries()), 2)
 
     def testUrbanEventInquiryGetLinkedInquiry(self):
@@ -88,9 +91,7 @@ class TestBuildLicenceInquiries(unittest.TestCase):
         # define a second Inquiry so we will be able to add a second
         # UrbanEventInquiry
         inquiry2 = self._addInquiry()
-        urbanEventInquiry2 = createObject(
-            "UrbanEventInquiry", "enquete-publique", licence
-        )
+        urbanEventInquiry2 = licence.createUrbanEvent("enquete-publique")
         self.assertEquals(urbanEventInquiry2.getLinkedInquiry(), inquiry2)
         # and test that getting the first linked inqury still works
         self.assertEquals(urbanEventInquiry1.getLinkedInquiry(), inquiry1)
@@ -100,7 +101,7 @@ class TestBuildLicenceInquiries(unittest.TestCase):
         Test the Inquiry.getUrbanEventLinkedInquiry method
         There is a "1 to 1" link between an Inquiry and an UrbanEventInquiry
         (if exists)
-        An Inquiry can exist alone but an UrbanEventInquiry must be linekd to
+        An Inquiry can exist alone but an UrbanEventInquiry must be linked to
         an existing Inquiry
         """
         licence = self.licence
@@ -112,16 +113,12 @@ class TestBuildLicenceInquiries(unittest.TestCase):
         # maybe no UrbanEventInquiry is linked
         self.assertEquals(inquiry1.getLinkedUrbanEventInquiry(), None)
         # now we can create an UrbanEventInquiry
-        urbanEventInquiry1 = createObject(
-            "UrbanEventInquiry", "enquete-publique", licence
-        )
+        urbanEventInquiry1 = licence.createUrbanEvent("enquete-publique")
         self.assertEquals(inquiry1.getLinkedUrbanEventInquiry(), urbanEventInquiry1)
         # define a second Inquiry so we will be able to add a second
         # UrbanEventInquiry
         inquiry2 = self._addInquiry()
-        urbanEventInquiry2 = createObject(
-            "UrbanEventInquiry", "enquete-publique", licence
-        )
+        urbanEventInquiry2 = licence.createUrbanEvent("enquete-publique")
         self.assertEquals(inquiry2.getLinkedUrbanEventInquiry(), urbanEventInquiry2)
         # and test that getting the first linked inqury still works
         self.assertEquals(inquiry1.getLinkedUrbanEventInquiry(), urbanEventInquiry1)
@@ -136,9 +133,7 @@ class TestBuildLicenceInquiries(unittest.TestCase):
         licence = self.licence
         # now test next inquiries
         inquiry2 = self._addInquiry()
-        urbanEventInquiry2 = createObject(
-            "UrbanEventInquiry", "enquete-publique", licence
-        )
+        urbanEventInquiry2 = licence.createUrbanEvent("enquete-publique")
         # we can not delete the inquiry2 as urbanEventInquiry2 exists
         self.assertRaises(BeforeDeleteException, licence.manage_delObjects, inquiry2.id)
         # if we delete urbanEventInquiry2...
@@ -155,13 +150,9 @@ class TestBuildLicenceInquiries(unittest.TestCase):
         # add 3 inquiries and 3 linked UrbanEventInquiries
         urbanEventInquiry1 = licence.objectValues("UrbanEventInquiry")[0]
         self._addInquiry()
-        urbanEventInquiry2 = createObject(
-            "UrbanEventInquiry", "enquete-publique", licence
-        )
+        urbanEventInquiry2 = licence.createUrbanEvent("enquete-publique")
         self._addInquiry()
-        urbanEventInquiry3 = createObject(
-            "UrbanEventInquiry", "enquete-publique", licence
-        )
+        urbanEventInquiry3 = licence.createUrbanEvent("enquete-publique")
         # we cannot not remove an UrbanEventInquiry if it is not the last
         self.assertRaises(
             BeforeDeleteException, licence.manage_delObjects, urbanEventInquiry2.id
@@ -173,3 +164,59 @@ class TestBuildLicenceInquiries(unittest.TestCase):
         api.content.delete(urbanEventInquiry3)
         api.content.delete(urbanEventInquiry2)
         api.content.delete(urbanEventInquiry1)
+
+    def test_copy_proprietary_to_claimant(self):
+
+        licence = self.licence
+        urbaneventiniquiry1 = licence.objectValues("UrbanEventInquiry")[0]
+        recipient_cadastre1 = {}
+        recipient_cadastre1["id"] = "recipient_cadastre1_id"
+        recipient_cadastre1["name"] = "Dujardin"
+        recipient_cadastre1["firstname"] = "Jan"
+        recipient_cadastre1["street"] = "Rue du Moulin"
+        recipient_cadastre1["number"] = "666"
+        recipient_cadastre1["city"] = "Bruxelles"
+        recipient_cadastre1["zipcode"] = "1000"
+        recipient_id = urbaneventiniquiry1.invokeFactory(
+            "RecipientCadastre", **recipient_cadastre1
+        )
+        recipient = getattr(urbaneventiniquiry1, recipient_id)
+
+        recipient.restrictedTraverse("copy_recipient_to_claimant")()
+
+        # testing if claimant exists and is created from recipient attributes
+        self.assertTrue(hasattr(urbaneventiniquiry1, "claimant_recipient_cadastre1_id"))
+        claimant = urbaneventiniquiry1.claimant_recipient_cadastre1_id
+        recipient = urbaneventiniquiry1.recipient_cadastre1_id
+        self.assertEquals(recipient.name, claimant.name1)
+        self.assertEquals(recipient.firstname, claimant.name2)
+        self.assertEquals(recipient.street, claimant.street)
+        self.assertEquals(recipient.number, claimant.number)
+        self.assertEquals(recipient.city, claimant.city)
+        self.assertEquals(recipient.zipcode, claimant.zipcode)
+
+
+class TestCODTInquiries(BrowserTestCase):
+
+    layer = URBAN_TESTS_LICENCES
+
+    def setUp(self):
+        self.portal = self.layer["portal"]
+        self.urban = self.portal.urban
+        default_user = self.layer.default_user
+        default_password = self.layer.default_password
+        self.browser = Browser(self.portal)
+        self.browserLogin(default_user, default_password)
+        if not getRequest():
+            setRequest(self.portal.REQUEST)
+
+    def testInquiryAddButtonIsVisible(self):
+        licence_types = [
+            "codt_integratedlicences",
+            "codt_uniquelicences",
+            "codt_buildlicences",
+        ]
+        for licence_type in licence_types:
+            licence = getattr(self.urban, licence_type).objectValues()[1]
+            self.browser.open(licence.absolute_url())
+            self.assertIn("Ajouter une enquête supplémentaire", self.browser.contents)

--- a/src/Products/urban/tests/test_UrbanEvent.py
+++ b/src/Products/urban/tests/test_UrbanEvent.py
@@ -1,17 +1,17 @@
 # -*- coding: utf-8 -*-
 
-from Products.urban.testing import URBAN_TESTS_LICENCES
+from Products.urban import utils
 from Products.urban.testing import URBAN_TESTS_CONFIG
 from Products.urban.testing import URBAN_TESTS_CONFIG_FUNCTIONAL
+from Products.urban.testing import URBAN_TESTS_LICENCES
 from Products.urban.tests.helpers import BrowserTestCase
 from Products.urban.tests.helpers import SchemaFieldsTestCase
-from Products.urban import utils
-
 from plone import api
 from plone.app.testing import login
 from plone.testing.z2 import Browser
-
 from zope.event import notify
+from zope.globalrequest import getRequest
+from zope.globalrequest import setRequest
 from zope.lifecycleevent import ObjectCreatedEvent
 
 import transaction
@@ -24,9 +24,12 @@ class TestUrbanEvent(unittest.TestCase):
 
     def setUp(self):
         portal = self.layer["portal"]
+        self.portal = portal
         self.portal_urban = portal.portal_urban
         self.licence = portal.urban.buildlicences.objectValues("BuildLicence")[0]
         login(portal, "urbaneditor")
+        if not getRequest():
+            setRequest(self.portal.REQUEST)
 
     def testAutomaticallyGenerateSingletonDocument(self):
 
@@ -46,6 +49,18 @@ class TestUrbanEvent(unittest.TestCase):
         notify(ObjectCreatedEvent(createdEvent))
         # if the urbanEvent can generate more than one document, no document should be generated at all
         self.failUnless(len(createdEvent.objectValues()) == 0)
+
+    def test_disable_EventConfig(self):
+        login(self.portal, "urbanmanager")
+        cfg = self.licence.getLicenceConfig()
+        licenceview = self.licence.restrictedTraverse("buildlicenceview")
+        allowed_events = licenceview.getAllowedEventConfigs()
+        event_config = allowed_events[0]
+        self.assertIn(event_config, licenceview.getAllowedEventConfigs())
+        api.content.transition(event_config, "disable")
+        self.assertNotIn(event_config, licenceview.getAllowedEventConfigs())
+        api.content.transition(event_config, "enable")
+        self.assertIn(event_config, licenceview.getAllowedEventConfigs())
 
 
 class TestUrbanEventInstance(SchemaFieldsTestCase):
@@ -67,16 +82,20 @@ class TestUrbanEventInstance(SchemaFieldsTestCase):
 
         # create a test UrbanEvent in test_buildlicence
         catalog = api.portal.get_tool("portal_catalog")
-        event_type_brain = catalog(portal_type="UrbanEventType", id="prorogation")[0]
+        event_type_brain = catalog(portal_type="EventConfig", id="prorogation")[0]
         self.event_type = event_type_brain.getObject()
         self.urban_event = self.licence.createUrbanEvent(self.event_type)
         transaction.commit()
 
         self.browser = Browser(self.portal)
         self.browserLogin(default_user, default_password)
+        if not getRequest():
+            setRequest(self.portal.REQUEST)
 
     def tearDown(self):
         with api.env.adopt_roles(["Manager"]):
+            if not getRequest():
+                setRequest(self.portal.REQUEST)
             api.content.delete(self.licence)
         transaction.commit()
 
@@ -145,8 +164,12 @@ class TestUrbanEventInquiryView(BrowserTestCase):
 
         self.browser = Browser(self.portal)
         self.browserLogin(default_user, default_password)
+        if not getRequest():
+            setRequest(self.portal.REQUEST)
 
     def _create_test_licence_with_inquiry(self, portal_type):
+        if not getRequest():
+            setRequest(self.portal.REQUEST)
         licence_folder = utils.getLicenceFolder(portal_type)
         testlicence_id = "test_{}".format(portal_type.lower())
         licence_folder.invokeFactory(portal_type, id=testlicence_id)

--- a/src/Products/urban/tests/test_contactEmailExport.py
+++ b/src/Products/urban/tests/test_contactEmailExport.py
@@ -1,11 +1,12 @@
 # -*- coding: utf-8 -*-
+from Products.urban import testing
+
 import unittest
-from Products.urban.testing import URBAN_TESTS_PROFILE_FUNCTIONAL
 
 
 class TestBuildLicence(unittest.TestCase):
 
-    layer = URBAN_TESTS_PROFILE_FUNCTIONAL
+    layer = testing.URBAN_TESTS_CONFIG
 
     def setUp(self):
         portal = self.layer["portal"]
@@ -15,7 +16,7 @@ class TestBuildLicence(unittest.TestCase):
     def testGetNotariesEmail(self):
         notaries = self.portal.urban.notaries
         view = notaries.restrictedTraverse("getemails")
-        expected_email = "NotaryName1 NotarySurname1 <maitre.duchnoque@notaire.be>"
+        expected_email = "NotaryName1 NotarySurname1 <maitre.duchnoque@notaire.be>; André Sanfrapper <maitre.andre@notaire.be>"
         generated_email = view.getEmails()
         self.assertEqual(expected_email, generated_email)
 

--- a/src/Products/urban/tests/test_keyEvent.py
+++ b/src/Products/urban/tests/test_keyEvent.py
@@ -2,13 +2,14 @@
 
 from Products.urban.testing import URBAN_TESTS_CONFIG
 from Products.urban.tests.helpers import BrowserTestCase
-
 from plone import api
 from plone.app.testing import login
 from plone.testing.z2 import Browser
 from zope.event import notify
 from zope.lifecycleevent import ObjectModifiedEvent
 from zope.lifecycleevent import ObjectRemovedEvent
+from zope.globalrequest import getRequest
+from zope.globalrequest import setRequest
 
 import transaction
 
@@ -32,7 +33,7 @@ class TestKeyEvent(BrowserTestCase):
         # create a test UrbanEvent in test_buildlicence
         self.catalog = api.portal.get_tool("portal_catalog")
         event_type_brain = self.catalog(
-            portal_type="UrbanEventType", id="accuse-de-reception"
+            portal_type="EventConfig", id="accuse-de-reception"
         )[0]
         self.event_type = event_type_brain.getObject()
         self.urban_event = self.licence.createUrbanEvent(self.event_type)
@@ -40,9 +41,13 @@ class TestKeyEvent(BrowserTestCase):
 
         self.browser = Browser(self.portal)
         self.browserLogin(default_user, default_password)
+        if not getRequest():
+            setRequest(self.portal.REQUEST)
 
     def tearDown(self):
         with api.env.adopt_roles(["Manager"]):
+            if not getRequest():
+                setRequest(self.portal.REQUEST)
             api.content.delete(self.licence)
         transaction.commit()
 
@@ -73,9 +78,9 @@ class TestKeyEvent(BrowserTestCase):
         catalog = self.catalog
 
         old_index_value = catalog(portal_type="BuildLicence")[0].last_key_event
-        event_type = self.catalog(
-            portal_type="UrbanEventType", id="depot-de-la-demande"
-        )[0].getObject()
+        event_type = self.catalog(portal_type="EventConfig", id="depot-de-la-demande")[
+            0
+        ].getObject()
         buildlicence.createUrbanEvent(event_type)
         urban_event = buildlicence.objectValues()[1]
         event = ObjectModifiedEvent(urban_event)
@@ -120,8 +125,8 @@ class TestKeyEvent(BrowserTestCase):
         self.assertTrue(date not in self.browser.contents)
 
         old_fields = self.event_type.getActivatedFields()
-        self.event_type.setActivatedFields(old_fields + ("decisionDate",))
-        self.event_type.setKeyDates(("decisionDate",))
+        self.event_type.activatedFields = old_fields + ("decisionDate",)
+        self.event_type.keyDates = ("decisionDate",)
         self.urban_event.setDecisionDate(date)
         transaction.commit()
 
@@ -143,6 +148,7 @@ class TestKeyEvent(BrowserTestCase):
         self.assertTrue(date_1 not in self.browser.contents)
         self.assertTrue(date_2 not in self.browser.contents)
 
+        setRequest(self.portal.REQUEST)
         buildlicence.createUrbanEvent(self.event_type)
         urban_event = buildlicence.objectValues()[-1]
         urban_event.setEventDate(date_1)

--- a/src/Products/urban/tests/test_urbanconfig.py
+++ b/src/Products/urban/tests/test_urbanconfig.py
@@ -1,12 +1,16 @@
 # -*- coding: utf-8 -*-
 
+from Products.urban import URBAN_TYPES
 from Products.urban.testing import URBAN_TESTS_CONFIG
 from Products.urban.testing import URBAN_TESTS_CONFIG_FUNCTIONAL
 from Products.urban.tests.helpers import BrowserTestCase
-
 from plone import api
 from plone.app.testing import login
 from plone.testing.z2 import Browser
+from zope.event import notify
+from zope.globalrequest import getRequest
+from zope.globalrequest import setRequest
+from zope.lifecycleevent import ObjectCreatedEvent
 
 import re
 import transaction
@@ -15,6 +19,7 @@ import transaction
 class TestUrbanConfig(BrowserTestCase):
 
     layer = URBAN_TESTS_CONFIG
+    maxDiff = 999
 
     def setUp(self):
         portal = self.layer["portal"]
@@ -27,6 +32,8 @@ class TestUrbanConfig(BrowserTestCase):
         self.browser = Browser(self.portal)
         self.browserLogin(default_user, default_password)
         self.browser.handleErrors = False
+        if not getRequest():
+            setRequest(self.portal.REQUEST)
 
     def test_urbanconfig_view_display(self):
         """
@@ -81,6 +88,8 @@ class TestUrbanConfigFunctional(BrowserTestCase):
         self.browser = Browser(self.portal)
         self.browserLogin(default_user, default_password)
         self.browser.handleErrors = False
+        if not getRequest():
+            setRequest(self.portal.REQUEST)
 
     def test_foldermanagers_view_sorting(self):
         fm_folder = self.portal.portal_urban.foldermanagers
@@ -130,3 +139,16 @@ class TestUrbanConfigFunctional(BrowserTestCase):
         )
         regex2 = regex2.replace("(", "\(").replace(")", "\)")  # escape parenthesis
         self.assertTrue(re.search(regex2, self.browser.contents, flags=re.DOTALL))
+
+    def test_foldermanagers_default_manageablelicences(self):
+        fm_folder = self.portal.portal_urban.foldermanagers
+        with api.env.adopt_roles(["Manager"]):
+            foldermanagertest = fm_folder.invokeFactory(
+                "FolderManager",
+                id="foldermanagertest",
+                name1="Dujardin",
+                name2="Jan",
+                grade="agent-technique",
+            )
+            foldermanagertest = getattr(fm_folder, foldermanagertest)
+            self.assertEqual(foldermanagertest.manageableLicences, tuple(URBAN_TYPES))


### PR DESCRIPTION

    Fix transition buttons
    Avoid a traceback if an UID was not found for inquiry cron [URB-2721]
    Do not escape z3c.table title columns.
    Fix actions display.
    Fix render of columns with escape parameter
    Fix `hidealloption` and `hide_category` parameters for dashboard collections
    Adapt cache key to be aware of the current category
    Fix an issue when we switch category and the type widget value was not updated
    Fix zcml for migrations
    Explicitly include `urban.restapi` zcml dependency
    SUP-31043. Add option to POST endpoint when creating a licence to disable check ref format (#178)
    SUP-30310 cadastral historic memory error (#176)
    * SUP-30310. Use json loads rather than ast.eval to avoid memory errors
    * Add collective.exportimport to urban dependencies.
    * Update changelog Fix encoding error (#180)
    * Fix encoding error [URB-2805]
    * Provide getLastAcknowledgment method for all urbancertificates [SUP-30852] URB-2575. Fix Select2 view display (#182) URB-2824. Add Couple to Preliminary Notice and Project Meeting (#181)
    * URB-2824. Add Couple to Preliminary Notice
    * URB-2824. Add Couple to Project Meeting SUP-27165. Change NN field position (#179)
    * SUP-27165. Change NN field position
    * SUP-27165. Remove nationalRegister mention in finalizingSchema URB-2575. Fix different type of vocabulary (#183)
    * URB-2575. Fix different type of vocabulary URB-2823: Update translation files URB-2823: Cleanup workflow definitions URB-2823: Add missing translations URB-2823: Add missing translations for workflow URB-2823: Add missing attributes for translations on workflow URB-2823: Add missing translations URB-2830. Fix inspection title (#187)
    * URB-2830. Fix inspection title Fix an issue with some urban instances with lists that contains empty strings or `None` [URB-2575] Add an external method to set profile version for Products.urban [URB-2835] URB-2696 Add parameter to autocomplete to search with exact match (#171) SUP-31554: Avoid errors on inexpected values on licences and log them URB-2575: Fix translation for road adaptation vocabulary values URB-2835: Avoid an error if a vocabulary does not exist, this can happen when multiple upgrade steps interract with vocabularies SUP-31682: Fix an issue with autocomplete view results format that was generating javascript errors URB-2864: Hide old document generation links viewlet SUP-31898. Fix select2 widget on folder manager (#191) SUP-31898: Fix opinion schedules assigned user column URB-2872: Fix UnicodeDecodeError on getFolderManagersSignaletic(withGrade=True) (#192) URB-2873: Avoid an error if a task was not correctly removed from catalog SUP-31983: Fix icon tag in table (#193) URB-2868, URB-2870: Fix new urban instance install (#194)
    * URB-2868. URB-2870. Fix new urban instance install
    * URB-2870. Fix facet config xml
    * URB-2868. Fix urban extra installation
    * Fix changelog
    * Update profile description URB-2868, URB-2870: Fix facet config xml new urban instance install (#195) URB-2855: Fix test initialization Reduce logging for sql queries URB-2855: Ensure that request is available on every layer, this is required by collective.fingerpointing URB-2855: Fix tests SUP-32338: Avoid an error if a vocabulary value was removed, instead log the removed value and display the key to the user URB-2855: Update changelog URB-2855: Fix tests URB-2903: Improve performances for add views MURBMSGA-37. URB-2696. Fix street search (#199)
    * MURBMSGA-37. Fix serializer to include disable street in uid resolver
    * URB-2696. Fix street search to include disable street SUP-33308: Adapt opinion request worklflow to bypass guard check for managers SUP-32215: Provide getFirstAcknowledgment method (#198) Add `fix_schedule_config` external method ta fix class of condition objects Fix an issue with Products.ZCTextIndex that was interpreting `NOT` as token instead of a word for notary letter references URB-2948. Fix street number in unicode (#202) URB-2869: Fix integrated licence creation by using unicode for regional authorities vocabulary (#196) URB-2831: Remove reference FD field from preliminary notice (#188) SUP-27127: Add prosecution ref and ticket ref to Inspection (#186) SUP-33538: Validate CSV before claimant import (#203) URB-2827: Add stop worksite option to inspection report (#184) SUP-34226: Fix an issue with Postgis `ST_MemUnion` by using `ST_Union` instead that also improve performances URB-2515: Underline close due dates (#200)

[URB-2721]: https://support-imio.atlassian.net/browse/URB-2721?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[URB-2805]: https://support-imio.atlassian.net/browse/URB-2805?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SUP-30852]: https://support-imio.atlassian.net/browse/SUP-30852?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[URB-2575]: https://support-imio.atlassian.net/browse/URB-2575?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ