### PR TITLE
Notice documents

### DIFF
--- a/news/PR-509.feature
+++ b/news/PR-509.feature
@@ -1,0 +1,6 @@
+Show form data sent to Notice
+Refactor Notice responses with forms
+Add Notice folder manager (for new installations)
+Expand REST API to include Notice data
+Rename college decision in Notice forms
+[daggelpop]

--- a/news/URB-3311.feature
+++ b/news/URB-3311.feature
@@ -1,0 +1,2 @@
+Include decision in Summary Report response
+[daggelpop]

--- a/news/URB-3514.feature
+++ b/news/URB-3514.feature
@@ -1,0 +1,4 @@
+Add Notice response to send documents
+Add vocabulary of licence documents available to send to Notice
+Refactor LicenceDocumentsVocabulary for easier subclassing
+[daggelpop]

--- a/src/Products/urban/UrbanEvent.py
+++ b/src/Products/urban/UrbanEvent.py
@@ -35,6 +35,7 @@ from Products.urban.UrbanVocabularyTerm import UrbanVocabulary
 from Products.urban.config import *
 from Products.urban.interfaces import IUrbanDoc
 from Products.urban.notice import NoticeOutgoingDecisionNotification
+from Products.urban.notice import NoticeOutgoingFileNotification
 from Products.urban.notice import NoticeOutgoingPublicSurveyOpinionNotification
 from Products.urban.notice import NoticeOutgoingSummaryReportDecisionNotification
 from Products.urban.notice import NoticeOutgoingSummaryReportDatesNotification
@@ -1011,6 +1012,14 @@ class UrbanEvent(OrderedBaseFolder, BrowserDefaultMixin):
             "user": api.user.get_current().id,
         }
         annotations[key] = dates
+    def transfer_notice_file(self, notice_id, file_path):
+        notification = NoticeOutgoingFileNotification(file_path)
+        service = WebserviceNotice()
+        result = service.post_notification_document(
+            notice_id,
+            notification.serialize(),
+        )
+        return result
 
     def store_reception_date(self, date=None):
         annotations = IAnnotations(self)

--- a/src/Products/urban/UrbanEvent.py
+++ b/src/Products/urban/UrbanEvent.py
@@ -1003,15 +1003,6 @@ class UrbanEvent(OrderedBaseFolder, BrowserDefaultMixin):
     def get_parent_licence(self):
         return aq_parent(self)
 
-    def store_transmit_date(self, event_type, date=None):
-        annotations = IAnnotations(self)
-        key = "notice_transmit_dates"
-        dates = annotations.get(key, OrderedDict())
-        dates[event_type] = {
-            "date": date if date else datetime.datetime.now(),
-            "user": api.user.get_current().id,
-        }
-        annotations[key] = dates
     def transfer_notice_file(self, notice_id, file_path):
         notification = NoticeOutgoingFileNotification(file_path)
         service = WebserviceNotice()
@@ -1033,13 +1024,6 @@ class UrbanEvent(OrderedBaseFolder, BrowserDefaultMixin):
             notification.notice_id("DEMANDE_EP"),
             notification.serialize(),
         )
-
-        reception_date_str = result["body"]["result"][
-            "receptionDate"
-        ]  # TODO: handle exception in result (KeyError, no "body")
-        reception_date = datetime.datetime.strptime(reception_date_str[:19], "%Y-%m-%dT%H:%M:%S")
-        self.store_transmit_date("transfer_opinion", reception_date)
-
         return result
 
     def transfer_decision(self, college_decision):
@@ -1053,13 +1037,6 @@ class UrbanEvent(OrderedBaseFolder, BrowserDefaultMixin):
             notification.notice_id("NOTIFICATION_RS"),
             notification.serialize(),
         )
-
-        reception_date_str = result["body"]["result"][
-            "receptionDate"
-        ]  # TODO: handle exception in result (KeyError, no "body")
-        reception_date = datetime.datetime.strptime(reception_date_str[:19], "%Y-%m-%dT%H:%M:%S")
-        self.store_transmit_date("transfer_decision", reception_date)
-
         return result
 
     def transfer_decision_display(self):
@@ -1085,13 +1062,6 @@ class UrbanEvent(OrderedBaseFolder, BrowserDefaultMixin):
                     licence.getReference()
                 )
             )
-
-        reception_date_str = result["body"]["result"][
-            "receptionDate"
-        ]  # TODO: handle exception in result (KeyError, no "body")
-        reception_date = datetime.datetime.strptime(reception_date_str[:19], "%Y-%m-%dT%H:%M:%S")
-        self.store_transmit_date("transfer_decision_display", reception_date)
-
         return result
 
 

--- a/src/Products/urban/UrbanEvent.py
+++ b/src/Products/urban/UrbanEvent.py
@@ -1033,10 +1033,10 @@ class UrbanEvent(OrderedBaseFolder, BrowserDefaultMixin):
 
         return result
 
-    def transfer_decision(self, college_opinion):
+    def transfer_decision(self, college_decision):
 
-        # store college opinion for later use (final response, transfer decision display)
-        self._notice_opinion = college_opinion
+        # store college decision for later use (final response, transfer decision display)
+        self._notice_decision = college_decision
 
         notification = NoticeOutgoingSummaryReportDecisionNotification(self)
         service = WebserviceNotice()

--- a/src/Products/urban/UrbanEventNotice.py
+++ b/src/Products/urban/UrbanEventNotice.py
@@ -72,23 +72,6 @@ class UrbanEventNotice(UrbanEvent, BrowserDefaultMixin):
             notice_id,
             notification.serialize(),
         )
-        if result["error"] is True:
-            if result["error_type"] == "WRONG_STATUS":
-                # This can happen if there was an error with the WS
-                existing_notification = service.get_notification(notice_id)
-                if existing_notification.status == u"TERMINE":
-                    self.store_transmit_date(
-                        "transfer_folder_to_dpa",
-                        date=existing_notification.status_date,
-                    )
-                    return {"error": False}
-                return result
-            else:
-                return result
-        reception_date_str = result["body"]["result"]["receptionDate"]  # TODO: handle exception in result (KeyError, no "body")
-        reception_date = datetime.datetime.strptime(reception_date_str[:19], "%Y-%m-%dT%H:%M:%S")
-        self.store_transmit_date("transfer_folder_to_dpa", reception_date)
-
         return result
 
     # Manually created methods

--- a/src/Products/urban/browser/configure.zcml
+++ b/src/Products/urban/browser/configure.zcml
@@ -245,6 +245,14 @@
   />
 
   <browser:page
+     for="Products.urban.interfaces.IUrbanEvent"
+     name="noticeformdatatextview"
+     class=".longtextview.NoticeFormDataTextView"
+     template="templates/longtextview.pt"
+     permission="zope2.View"
+  />
+
+  <browser:page
      for="Products.urban.interfaces.IGenericLicence"
      name="longtextview"
      class=".longtextview.LongTextView"

--- a/src/Products/urban/browser/configure.zcml
+++ b/src/Products/urban/browser/configure.zcml
@@ -506,25 +506,9 @@
   />
 
   <browser:page
-     for="Products.urban.interfaces.IUrbanEvent"
-     name="transfer_folder_to_dpa"
-     class=".urbaneventviews.UrbanEventNoticeActionsView"
-     attribute="transfer_folder_to_dpa"
-     permission="zope2.View"
-  />
-
-  <browser:page
      for="*"
      name="can_transfer_dates"
      class=".urbaneventviews.CanTransferDatesView"
-     permission="zope2.View"
-  />
-
-  <browser:page
-     for="Products.urban.interfaces.IUrbanEvent"
-     name="transfer_dates"
-     class=".urbaneventviews.UrbanEventNoticeActionsView"
-     attribute="transfer_dates"
      permission="zope2.View"
   />
 
@@ -556,16 +540,23 @@
      permission="zope2.View"
   />
 
+  <!--  NOTICE forms -->
+
   <browser:page
      for="Products.urban.interfaces.IUrbanEvent"
-     name="transfer_decision_display"
-     class=".urbaneventviews.UrbanEventNoticeActionsView"
-     attribute="transfer_decision_display"
+     layer="Products.urban.interfaces.IProductUrbanLayer"
+     name="transfer_folder_to_dpa_form"
+     class=".notice_forms.TransferFolderToDPAActionWrapper"
      permission="zope2.View"
-  />
+     />
 
-
-  <!--  NOTICE forms -->
+  <browser:page
+     for="Products.urban.interfaces.IUrbanEvent"
+     layer="Products.urban.interfaces.IProductUrbanLayer"
+     name="transfer_dates_form"
+     class=".notice_forms.TransferDatesActionWrapper"
+     permission="zope2.View"
+     />
 
   <browser:page
      for="Products.urban.interfaces.IUrbanEvent"
@@ -588,6 +579,14 @@
      layer="Products.urban.interfaces.IProductUrbanLayer"
      name="transfer_decision_form"
      class=".notice_forms.TransferDecisionActionWrapper"
+     permission="zope2.View"
+     />
+
+  <browser:page
+     for="Products.urban.interfaces.IUrbanEvent"
+     layer="Products.urban.interfaces.IProductUrbanLayer"
+     name="transfer_decision_display_form"
+     class=".notice_forms.TransferDecisionDisplayActionWrapper"
      permission="zope2.View"
      />
 

--- a/src/Products/urban/browser/longtextview.py
+++ b/src/Products/urban/browser/longtextview.py
@@ -2,6 +2,7 @@ from Acquisition import aq_inner
 from Products.CMFCore.utils import getToolByName
 from Products.CMFPlone import PloneMessageFactory as _
 from Products.Five import BrowserView
+from zope.annotation.interfaces import IAnnotations
 from zope.i18n import translate
 
 
@@ -77,3 +78,45 @@ class PmSummaryTextView(BrowserView):
         summary = "<br /><br />".join(summary)
 
         return summary
+
+
+class NoticeFormDataTextView(BrowserView):
+    def __init__(self, context, request):
+        super(NoticeFormDataTextView, self).__init__(context, request)
+        self.action_code = self.request.get("action_code", "")
+        if not self.action_code:
+            plone_utils = getToolByName(self.context, "plone_utils")
+            plone_utils.addPortalMessage(_("Nothing to show !!!"), type="error")
+
+    def getFieldText(self):
+        """
+        Returns an HTML structure of the form data sent with a particular action code.
+        This data comes from a dict stored as annotation on the event.
+        """
+
+        annotations = IAnnotations(self.context)
+        transmits = annotations.get("notice_transmit_dates", {})
+        action_data = transmits.get(self.action_code, {})
+        field_values = action_data.get("field_values", {})
+
+        if not field_values:
+            return _("Nothing to show !!!")
+
+        html_blocks = []
+        for field_id, field_value in field_values.items():
+            field_title = translate(
+                field_id,
+                context=self.request,
+            )
+            html_blocks.append(u"<h2>{}</h2>".format(field_title))
+            if field_id in ("college_opinion", "college_decision"):
+                html_blocks.append(u"<div>{}</div>".format(field_value))
+            elif field_id == "documents":
+                points = [
+                    u"<li>{}</li>".format(document["title"]) for document in field_value
+                ]
+                html_blocks.append(u"<ul>{}</ul>".format("\n".join(points)))
+                if not field_value:
+                    html_blocks.append(u"<div>{}</div>".format(_("content_none")))
+
+        return u"<br />\n".join(html_blocks)

--- a/src/Products/urban/browser/notice_forms.py
+++ b/src/Products/urban/browser/notice_forms.py
@@ -1,10 +1,13 @@
 # -*- coding: utf-8 -*-
+from collections import OrderedDict
+from datetime import datetime
 from z3c.form import button
 from z3c.form import field
 from z3c.form.browser.checkbox import CheckBoxFieldWidget
 from z3c.form.browser.radio import RadioFieldWidget
 from z3c.form.form import Form
 from zope import schema
+from zope.annotation.interfaces import IAnnotations
 from zope.interface import Interface
 from zope.schema.vocabulary import SimpleTerm
 from zope.schema.vocabulary import SimpleVocabulary
@@ -13,13 +16,34 @@ from Products.statusmessages.interfaces import IStatusMessage
 from Products.urban import UrbanMessage as _
 from Products.urban.notice.response import clean_accents
 from Products.urban.utils import get_ws_meetingitem_infos
-from imio.pm.wsclient.interfaces import IRedirect
+from plone import api
 from plone.app.textfield import RichText
 from plone.app.textfield.value import RichTextValue
 from plone.z3cform.layout import wrap_form
 
 
+class ITransferBaseActionForm(Interface):
+    file_paths = schema.List(
+        title=_(u"Licence Files"),
+        description=_(
+            u"Select files from this event or the parent licence you want to send (PDF, XLSX or PNG)."
+        ),
+        required=False,
+        value_type=schema.Choice(
+            vocabulary="urban.vocabularies.valid_notice_licence_documents"
+        ),
+    )
+
+
 class NoticeResponseActionForm(Form):
+    _finishedSent = False
+    _displayErrorsInOverlay = False
+    ignoreContext = True
+
+    # FIELDS TO BE OVERRIDDEN IN SUBCLASSES
+    response_id_code = None
+    success_message = None
+
     def _fetch_iadelib_opinion(self, field_to_fill):
         motivation = self._get_iadelib_field(self.context, "motivation") or ""
         decision = self._get_iadelib_field(self.context, "decision") or ""
@@ -46,8 +70,117 @@ class NoticeResponseActionForm(Form):
             field = linked_item[field_name]
             return field.get("data", "") if isinstance(field, dict) else field
 
+    def transfer_response(self, data):
+        raise NotImplementedError()
 
-class ITransferTicketActionForm(Interface):
+    def store_sent_data(self, reception_date=None, field_values=None):
+        annotations = IAnnotations(self.context)
+        key = "notice_transmit_dates"
+        transmits = annotations.get(key, OrderedDict())
+        transmits[self.action_code] = {
+            "date": reception_date if reception_date else datetime.now(),
+            "user": api.user.get_current().id,
+            "field_values": field_values,
+        }
+        annotations[key] = transmits
+
+    def updateWidgets(self):
+        super(NoticeResponseActionForm, self).updateWidgets()
+
+        self.widgets["file_paths"].value = []
+
+    @button.buttonAndHandler(_("Send"), name="send_response")
+    def handleSendResponse(self, action):
+        data, errors = self.extractData()
+        if errors:
+            self.status = self.formErrorsMessage
+            return
+
+        notice_id = self.context.aq_parent.get_notice_id(self.response_id_code)
+        if not notice_id:
+            raise ValueError(
+                _(
+                    u"Can't send response to event '{}': no Notice ID found for '{}'".format(
+                        self.context.absolute_url(), self.response_id_code
+                    )
+                )
+            )
+
+        self.field_values_to_store = {}
+        response_result = self.transfer_response(data)
+        if type(response_result) == dict and response_result.get("error") is True:
+            IStatusMessage(self.request).addStatusMessage(
+                response_result.get("message"), "error"
+            )
+            return
+        else:
+            IStatusMessage(self.request).addStatusMessage(self.success_message, "info")
+
+        file_paths = data.get("file_paths", [])
+        for file_path in file_paths:
+            file_obj = api.content.get(path=file_path)
+            if not file_obj:
+                IStatusMessage(self.request).addStatusMessage(
+                    _("One file is not available anymore, and couldn't be sent."),
+                    "error",
+                )
+                continue
+            document_title = file_obj.Title().decode("utf8")
+            sent_documents = self.field_values_to_store.get("documents", [])
+            sent_documents.append(
+                {
+                    "path": file_path,
+                    "title": document_title,
+                }
+            )
+            self.field_values_to_store["documents"] = sent_documents
+
+            file_result = self.context.transfer_notice_file(notice_id, file_path)
+
+        reception_date_str = response_result["body"]["result"]["receptionDate"]
+        reception_date = datetime.strptime(reception_date_str[:19], "%Y-%m-%dT%H:%M:%S")
+
+        self.store_sent_data(
+            reception_date=reception_date,
+            field_values=self.field_values_to_store,
+        )
+
+        self._finishedSent = True
+
+
+class TransferFolderToDPAActionForm(NoticeResponseActionForm):
+    label = _("Transfer folder to DPA")
+    fields = field.Fields(ITransferBaseActionForm)
+    fields["file_paths"].widgetFactory = CheckBoxFieldWidget
+    response_id_code = "TRANSFERT_DOSSIER"
+    action_code = "transfer_folder_to_dpa"
+    success_message = _(u"The folder transfer to DPA is done.")
+
+    def transfer_response(self, data):
+        result = self.context.transfer_folder_to_dpa()
+        return result
+
+
+TransferFolderToDPAActionWrapper = wrap_form(TransferFolderToDPAActionForm)
+
+
+class TransferDatesActionForm(NoticeResponseActionForm):
+    label = _("Transfer dates to the SPW")
+    fields = field.Fields(ITransferBaseActionForm)
+    fields["file_paths"].widgetFactory = CheckBoxFieldWidget
+    response_id_code = "DEMANDE_EP"
+    action_code = "transfer_dates"
+    success_message = _(u"The transfer of dates is done.")
+
+    def transfer_response(self, data):
+        result = self.context.transfer_dates()
+        return result
+
+
+TransferDatesActionWrapper = wrap_form(TransferDatesActionForm)
+
+
+class ITransferTicketActionForm(ITransferBaseActionForm):
     partial_or_final = schema.Choice(
         title=_(u"Preliminary Opinion"),
         description=_(u"This action cannot be reversed."),
@@ -71,48 +204,27 @@ class ITransferTicketActionForm(Interface):
 class TransferTicketActionForm(NoticeResponseActionForm):
     label = _("Transfer ticket to the SPW")
     fields = field.Fields(ITransferTicketActionForm)
+    fields["file_paths"].widgetFactory = CheckBoxFieldWidget
     fields["partial_or_final"].widgetFactory = RadioFieldWidget
-    _finishedSent = False
-    _displayErrorsInOverlay = False
-    ignoreContext = True
-    @button.buttonAndHandler(_("Send"), name="send_response")
-    def handleSendResponse(self, action):
-        data, errors = self.extractData()
-        if errors:
-            self.status = self.formErrorsMessage
-            return
+    response_id_code = "DEMANDE_EP"
+    action_code = (
+        None  # will be set in self.transfer_response, before it's actually needed
+    )
+    success_message = _(u"The ticket transfer is done.")
 
+    def transfer_response(self, data):
         if data.get("partial_or_final") == "PARTIAL":
-            result = self.context.transfer_ticket()
-
+            self.action_code = "transfer_ticket"
+            return self.context.transfer_ticket()
         if data.get("partial_or_final") == "FINAL":
-            result = self.context.finalize_inquiry_without_opinion()
-
-        if result["error"] is True:
-            IStatusMessage(self.request).addStatusMessage(result["message"], "error")
-        else:
-            IStatusMessage(self.request).addStatusMessage(
-                _(u"The ticket transfer is done."), "info"
-            )
-
-        self._finishedSent = True
-
-    @button.buttonAndHandler(_("Cancel"), name="cancel")
-    def handleCancel(self, action):
-        self._finishedSent = True
-
-    def render(self):
-        if self._finishedSent:
-            IRedirect(self.request).redirect(self.context.absolute_url())
-            return ""
-        return super(TransferTicketActionForm, self).render()
+            self.action_code = "transfer_ticket_final"
+            return self.context.finalize_inquiry_without_opinion()
 
 
 TransferTicketActionWrapper = wrap_form(TransferTicketActionForm)
 
 
-class ITransferOpinionActionForm(Interface):
-
+class ITransferOpinionActionForm(ITransferBaseActionForm):
     college_opinion = RichText(
         title=_(u"College opinion"),
         default=u"<h1>Motivation:</h1>\r\n\r\n<h1>Décision:</h1>\r\n\r\n",
@@ -123,49 +235,27 @@ class ITransferOpinionActionForm(Interface):
 class TransferOpinionActionForm(NoticeResponseActionForm):
     label = _("Transfer opinion to the SPW")
     fields = field.Fields(ITransferOpinionActionForm)
-    _finishedSent = False
-    _displayErrorsInOverlay = False
-    ignoreContext = True
+    fields["file_paths"].widgetFactory = CheckBoxFieldWidget
+    response_id_code = "DEMANDE_EP"
+    action_code = "transfer_opinion"
+    success_message = _(u"The opinion transfer is done.")
+
+    def transfer_response(self, data):
+        college_opinion = data.get("college_opinion", "")
+        output = college_opinion.output if college_opinion else ""
+        self.field_values_to_store["college_opinion"] = output
+        result = self.context.transfer_opinion(output)
+        return result
 
     def updateWidgets(self):
         super(TransferOpinionActionForm, self).updateWidgets()
         self._fetch_iadelib_opinion("college_opinion")
 
-    @button.buttonAndHandler(_("Send"), name="send_response")
-    def handleSendResponse(self, action):
-        data, errors = self.extractData()
-        if errors:
-            self.status = self.formErrorsMessage
-            return
-
-        college_opinion = data.get("college_opinion", "")
-
-        result = self.context.transfer_opinion(college_opinion.output)
-
-        if result["error"] is True:
-            IStatusMessage(self.request).addStatusMessage(result["message"], "error")
-        else:
-            IStatusMessage(self.request).addStatusMessage(
-                _(u"The opinion transfer is done."), "info"
-            )
-        self._finishedSent = True
-
-    @button.buttonAndHandler(_("Cancel"), name="cancel")
-    def handleCancel(self, action):
-        self._finishedSent = True
-
-    def render(self):
-        if self._finishedSent:
-            IRedirect(self.request).redirect(self.context.absolute_url())
-            return ""
-        return super(TransferOpinionActionForm, self).render()
-
 
 TransferOpinionActionWrapper = wrap_form(TransferOpinionActionForm)
 
 
-class ITransferDecisionActionForm(Interface):
-
+class ITransferDecisionActionForm(ITransferBaseActionForm):
     college_decision = RichText(
         title=_(u"College decision"),
         default=u"<h1>Motivation:</h1>\r\n\r\n<h1>Décision:</h1>\r\n\r\n",
@@ -176,46 +266,47 @@ class ITransferDecisionActionForm(Interface):
 class TransferDecisionActionForm(NoticeResponseActionForm):
     label = _("Transfer decision to the SPW")
     fields = field.Fields(ITransferDecisionActionForm)
-    _finishedSent = False
-    _displayErrorsInOverlay = False
-    ignoreContext = True
+    fields["file_paths"].widgetFactory = CheckBoxFieldWidget
+    response_id_code = "NOTIFICATION_RS"
+    action_code = "transfer_decision"
+    success_message = _(u"The decision transfer is done.")
+
+    def transfer_response(self, data):
+        college_decision = data.get("college_decision", "")
+        output = college_decision.output if college_decision else ""
+        self.field_values_to_store["college_decision"] = output
+        result = self.context.transfer_decision(output)
+        return result
 
     def updateWidgets(self):
         super(TransferDecisionActionForm, self).updateWidgets()
         self._fetch_iadelib_opinion("college_decision")
 
-    @button.buttonAndHandler(_("Send"), name="send_response")
-    def handleSendResponse(self, action):
-        data, errors = self.extractData()
-        if errors:
-            self.status = self.formErrorsMessage
-            return
-
-        college_decision = data.get("college_decision", "")
-
-        result = self.context.transfer_decision(college_decision.output)
-
-        notice_id = self.context.aq_parent.get_notice_id(self.response_id_code)
-        if not notice_id:
-            raise ValueError(
-                _(
-                    u"Can't send response to event '{}': no Notice ID found for '{}'".format(
-                        self.context.absolute_url, self.response_id_code
-                    )
-                )
-            )
-
-        self._finishedSent = True
-
-    @button.buttonAndHandler(_("Cancel"), name="cancel")
-    def handleCancel(self, action):
-        self._finishedSent = True
-
-    def render(self):
-        if self._finishedSent:
-            IRedirect(self.request).redirect(self.context.absolute_url())
-            return ""
-        return super(TransferDecisionActionForm, self).render()
-
 
 TransferDecisionActionWrapper = wrap_form(TransferDecisionActionForm)
+
+
+class TransferDecisionDisplayActionForm(NoticeResponseActionForm):
+    label = _(u"Transfer decision display to the SPW")
+    fields = field.Fields(ITransferBaseActionForm)
+    fields["file_paths"].widgetFactory = CheckBoxFieldWidget
+    action_code = "transfer_decision"
+    success_message = _(u"The transfer of decision display dates is done.")
+
+    @property
+    def response_id_code(self):
+        licence = self.context.aq_parent
+        if licence.get_notice_id("NOTIFICATION_DECISION"):
+            return "NOTIFICATION_DECISION"
+        elif licence.get_notice_id("NOTIFICATION_RS"):
+            return "NOTIFICATION_RS"
+        else:
+            # should never happen; return useful value for debugging
+            return "NOTIFICATION_RS or NOTIFICATION_DECISION"
+
+    def transfer_response(self, data):
+        result = self.context.transfer_decision_display()
+        return result
+
+
+TransferDecisionDisplayActionWrapper = wrap_form(TransferDecisionDisplayActionForm)

--- a/src/Products/urban/browser/notice_forms.py
+++ b/src/Products/urban/browser/notice_forms.py
@@ -20,7 +20,7 @@ from plone.z3cform.layout import wrap_form
 
 
 class NoticeResponseActionForm(Form):
-    def _fetch_iadelib_opinion(self):
+    def _fetch_iadelib_opinion(self, field_to_fill):
         motivation = self._get_iadelib_field(self.context, "motivation") or ""
         decision = self._get_iadelib_field(self.context, "decision") or ""
         if motivation or decision:
@@ -30,7 +30,7 @@ class NoticeResponseActionForm(Form):
                 )
             )
             full_text = clean_accents(full_text)
-            self.widgets["college_opinion"].value = RichTextValue(
+            self.widgets[field_to_fill].value = RichTextValue(
                 full_text,
                 "text/html",
                 "text/html",
@@ -129,7 +129,7 @@ class TransferOpinionActionForm(NoticeResponseActionForm):
 
     def updateWidgets(self):
         super(TransferOpinionActionForm, self).updateWidgets()
-        self._fetch_iadelib_opinion()
+        self._fetch_iadelib_opinion("college_opinion")
 
     @button.buttonAndHandler(_("Send"), name="send_response")
     def handleSendResponse(self, action):
@@ -166,8 +166,8 @@ TransferOpinionActionWrapper = wrap_form(TransferOpinionActionForm)
 
 class ITransferDecisionActionForm(Interface):
 
-    college_opinion = RichText(
-        title=_(u"College opinion"),
+    college_decision = RichText(
+        title=_(u"College decision"),
         default=u"<h1>Motivation:</h1>\r\n\r\n<h1>Décision:</h1>\r\n\r\n",
         required=False,
     )
@@ -182,7 +182,7 @@ class TransferDecisionActionForm(NoticeResponseActionForm):
 
     def updateWidgets(self):
         super(TransferDecisionActionForm, self).updateWidgets()
-        self._fetch_iadelib_opinion()
+        self._fetch_iadelib_opinion("college_decision")
 
     @button.buttonAndHandler(_("Send"), name="send_response")
     def handleSendResponse(self, action):
@@ -191,15 +191,18 @@ class TransferDecisionActionForm(NoticeResponseActionForm):
             self.status = self.formErrorsMessage
             return
 
-        college_opinion = data.get("college_opinion", "")
+        college_decision = data.get("college_decision", "")
 
-        result = self.context.transfer_decision(college_opinion.output)
+        result = self.context.transfer_decision(college_decision.output)
 
-        if result["error"] is True:
-            IStatusMessage(self.request).addStatusMessage(result["message"], "error")
-        else:
-            IStatusMessage(self.request).addStatusMessage(
-                _(u"The opinion transfer is done."), "info"
+        notice_id = self.context.aq_parent.get_notice_id(self.response_id_code)
+        if not notice_id:
+            raise ValueError(
+                _(
+                    u"Can't send response to event '{}': no Notice ID found for '{}'".format(
+                        self.context.absolute_url, self.response_id_code
+                    )
+                )
             )
 
         self._finishedSent = True

--- a/src/Products/urban/browser/urbaneventviews.py
+++ b/src/Products/urban/browser/urbaneventviews.py
@@ -1322,7 +1322,7 @@ class CanTransferFolderToDpaView(BrowserView):
     def no_transmit_yet(self):
         annotations = interfaces.IAnnotations(self.context)
         dates = annotations.get("notice_transmit_dates", {})
-        return len(dates) == 0
+        return "transfer_folder_to_dpa" not in dates.keys()
 
     def __call__(self):
         return (
@@ -1356,7 +1356,8 @@ class CanTransferDatesView(BrowserView):
         annotations = interfaces.IAnnotations(self.context)
         dates = annotations.get("notice_transmit_dates", {})
         return (
-            "transfer_opinion" not in dates.keys()
+            "transfer_dates" not in dates.keys()
+            and "transfer_opinion" not in dates.keys()
             and "transfer_ticket_final" not in dates.keys()
         )
 
@@ -1391,7 +1392,8 @@ class CanTransferTicketView(BrowserView):
         annotations = interfaces.IAnnotations(self.context)
         dates = annotations.get("notice_transmit_dates", {})
         return (
-            "transfer_opinion" not in dates.keys()
+            "transfer_ticket" not in dates.keys()
+            and "transfer_opinion" not in dates.keys()
             and "transfer_ticket_final" not in dates.keys()
         )
 
@@ -1561,41 +1563,3 @@ class CanTransferDecisionDisplayView(BrowserView):
             and self.no_transmit_yet
             and self.can_send_decision_display
         )
-
-
-class UrbanEventNoticeActionsView(BrowserView):
-    """ """
-
-    def transfer_folder_to_dpa(self):
-        result = self.context.transfer_folder_to_dpa()
-        if result["error"] is True:
-            IStatusMessage(self.request).addStatusMessage(result["message"], "error")
-        else:
-            IStatusMessage(self.request).addStatusMessage(
-                _(u"The folder transfer to DPA is done."), "info"
-            )
-        self.request.response.redirect(self.context.absolute_url())
-
-    def transfer_dates(self):
-        result = self.context.transfer_dates()
-        if result["error"] is True:
-            IStatusMessage(self.request).addStatusMessage(
-                result["message"], "error"
-            )
-        else:
-            IStatusMessage(self.request).addStatusMessage(
-                _(u"The transfer of dates is done."), "info"
-            )
-        self.request.response.redirect(self.context.absolute_url())
-
-    def transfer_decision_display(self):
-        result = self.context.transfer_decision_display()
-        if result["error"] is True:
-            IStatusMessage(self.request).addStatusMessage(
-                result["message"], "error"
-            )
-        else:
-            IStatusMessage(self.request).addStatusMessage(
-                _(u"The transfer of decision display dates is done."), "info"
-            )
-        self.request.response.redirect(self.context.absolute_url())

--- a/src/Products/urban/browser/urbaneventviews.py
+++ b/src/Products/urban/browser/urbaneventviews.py
@@ -1546,8 +1546,8 @@ class CanTransferDecisionDisplayView(BrowserView):
                     "Products.urban.interfaces.ITheLicenceEvent" in event_types
                     or "Products.urban.interfaces.ILicenceDeliveryEvent" in event_types
                 )
-                event_has_college_opinion_data = getattr(event, "_notice_opinion", None)
-                if is_a_college_decision_event and event_has_college_opinion_data:
+                event_has_college_decision_data = getattr(event, "_notice_decision", None)
+                if is_a_college_decision_event and event_has_college_decision_data:
                     return True
 
         return False

--- a/src/Products/urban/content/UrbanEventInquiry.py
+++ b/src/Products/urban/content/UrbanEventInquiry.py
@@ -350,10 +350,6 @@ class UrbanEventInquiry(OrderedBaseFolder, UrbanEvent, BrowserDefaultMixin):
             notification.notice_id("DEMANDE_EP"),
             notification.serialize(),
         )
-        reception_date_str = result["body"]["result"]["receptionDate"]
-        reception_date = datetime.datetime.strptime(reception_date_str[:19], "%Y-%m-%dT%H:%M:%S")
-        self.store_transmit_date("transfer_dates", reception_date)
-
         return result
 
     def transfer_ticket(self):
@@ -363,10 +359,6 @@ class UrbanEventInquiry(OrderedBaseFolder, UrbanEvent, BrowserDefaultMixin):
             notification.notice_id("DEMANDE_EP"),
             notification.serialize(),
         )
-        reception_date_str = result["body"]["result"]["receptionDate"]
-        reception_date = datetime.datetime.strptime(reception_date_str[:19], "%Y-%m-%dT%H:%M:%S")
-        self.store_transmit_date("transfer_ticket", reception_date)
-
         return result
 
     def finalize_inquiry_without_opinion(self):
@@ -376,10 +368,6 @@ class UrbanEventInquiry(OrderedBaseFolder, UrbanEvent, BrowserDefaultMixin):
             notification.notice_id("DEMANDE_EP"),
             notification.serialize(),
         )
-        reception_date_str = result["body"]["result"]["receptionDate"]
-        reception_date = datetime.datetime.strptime(reception_date_str[:19], "%Y-%m-%dT%H:%M:%S")
-        self.store_transmit_date("transfer_ticket_final", reception_date)
-
         return result
 
 

--- a/src/Products/urban/locales/fr/LC_MESSAGES/urban.po
+++ b/src/Products/urban/locales/fr/LC_MESSAGES/urban.po
@@ -241,9 +241,13 @@ msgstr "Adresse introuvable"
 msgid "Can't find the street : ${street}"
 msgstr "Cette rue est introuvable : ${street}"
 
-#: ../browser/gig_coring_settings.py:75
-#: ../browser/offdays_settings.py:113
-#: ../browser/schedule_settings.py:31
+#: ../browser/notice_forms.py:106
+msgid "Can't send response to event '{}': no Notice ID found for '{}'"
+msgstr ""
+
+#: ../browser/gig_coring_settings.py:72
+#: ../browser/notice_settings.py:67
+#: ../browser/offdays_settings.py:108
 msgid "Cancel"
 msgstr "Annuler"
 
@@ -841,7 +845,11 @@ msgstr "Jours de suspension"
 msgid "Off days period"
 msgstr "Périodes de suspension"
 
-#: ../contentrules/configure.zcml:99
+#: ../browser/notice_forms.py:132
+msgid "One file is not available anymore, and couldn't be sent."
+msgstr "Un fichier n'est plus disponible et n'a pas pu être envoyé"
+
+#: ../contentrules/configure.zcml:112
 #: ../contentrules/opinions.py:26
 msgid "Opinion to ask"
 msgstr "Avis à demander"
@@ -937,7 +945,11 @@ msgstr "Chercher des références cadastrales."
 msgid "Select all files from this event or the parent licence you want to send."
 msgstr "Sélectionnez tous les fichiers de cet événement ou du permis parent que vous souhaitez envoyer."
 
-#: ../docgen/UrbanTemplate.py:29
+#: ../browser/notice_forms.py:29
+msgid "Select files from this event or the parent licence you want to send (PDF, XLSX or PNG)."
+msgstr "Sélectionnez tous les fichiers de cet événement ou du permis parent que vous souhaitez envoyer (PDF, XLSX ou PNG)."
+
+#: ../docgen/UrbanTemplate.py:26
 msgid "Select for which content types the template will be available."
 msgstr "Sélectionner les types de contenues autorisés pour ce modèle"
 
@@ -1019,7 +1031,11 @@ msgstr "Le fichier CSV n'a pas pu être lu correctement. Veuillez vérifier son 
 msgid "The claimants import will be ready tomorrow!"
 msgstr "L'import des réclamants a bien été enregistré et sera éxécuté cette nuit"
 
-#: ../browser/longtextview.py:34
+#: ../browser/notice_forms.py:284
+msgid "The decision transfer is done."
+msgstr "L'envoi de la décision est terminé."
+
+#: ../browser/longtextview.py:35
 msgid "The field does not exist !!!"
 msgstr "Le champ n'existe pas."
 
@@ -1439,8 +1455,14 @@ msgstr "Paramètres des certificats d'urbanisme 1 (CODT)"
 msgid "codt_urbancertificatetwo_urbanconfig_title"
 msgstr "Paramètres des certificats d'urbanisme 2 (CODT)"
 
+msgid "college_decision"
+msgstr "Décision du collège"
+
 msgid "college_holydays"
 msgstr "Vacances du collège"
+
+msgid "college_opinion"
+msgstr "Avis du collège"
 
 msgid "collegeopinions_folder_title"
 msgstr "Avis du collège"
@@ -2597,6 +2619,10 @@ msgstr "SSC"
 msgid "stop_worksite"
 msgstr "Arrêt de chantier"
 
+#: ../browser/cron/notice.py:369
+msgid "street"
+msgstr "rue"
+
 #. Default: "When adding manually a new street, please let the default value"
 #: Street.py
 msgid "street_best_address_key_descr"
@@ -2712,6 +2738,11 @@ msgstr "Action"
 #: ../viewlets/templates/notice_transmit_state.pt:14
 msgid "transmit_date"
 msgstr "Le"
+
+#. Default: "Form data"
+#: ../viewlets/templates/notice_transmit_state.pt:17
+msgid "transmit_form_data"
+msgstr "Données du formulaire"
 
 #. Default: "User"
 #: ../viewlets/templates/notice_transmit_state.pt:15

--- a/src/Products/urban/locales/fr/LC_MESSAGES/urban.po
+++ b/src/Products/urban/locales/fr/LC_MESSAGES/urban.po
@@ -261,7 +261,11 @@ msgstr "Changements enregistrés"
 msgid "Check parcels"
 msgstr "Vérifier les parcelles"
 
-#: ../browser/notice_forms.py:161
+#: ../browser/notice_forms.py:423
+msgid "College decision"
+msgstr "Décision du collège"
+
+#: ../browser/notice_forms.py:279
 msgid "College opinion"
 msgstr "Avis collège"
 

--- a/src/Products/urban/locales/urban-manual.pot
+++ b/src/Products/urban/locales/urban-manual.pot
@@ -1542,3 +1542,9 @@ msgstr ""
 
 msgid "transfer_decision_display"
 msgstr ""
+
+msgid "college_opinion"
+msgstr ""
+
+msgid "college_decision"
+msgstr ""

--- a/src/Products/urban/locales/urban.pot
+++ b/src/Products/urban/locales/urban.pot
@@ -65,8 +65,8 @@ msgstr ""
 msgid "75 days"
 msgstr ""
 
-#: ../contentrules/event_type.py:70
-msgid "A Event type condition makes the rule apply only if Event type correspond to the one from the context."
+#: ../browser/cron/notice.py:171
+msgid "<p>${msg} for informations: ${data}</p>"
 msgstr ""
 
 #: ../contentrules/opinions.py:77
@@ -245,9 +245,13 @@ msgstr ""
 msgid "Can't find the street : ${street}"
 msgstr ""
 
-#: ../browser/gig_coring_settings.py:75
-#: ../browser/offdays_settings.py:113
-#: ../browser/schedule_settings.py:31
+#: ../browser/notice_forms.py:106
+msgid "Can't send response to event '{}': no Notice ID found for '{}'"
+msgstr ""
+
+#: ../browser/gig_coring_settings.py:72
+#: ../browser/notice_settings.py:67
+#: ../browser/offdays_settings.py:108
 msgid "Cancel"
 msgstr ""
 
@@ -834,7 +838,11 @@ msgstr ""
 msgid "Off days period"
 msgstr ""
 
-#: ../contentrules/configure.zcml:99
+#: ../browser/notice_forms.py:132
+msgid "One file is not available anymore, and couldn't be sent."
+msgstr ""
+
+#: ../contentrules/configure.zcml:112
 #: ../contentrules/opinions.py:26
 msgid "Opinion to ask"
 msgstr ""
@@ -930,7 +938,11 @@ msgstr ""
 msgid "Select all files from this event or the parent licence you want to send."
 msgstr ""
 
-#: ../docgen/UrbanTemplate.py:29
+#: ../browser/notice_forms.py:29
+msgid "Select files from this event or the parent licence you want to send (PDF, XLSX or PNG)."
+msgstr ""
+
+#: ../docgen/UrbanTemplate.py:26
 msgid "Select for which content types the template will be available."
 msgstr ""
 
@@ -1012,7 +1024,11 @@ msgstr ""
 msgid "The claimants import will be ready tomorrow!"
 msgstr ""
 
-#: ../browser/longtextview.py:34
+#: ../browser/notice_forms.py:284
+msgid "The decision transfer is done."
+msgstr ""
+
+#: ../browser/longtextview.py:35
 msgid "The field does not exist !!!"
 msgstr ""
 
@@ -1430,7 +1446,13 @@ msgstr ""
 msgid "codt_urbancertificatetwo_urbanconfig_title"
 msgstr ""
 
+msgid "college_decision"
+msgstr ""
+
 msgid "college_holydays"
+msgstr ""
+
+msgid "college_opinion"
 msgstr ""
 
 msgid "collegeopinions_folder_title"
@@ -2694,6 +2716,11 @@ msgstr ""
 #. Default: "When"
 #: ../viewlets/templates/notice_transmit_state.pt:14
 msgid "transmit_date"
+msgstr ""
+
+#. Default: "Form data"
+#: ../viewlets/templates/notice_transmit_state.pt:17
+msgid "transmit_form_data"
 msgstr ""
 
 #. Default: "User"

--- a/src/Products/urban/locales/urban.pot
+++ b/src/Products/urban/locales/urban.pot
@@ -265,7 +265,11 @@ msgstr ""
 msgid "Check parcels"
 msgstr ""
 
-#: ../browser/notice_forms.py:161
+#: ../browser/notice_forms.py:423
+msgid "College decision"
+msgstr ""
+
+#: ../browser/notice_forms.py:279
 msgid "College opinion"
 msgstr ""
 

--- a/src/Products/urban/notice/__init__.py
+++ b/src/Products/urban/notice/__init__.py
@@ -8,6 +8,7 @@ from Products.urban.notice.party import NoticeParty
 from Products.urban.notice.response import NoticeOutgoingNotification
 from Products.urban.notice.sender import NoticeSender
 from Products.urban.notice.response import NoticeOutgoingDecisionNotification
+from Products.urban.notice.response import NoticeOutgoingFileNotification
 from Products.urban.notice.response import NoticeOutgoingPublicSurveyDatesNotification
 from Products.urban.notice.response import NoticeOutgoingPublicSurveyFinalWithoutOpinionNotification
 from Products.urban.notice.response import NoticeOutgoingPublicSurveyPVNotification
@@ -24,6 +25,7 @@ __all__ = (
     "NoticeParty",
     "NoticeSender",
     "NoticeOutgoingNotification",
+    "NoticeOutgoingFileNotification",
     "NoticeOutgoingPublicSurveyDatesNotification",
     "NoticeOutgoingPublicSurveyFinalWithoutOpinionNotification",
     "NoticeOutgoingPublicSurveyPVNotification",

--- a/src/Products/urban/notice/response.py
+++ b/src/Products/urban/notice/response.py
@@ -1,9 +1,12 @@
 # -*- coding: utf-8 -*-
 
+import base64
+
 from Acquisition import aq_parent
 from Products.urban.interfaces import IInquiryEvent
 from Products.urban.interfaces import ITheLicenceEvent
 from Products.urban.notice.base import NoticeElement
+from plone import api
 
 
 def clean_accents(raw_string):
@@ -41,6 +44,34 @@ class NoticeResponse(NoticeElement):
     def specific(self):
         """Response specific data"""
         raise NotImplementedError
+
+
+class NoticeOutgoingFileNotification(NoticeElement):
+    def __init__(self, file_path):
+        self._file = api.content.get(path=file_path)
+
+    @property
+    def file(self):
+        return {
+            "name": self._file.id,
+            "mime": self._file.content_type,
+            "content": base64.encodestring(self._file.data),
+        }
+
+    @property
+    def type(self):
+        return {
+            "code": "PIECE_JOINTE_URBAN",
+            "label": u"Pièce jointe venant d'iA.Urban",
+        }
+
+    @property
+    def language(self):
+        return "FR"
+
+    @property
+    def description(self):
+        return self._file.title
 
 
 class NoticeOutgoingNotification(NoticeResponse):

--- a/src/Products/urban/notice/response.py
+++ b/src/Products/urban/notice/response.py
@@ -200,10 +200,6 @@ class NoticeOutgoingSummaryReportNotification(NoticeResponse):
         return self._licence.getReference()
 
     @property
-    def _caracteristics_comment(self):
-        return None
-
-    @property
     def _display_decision_start_date(self):
         return None
 
@@ -216,6 +212,19 @@ class NoticeOutgoingSummaryReportNotification(NoticeResponse):
         raise NotImplementedError
 
     @property
+    def _decision_code(self):
+        if self._decision_event:
+            decision_codes = {
+                "favorable": "OCTROI",
+                "defavorable": "REFUS",
+                "octroi": "OCTROI",
+                "refus": "REFUS",
+            }
+            return {"cod:code": decision_codes.get(self._decision_event.getDecision())}
+        else:
+            return None
+
+    @property
     def _motivation(self):
         return getattr(self._decision_event, "_notice_decision", None)
 
@@ -226,9 +235,9 @@ class NoticeOutgoingSummaryReportNotification(NoticeResponse):
     @property
     def specific(self):
         return {
+            "not:notice": self._decision_code,
             "not:motivation": self._motivation,
             "tns:municipalityReference": self._reference,
-            "tns:caracteristicsComment": self._caracteristics_comment,
             "tns:decisionDate": self._decision_date,
             "tns:displayDecisionStartDate": self._display_decision_start_date,
             "tns:displayDecisionEndDate": self._display_decision_end_date,

--- a/src/Products/urban/notice/response.py
+++ b/src/Products/urban/notice/response.py
@@ -186,7 +186,7 @@ class NoticeOutgoingSummaryReportNotification(NoticeResponse):
 
     @property
     def _motivation(self):
-        return getattr(self._decision_event, "_notice_opinion", None)
+        return getattr(self._decision_event, "_notice_decision", None)
 
     @property
     def _decision_date(self):

--- a/src/Products/urban/profiles/default/actions.xml
+++ b/src/Products/urban/profiles/default/actions.xml
@@ -128,7 +128,7 @@
   <object name="transfer_folder_to_dpa" meta_type="CMF Action" i18n:domain="urban">
    <property name="title" i18n:translate="">Transfer folder to DPA</property>
    <property name="description" i18n:translate=""></property>
-   <property name="url_expr">string:$object_url/@@transfer_folder_to_dpa</property>
+   <property name="url_expr">string:$object_url/@@transfer_folder_to_dpa_form</property>
    <property name="icon_expr">string:$portal_url/++resource++Products.urban/coq_wallon.png</property>
    <property name="available_expr">context/@@can_transfer_folder_to_dpa</property>
    <property name="permissions">
@@ -139,7 +139,7 @@
   <object name="transfer_dates" meta_type="CMF Action" i18n:domain="urban">
    <property name="title" i18n:translate="">Transfer dates to the SPW</property>
    <property name="description" i18n:translate=""></property>
-   <property name="url_expr">string:$object_url/@@transfer_dates</property>
+   <property name="url_expr">string:$object_url/@@transfer_dates_form</property>
    <property name="icon_expr">string:$portal_url/++resource++Products.urban/coq_wallon.png</property>
    <property name="available_expr">context/@@can_transfer_dates</property>
    <property name="permissions">
@@ -183,7 +183,7 @@
   <object name="transfer_decision_display" meta_type="CMF Action" i18n:domain="urban">
    <property name="title" i18n:translate="">Transfer decision display to the SPW</property>
    <property name="description" i18n:translate=""></property>
-   <property name="url_expr">string:$object_url/@@transfer_decision_display</property>
+   <property name="url_expr">string:$object_url/@@transfer_decision_display_form</property>
    <property name="icon_expr">string:$portal_url/++resource++Products.urban/coq_wallon.png</property>
    <property name="available_expr">context/@@can_transfer_decision_display</property>
    <property name="permissions">

--- a/src/Products/urban/profiles/extra/default_objects.py
+++ b/src/Products/urban/profiles/extra/default_objects.py
@@ -94,5 +94,12 @@ default_objects = {
             "name2": "Patrick",
             "grade": "responsable-administratif",
         },
+        {
+            "id": "notice",
+            "personTitle": "mister",
+            "name1": "Import NOTICE",
+            "name2": "",
+            "grade": "agent-technique",
+        },
     ],
 }

--- a/src/Products/urban/profiles/testsWithConfig/default_objects.py
+++ b/src/Products/urban/profiles/testsWithConfig/default_objects.py
@@ -48,5 +48,12 @@ default_objects = {
             "grade": "agent-technique",
             "ploneUserId": "urbanmanager",
         },
+        {
+            "id": "notice",
+            "personTitle": "mister",
+            "name1": "Import NOTICE",
+            "name2": "",
+            "grade": "agent-technique",
+        },
     ],
 }

--- a/src/Products/urban/services/configure.zcml
+++ b/src/Products/urban/services/configure.zcml
@@ -1,6 +1,7 @@
 <configure xmlns="http://namespaces.zope.org/zope"
            xmlns:five="http://namespaces.zope.org/five"
            xmlns:i18n="http://namespaces.zope.org/i18n"
+           xmlns:plone="http://namespaces.plone.org/plone"
            i18n_domain="urban">
 
   <include file="licences_export.zcml" />
@@ -24,6 +25,17 @@
     for="Products.urban.services.gig.GigService"
     provides="Products.urban.services.interfaces.ISQLSession"
     factory="Products.urban.services.gig.GigSession" />
+
+  <adapter
+    factory=".notice.Notice"
+    name="notice" />
+
+  <plone:service
+    method="GET"
+    factory=".notice.NoticeGet"
+    for="zope.interface.Interface"
+    permission="zope2.View"
+    name="@notice" />
 
   <adapter factory=".serializer.UrbanDefaultFieldSerializer" />
   <adapter factory=".deserializer.DeserializeFromJsonUrban" />

--- a/src/Products/urban/services/notice.py
+++ b/src/Products/urban/services/notice.py
@@ -84,7 +84,9 @@ class WebserviceNotice(WebService):
         """Get notifications for the current instance"""
         response = self._get_notifications(status=status)
         if response.status_code != 200:
-            raise ValueError("Unexpected response '{}'".format(response.status_code))
+            raise ValueError(
+                "Unexpected response {}: '{}'".format(response.status_code, response.content)
+            )
         result = response.json()
         if result["status"] != "PROCESSED":
             raise ValueError("Error in response '{}'".format(result["status"]["value"]))
@@ -125,6 +127,15 @@ class WebserviceNotice(WebService):
         """Post a response for a notification using REST API"""
         return self._post(
             "notifications/{notification_id}/responses".format(
+                notification_id=notification_id
+            ),
+            data=data,
+        )
+
+    def _post_notification_document(self, notification_id, data):
+        """Post a document for a notification using REST API"""
+        return self._post(
+            "notifications/{notification_id}/documents".format(
                 notification_id=notification_id
             ),
             data=data,
@@ -175,3 +186,10 @@ class WebserviceNotice(WebService):
                 "message": _("An unexcepted error occured, please try again"),
             }
         return {"error": False, "body": result}
+
+    def post_notification_document(self, notification_id, data):
+        """Post a document for a notification"""
+        response = self._post_notification_document(notification_id, data)
+        if response.status_code != 204:
+            return self._handle_error(response)
+        return "OK"

--- a/src/Products/urban/services/notice.py
+++ b/src/Products/urban/services/notice.py
@@ -1,11 +1,52 @@
 # -*- coding: utf-8 -*-
 
+import requests
+
 from Products.urban import UrbanMessage as _
+from Products.urban.interfaces import IGenericLicence
+from Products.urban.interfaces import IUrbanEvent
 from Products.urban.notice import NoticeNotification
 from Products.urban.services.base import WebService
 from plone import api
+from plone.restapi.interfaces import IExpandableElement
+from plone.restapi.serializer.converters import json_compatible
+from plone.restapi.services import Service
+from zope.annotation.interfaces import IAnnotations
+from zope.component import adapter
+from zope.interface import implementer
+from zope.interface import Interface
 
-import requests
+
+@implementer(IExpandableElement)
+@adapter(Interface, Interface)
+class Notice(object):
+    def __init__(self, context, request):
+        self.context = context
+        self.request = request
+
+    def __call__(self, expand=False):
+        result = {"notice": {"@id": "{}/@notice".format(self.context.absolute_url())}}
+        if not expand:
+            return result
+
+        data = {}
+
+        if IGenericLicence.providedBy(self.context):
+            notice_ids = getattr(self.context, "notice_ids", {})
+            data["notice_ids"] = notice_ids
+
+        if IUrbanEvent.providedBy(self.context):
+            annotations = IAnnotations(self.context)
+            for key in ("notice_transmit_dates", "notice_reception_date"):
+                data[key] = annotations.get(key, None)
+
+        return json_compatible({"notice": data})
+
+
+class NoticeGet(Service):
+    def reply(self):
+        notice = Notice(self.context, self.request)
+        return notice(expand=True)["notice"]
 
 
 class WebserviceNotice(WebService):

--- a/src/Products/urban/skins/urban_styles/urbanpopups.js
+++ b/src/Products/urban/skins/urban_styles/urbanpopups.js
@@ -45,4 +45,8 @@ jQuery(function($){
     $('.link-overlay-urban-annex').prepOverlay({
        subtype: 'ajax',
     });
+    // Notice form data
+    $('.urban-form-data a').prepOverlay({
+       subtype: 'ajax',
+    });
 });

--- a/src/Products/urban/viewlets/notice.py
+++ b/src/Products/urban/viewlets/notice.py
@@ -17,12 +17,14 @@ class NoticeTransmitState(ViewletBase):
         for (label, value) in dates.items():
             if type(value) is dict:
                 results.append({
+                    "action_code": label,
                     "label": translate(label, "urban", context=self.request),
                     "date": value.get("date"),
                     "user": value.get("user"),
                 })
             else:  # old style; before we also stored the user, "value" was the date
                 results.append({
+                    "action_code": label,
                     "label": translate(label, "urban", context=self.request),
                     "date": value,
                     "user": "",

--- a/src/Products/urban/viewlets/templates/notice_transmit_state.pt
+++ b/src/Products/urban/viewlets/templates/notice_transmit_state.pt
@@ -14,12 +14,22 @@
             <th i18n:translate="transmit_action">Action</th>
             <th i18n:translate="transmit_date">When</th>
             <th i18n:translate="transmit_user">User</th>
+            <th i18n:translate="transmit_form_data">Form data</th>
           </thead>
           <tbody>
             <tr tal:repeat="transmit transmits">
                 <td tal:content="transmit/label"></td>
                 <td tal:content="python: transmit['date'].strftime('%d/%m/%Y, %H:%M:%S')"></td>
                 <td tal:content="transmit/user"></td>
+                <td tal:define="action_code transmit/action_code">
+                    <span class="urban-form-data">
+                        <a class="link-overlay"
+                           href="@@noticeformdatatextview"
+                           tal:attributes="href python: context.absolute_url() + '/@@noticeformdatatextview?action_code=' + action_code"
+                           i18n:translate="read_more">Lire la suite
+                        </a>
+                    </span>
+                </td>
             </tr>
           </tbody>
       </table>

--- a/src/Products/urban/vocabularies.py
+++ b/src/Products/urban/vocabularies.py
@@ -466,6 +466,34 @@ class LicenceDocumentsVocabulary(object):
 LicenceDocumentsVocabularyFactory = LicenceDocumentsVocabulary()
 
 
+class ValidNoticeLicenceDocumentsVocabulary(LicenceDocumentsVocabulary):
+    acceptable_content_types = {
+        "application/pdf": "Document PDF",
+        "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet": "Document Excel",
+        "image/png": "Image PNG",
+    }
+
+    def filter_document(self, doc):
+        """
+        Keep only document types that are viewable in TWICE,
+        and hide documents created by user admin (= documents received from Notice)
+        """
+        content_type = getattr(doc, "content_type", None)
+        creator = doc.Creator()
+        return content_type in self.acceptable_content_types and creator != "admin"
+
+    def make_term(self, doc):
+        """
+        Display doc title and file type
+        """
+        extension = self.acceptable_content_types.get(doc.content_type, "")
+        title = "{} ({})".format(doc.Title(), extension)
+        return SimpleTerm(self.get_path(doc), self.get_path(doc), title)
+
+
+ValidNoticeLicenceDocumentsVocabularyFactory = ValidNoticeLicenceDocumentsVocabulary()
+
+
 class ComplementaryDelayVocabulary(object):
     implements(IVocabularyFactory)
 

--- a/src/Products/urban/vocabularies.py
+++ b/src/Products/urban/vocabularies.py
@@ -435,22 +435,32 @@ class LicenceDocumentsVocabulary(object):
     def get_path(sefl, obj):
         return "/".join(obj.getPhysicalPath())
 
-    def __call__(self, context):
-        contexts = get_licence_context(context, get_all_object=True)
-        output = []
+    def list_documents(self, base_context):
+        documents = []
+        contexts = get_licence_context(base_context, get_all_object=True)
         if contexts is None:
-            return SimpleVocabulary(output)
+            return documents
         for context in contexts:
-            docs = [
-                SimpleTerm(self.get_path(doc), self.get_path(doc), doc.Title())
-                for doc in context.listFolderContents(
-                    contentFilter={
-                        "portal_type": ["ATFile", "ATImage", "File", "Image"]
-                    }
-                )
-            ]
-            output += docs
-        return SimpleVocabulary(output)
+            for doc in context.listFolderContents(
+                contentFilter={"portal_type": ["ATFile", "ATImage", "File", "Image"]}
+            ):
+                if self.filter_document(doc):
+                    documents.append(doc)
+        return documents
+
+    def filter_document(self, doc):
+        """Can be subclassed to filter documents based on their attributes"""
+        return True
+
+    def make_term(self, doc):
+        return SimpleTerm(self.get_path(doc), self.get_path(doc), doc.Title())
+
+    def __call__(self, context):
+        terms = [
+            self.make_term(doc)
+            for doc in self.list_documents(context)
+        ]
+        return SimpleVocabulary(terms)
 
 
 LicenceDocumentsVocabularyFactory = LicenceDocumentsVocabulary()

--- a/src/Products/urban/vocabulary.zcml
+++ b/src/Products/urban/vocabulary.zcml
@@ -106,6 +106,12 @@
   />
 
   <utility
+    component=".vocabularies.ValidNoticeLicenceDocumentsVocabularyFactory"
+    name="urban.vocabularies.valid_notice_licence_documents"
+    provides="zope.schema.interfaces.IVocabularyFactory"
+  />
+
+  <utility
     component=".vocabularies.ComplementaryDelayFactory"
     name="urban.vocabularies.complementary_delay"
     provides="zope.schema.interfaces.IVocabularyFactory"


### PR DESCRIPTION
- Show form data sent to Notice
- Refactor Notice responses with forms
- URB-3311: Include decision in Summary Report response
- Add Notice folder manager (for new installations)
- Expand REST API to include Notice data
- URB-3514: Add Notice response to send documents
- URB-3514: Add vocabulary of licence documents available to send to Notice
- URB-3514: Refactor `LicenceDocumentsVocabulary` for easier subclassing
- Rename college decision in Notice forms