### PR TITLE
fix:return existing config folder instead of None

### DIFF
--- a/src/Products/urban/setuphandlers.py
+++ b/src/Products/urban/setuphandlers.py
@@ -1977,7 +1977,7 @@ def add_urban_config_folder(urban_type, tool=None, site=None):
 
     licenceConfigId = urban_type.lower()
     if hasattr(aq_base(tool), licenceConfigId):
-        return None
+        return getattr(tool, licenceConfigId)
 
     # Add folder
     config_folder_id = tool.invokeFactory(


### PR DESCRIPTION
Cette PR corrige add_urban_config_folder qui retournait None si le dossier existait déjà, causant une erreur dans add_schedule → createScheduleConfig durant la migration.
