### PR TITLE
URB-3437: Skip failed notifications during Notice fresh processing

### DIFF
--- a/src/Products/urban/browser/cron/notice.py
+++ b/src/Products/urban/browser/cron/notice.py
@@ -94,6 +94,9 @@ class ImportFromNoticeView(BrowserView):
             if notif_last_status_date <= self.last_import_date:
                 continue
 
+            if notice_id in self.failed_notifications:
+                continue
+
             if notice_id in self.already_handled_notifications:
                 continue
             self.already_handled_notifications.append(notice_id)


### PR DESCRIPTION
Before that, notifications returned from the WS, that are also in `failed_notifications`, would be processed as fresh.
So, they would be added at every cycle in `failed_notifications`.