### PR TITLE
URB-3438: Fix Notice Parcel parsing

### DIFF
--- a/src/Products/urban/notice/parcel.py
+++ b/src/Products/urban/notice/parcel.py
@@ -54,11 +54,11 @@ class NoticeParcel(NoticeElement):
 
     @property
     def radical(self):
-        return self._get_data("radical")
+        return self._get_data("radical").lstrip("0")
 
     @property
     def bis(self):
-        return self._get_data("bisTier")
+        return self._get_data("bisTer").lstrip("0")
 
     @property
     def exposant(self):
@@ -66,7 +66,7 @@ class NoticeParcel(NoticeElement):
 
     @property
     def puissance(self):
-        return self._get_data("power")
+        return self._get_data("power").lstrip("0")
 
     @property
     def partie(self):


### PR DESCRIPTION
- remove leading zeros in parcel sub-elements ("0042" => "42")
- "bisTer" typo