### PR TITLE
URB-3470: PE & PU bordering licences

### DIFF
--- a/news/URB-3470.feature
+++ b/news/URB-3470.feature
@@ -1,0 +1,3 @@
+Add new content type `CODT_UniqueBorderingLicence`
+Handle `DEMANDE_EP_EXTRA` notification
+[daggelpop]

--- a/src/Products/urban/LicenceConfig.py
+++ b/src/Products/urban/LicenceConfig.py
@@ -569,6 +569,7 @@ class LicenceConfig(BaseFolder, BrowserDefaultMixin, OrderedContainer):
             "codt_article127": codt_buildlicence_tabs_config,
             "codt_parceloutlicence": codt_inquiry_tabs_config,
             "codt_uniquelicence": codt_uniquelicence_tabs_config,
+            "codt_uniqueborderinglicence": codt_uniquelicence_tabs_config,
             "codt_commerciallicence": codt_buildlicence_tabs_config,
             "codt_integratedlicence": codt_uniquelicence_tabs_config,
             "codt_urbancertificatetwo": codt_buildlicence_tabs_config,

--- a/src/Products/urban/__init__.py
+++ b/src/Products/urban/__init__.py
@@ -220,6 +220,7 @@ def initialize(context):
     import content.licence.CODT_CommercialLicence
     import content.licence.CODT_IntegratedLicence
     import content.licence.CODT_ParcelOutLicence
+    import content.licence.CODT_UniqueBorderingLicence
     import content.licence.CODT_UniqueLicence
     import content.licence.CODT_UrbanCertificateTwo
     import content.licence.Declaration

--- a/src/Products/urban/browser/cron/notice.py
+++ b/src/Products/urban/browser/cron/notice.py
@@ -164,6 +164,55 @@ class ImportFromNoticeView(BrowserView):
         licence.description.raw += translate(error, context=self.request)
         licence._p_changed = 1
 
+    def _demande_ep_extra(self, detailed_notification):
+        container = detailed_notification.container
+        licence = api.content.create(
+            container=container, **detailed_notification.serialize()
+        )
+        licence.set_notice_id("DEMANDE_EP", detailed_notification.noticeId)
+        licence.setFoldermanagers(
+            detailed_notification.foldermanagers
+        )  # Must be set manually, serialized value is ignored at creation
+
+        licence.setManualParcels(
+            [{"ref": "", "capakey": parcel.capakey} for parcel in detailed_notification.parcels]
+        )
+        addresses = detailed_notification.addresses
+        if addresses:
+            first_address = addresses[0]
+            licence.setZipcode(first_address.postCode)
+            licence.setCity(first_address.municipality)
+            licence.setWorkLocations(
+                [
+                    {"number": address.number, "street": address.notice_street}
+                    for address in addresses
+                ]
+            )
+
+        licence._p_changed = 1
+        for party in detailed_notification.parties:
+            api.content.create(container=licence, **party.serialize())
+        for document in detailed_notification.documents:
+            api.content.create(container=licence, **document.serialize())
+        # Set title and update reference number
+        notify(ObjectInitializedEvent(licence))
+
+        event_config_complete = detailed_notification.event_config(
+            "Products.urban.interfaces.IAcknowledgmentEvent"
+        )
+        event = licence.createUrbanEvent(event_config_complete)
+        event_date = DateTime(str(detailed_notification.send_date))
+        event.setEventDate(event_date)
+        event.store_reception_date(detailed_notification.reception_date)
+        api.content.transition(event, "close")
+
+        api.content.transition(licence, "iscomplete")
+
+        # Reindex licence
+        licence.reindexObject()
+
+        transaction.commit()  # Useful in case of an error
+
     def _demande_ep(self, detailed_notification):
         licence = detailed_notification.licence
         if not licence:
@@ -264,9 +313,10 @@ class ImportFromNoticeView(BrowserView):
         elif detailed_notification.notice_type in (
             "DEMANDE_EP",
             "DEMANDE_EP_DOSSIER_PRECEDENT",
-            "DEMANDE_EP_EXTRA",
         ):
             self._demande_ep(detailed_notification)
+        elif detailed_notification.notice_type == "DEMANDE_EP_EXTRA":
+            self._demande_ep_extra(detailed_notification)
         elif detailed_notification.notice_type == "NOTIFICATION_PROROGATION_COMMUNE":
             self.process_extension_of_deadline_notification(detailed_notification)
         elif detailed_notification.notice_type in (

--- a/src/Products/urban/browser/exportimport/import_config.py
+++ b/src/Products/urban/browser/exportimport/import_config.py
@@ -166,7 +166,7 @@ class ConfigImportContent(ImportContent):
         return self.get_uid_from_proximity_context(aq_parent(context), id, ignore_uid)
 
     def get_template_uid(self, item, template):
-        if isinstance(template["template"], str):
+        if isinstance(template["template"], basestring):
             obj = api.content.get(UID=template["template"])
             if obj:
                 return template["template"]

--- a/src/Products/urban/browser/exportimport/import_ordering.py
+++ b/src/Products/urban/browser/exportimport/import_ordering.py
@@ -18,7 +18,9 @@ class UrbanConfigImportOrdering(ImportOrdering):
         for index, item in enumerate(data, start=1):
             obj = api.content.get(UID=item["uuid"])
             if not obj and "path" in item:
-                obj = api.content.get(path=item["path"])
+                path = str(item["path"])
+                # a unicode path would return nothing, even if the content exists !
+                obj = api.content.get(path=path)
             if not obj:
                 continue
             ordered = IOrderedContainer(obj.__parent__, None)

--- a/src/Products/urban/browser/licence/codt_uniqueborderinglicenceview.py
+++ b/src/Products/urban/browser/licence/codt_uniqueborderinglicenceview.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+
+from Acquisition import aq_inner
+from Products.CMFCore.utils import getToolByName
+from Products.CMFPlone import PloneMessageFactory as _
+from Products.urban.browser.licence.codt_uniquelicenceview import CODTUniqueLicenceView
+
+
+class CODTUniqueBorderingLicenceView(CODTUniqueLicenceView):
+    def __init__(self, context, request):
+        super(CODTUniqueBorderingLicenceView, self).__init__(context, request)
+        self.context = context
+        self.request = request
+        # disable portlets on licences
+        self.request.set("disable_plone.rightcolumn", 1)
+        self.request.set("disable_plone.leftcolumn", 1)
+        plone_utils = getToolByName(context, "plone_utils")
+        if not self.context.getApplicants():
+            plone_utils.addPortalMessage(_("warning_add_an_applicant"), type="warning")
+
+    def getMacroViewName(self):
+        return "codt_uniqueborderinglicence-macros"

--- a/src/Products/urban/browser/licence/configure.zcml
+++ b/src/Products/urban/browser/licence/configure.zcml
@@ -173,6 +173,21 @@
   />
 
   <browser:page
+     for="Products.urban.interfaces.ICODT_UniqueBorderingLicence"
+     name="codt_uniqueborderinglicenceview"
+     class=".codt_uniqueborderinglicenceview.CODTUniqueBorderingLicenceView"
+     template="templates/codt_uniqueborderinglicenceview.pt"
+     permission="zope2.View"
+  />
+
+  <browser:page
+     name="codt_uniqueborderinglicence-macros"
+     for="Products.urban.interfaces.ICODT_UniqueBorderingLicence"
+     template="templates/codt_uniqueborderinglicencemacros.pt"
+     permission="zope2.View"
+  />
+
+  <browser:page
      for="Products.urban.interfaces.ICODT_IntegratedLicence"
      name="codt_integratedlicenceview"
      class=".codt_integratedlicenceview.CODTIntegratedLicenceView"

--- a/src/Products/urban/browser/licence/templates/codt_uniqueborderinglicencemacros.pt
+++ b/src/Products/urban/browser/licence/templates/codt_uniqueborderinglicencemacros.pt
@@ -1,0 +1,105 @@
+<metal:description define-macro="description_macro" i18n:domain="urban">
+
+    <tal:vars define="exclude python:[
+                          'title', 'workLocations', 'businessOldLocation',
+                          'additionalLegalConditions', 'additionalConditions',
+                          'additionalPreviousLicences', 'manualParcels', 'manualOldParcels',
+                          'city', 'zipcode'
+                      ];
+                      custom python:['impactStudy', 'bound_licences',];">
+        <metal:parent_call use-macro="here/@@licencetabs-macros/description_macro">
+
+            <metal:applicants fill-slot="applicant_slot">
+                <metal:applicants_and_corporations_macro use-macro="here/@@licencemacros/urbanApplicantsAndCorporationsMacro" />
+                <tal:show_disabled_applicants condition= "here/get_applicants_history">
+                    <metal:disabled_applicants_and_corporations_macro use-macro="here/@@licencemacros/urbanApplicantsHistoricAndCorporationsMacro" />
+                </tal:show_disabled_applicants>
+            </metal:applicants>
+
+            <metal:representatives fill-slot="representatives">
+                <metal:representatives_macro use-macro="here/@@licencemacros/urbanRepresentativeContactsMacro" />
+            </metal:representatives>
+
+            <metal:worklocations fill-slot="worklocations">
+            <div metal:define-macro="env_worklocations_macro" i18n:domain="urban">
+                <fieldset tal:define="workLocations context/getWorkLocations;
+                                      manual_parcels context/getManualParcels;">
+                    <legend i18n:translate="urban_label_situation">Situation</legend>
+                    <div tal:condition="workLocations">
+                        <metal:myfield use-macro="python:here.widget('workLocations', mode='view')" />
+                        <br />
+                        <table class="no-style-table" cellspacing=0 cellpadding=0 width=100%>
+                        <tr tal:repeat="field python: [context.getField('city'), context.getField('zipcode')]">
+                            <tal:vars define="fieldname field/getName;
+                                              value python: field.getAccessor(context)();
+                                              nullvalue python: value == '' or value == ();">
+                        <td valign="top"><b><span tal:content="field/widget/label | field/widget/label_msgid" i18n:translate=""></span>:</b></td>
+                        <td width="10px"></td>
+                        <td valign="top">
+                            <tal:non_null_value condition="not: nullvalue">
+                                <metal:myfield use-macro="python:context.widget(fieldname, mode='view')" />
+                            </tal:non_null_value>
+                            <span tal:condition="nullvalue" class="discreet" i18n:translate="content_none">Aucun(e)</span>
+                        </td>
+                            </tal:vars>
+                        </tr>
+                        </table>
+                        <br />
+                    </div>
+                    <div tal:condition="manual_parcels">
+                        <metal:myfield use-macro="python:here.widget('manualParcels', mode='view')" />
+                    </div>
+                    <span tal:condition="python: not workLocations and not manual_parcels" class="discreet" i18n:translate="content_none">Aucun(e)</span>
+                </fieldset>
+
+            </div>
+            </metal:worklocations>
+
+        </metal:parent_call>
+    </tal:vars>
+
+</metal:description>
+
+<metal:analysis define-macro="analysis_macro" i18n:domain="urban">
+    <metal:parent_call use-macro="here/@@licencetabs-macros/analysis_macro">
+    </metal:parent_call>
+</metal:analysis>
+
+<metal:environment define-macro="environment_macro" i18n:domain="urban">
+    <tal:vars define="custom python:['rubrics', 'minimumLegalConditions', 'hasAdditionalConditions'];">
+        <metal:parent_call use-macro="here/@@licencetabs-macros/environment_macro">
+        </metal:parent_call>
+    </tal:vars>
+</metal:environment>
+
+<metal:road define-macro="road_macro" i18n:domain="urban">
+    <metal:parent_call use-macro="here/@@licencetabs-macros/road_macro">
+    </metal:parent_call>
+</metal:road>
+
+<metal:location define-macro="location_macro" i18n:domain="urban">
+    <metal:parent_call use-macro="here/@@licencetabs-macros/location_macro">
+    </metal:parent_call>
+</metal:location>
+
+<metal:peb define-macro="habitation_macro" i18n:domain="urban">
+    <metal:parent_call use-macro="here/@@licencetabs-macros/habitation_macro">
+    </metal:parent_call>
+</metal:peb>
+
+<metal:peb define-macro="peb_macro" i18n:domain="urban">
+    <metal:parent_call use-macro="here/@@licencetabs-macros/peb_macro">
+    </metal:parent_call>
+</metal:peb>
+
+<metal:inquiry define-macro="inquiry_macro" i18n:domain="urban">
+    <metal:parent_call use-macro="here/@@licencetabs-macros/inquiry_macro" />
+</metal:inquiry>
+
+<metal:advices define-macro="advices_macro" i18n:domain="urban">
+    <metal:parent_call use-macro="here/@@licencetabs-macros/advices_macro" />
+</metal:advices>
+
+<metal:patrimony define-macro="patrimony_macro" i18n:domain="urban">
+    <metal:parent_call use-macro="here/@@licencetabs-macros/patrimony_macro" />
+</metal:patrimony>

--- a/src/Products/urban/browser/licence/templates/codt_uniqueborderinglicenceview.pt
+++ b/src/Products/urban/browser/licence/templates/codt_uniqueborderinglicenceview.pt
@@ -1,0 +1,13 @@
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en"
+      lang="en"
+      metal:use-macro="here/main_template/macros/master"
+      i18n:domain="urban">
+
+  <body>
+    <metal:main fill-slot="main">
+      <tal:main_macro define="main_macro view/getLicenceMainTemplateMacro">
+        <metal:test use-macro="main_macro" />
+      </tal:main_macro>
+    </metal:main>
+  </body>
+</html>

--- a/src/Products/urban/config.py
+++ b/src/Products/urban/config.py
@@ -71,6 +71,7 @@ ADD_CONTENT_PERMISSIONS = {
     "CODT_IntegratedLicence": "urban: Add CODT_IntegratedLicence",
     "CODT_ParcelOutLicence": "urban: Add CODT_ParcelOutLicence",
     "CODT_UniqueLicence": "urban: Add CODT_UniqueLicence",
+    "CODT_UniqueBorderingLicence": "urban: Add CODT_UniqueBorderingLicence",
     "CODT_UrbanCertificateTwo": "urban: Add CODT_UrbanCertificateTwo",
     "CODT_UrbanCertificateBase": "urban: Add CODT_UrbanCertificateBase",
     "Contact": "urban: Add Contact",
@@ -137,6 +138,7 @@ setDefaultRoles("urban: Add CODT_IntegratedLicence", ("Manager", "Contributor"))
 setDefaultRoles("urban: Add CODT_NotaryLetter", ("Manager", "Contributor"))
 setDefaultRoles("urban: Add CODT_ParcelOutLicence", ("Manager", "Contributor"))
 setDefaultRoles("urban: Add CODT_UniqueLicence", ("Manager", "Contributor"))
+setDefaultRoles("urban: Add CODT_UniqueBorderingLicence", ("Manager", "Contributor"))
 setDefaultRoles("urban: Add CODT_UrbanCertificateOne", ("Manager", "Contributor"))
 setDefaultRoles("urban: Add CODT_UrbanCertificateTwo", ("Manager", "Contributor"))
 setDefaultRoles("urban: Add CODT_UrbanCertificateBase", ("Manager", "Contributor"))
@@ -204,6 +206,7 @@ URBAN_TYPES = [
     "CODT_IntegratedLicence",
     "UniqueLicence",
     "CODT_UniqueLicence",
+    "CODT_UniqueBorderingLicence",
     "Declaration",
     "UrbanCertificateOne",
     "CODT_UrbanCertificateOne",
@@ -239,6 +242,7 @@ URBAN_TYPES_ACRONYM = {
     "CODT_IntegratedLicence": "PI",
     "UniqueLicence": "PU",
     "CODT_UniqueLicence": "PU",
+    "CODT_UniqueBorderingLicence": "PUL",
     "Declaration": "D",
     "UrbanCertificateOne": "CU1",
     "CODT_UrbanCertificateOne": "CU1",
@@ -290,6 +294,7 @@ URBAN_CODT_TYPES = [
     "CODT_IntegratedLicence",
     "CODT_ParcelOutLicence",
     "CODT_UniqueLicence",
+    "CODT_UniqueBorderingLicence",
     "CODT_UrbanCertificateTwo",
     "CODT_UrbanCertificateOne",
     "CODT_NotaryLetter",

--- a/src/Products/urban/content/licence/CODT_UniqueBorderingLicence.py
+++ b/src/Products/urban/content/licence/CODT_UniqueBorderingLicence.py
@@ -1,0 +1,148 @@
+# -*- coding: utf-8 -*-
+
+from AccessControl import ClassSecurityInfo
+from Products.Archetypes.atapi import *
+from Products.CMFDynamicViewFTI.browserdefault import BrowserDefaultMixin
+from Products.DataGridField import DataGridField
+from Products.DataGridField import DataGridWidget
+from Products.DataGridField.Column import Column
+from Products.urban import interfaces
+from Products.urban import UrbanMessage as _
+from Products.urban.config import *
+from Products.urban.content.licence.CODT_UniqueLicence import CODT_UniqueLicence
+from Products.urban.utils import setOptionalAttributes
+from zope.interface import implements
+
+from zope.i18n import translate
+
+optional_fields = []
+
+schema = Schema(
+    (
+        DataGridField(
+            name="workLocations",
+            schemata="urban_description",
+            widget=DataGridWidget(
+                columns={"number": Column("Number"), "street": Column("Street")},
+                label=_("urban_label_workLocations", default="Work locations"),
+            ),
+            allow_oddeven=True,
+            columns=("number", "street"),
+        ),
+        StringField(
+            name="zipcode",
+            schemata="urban_description",
+            widget=StringField._properties["widget"](
+                label=_("urban_label_zipcode", default="Zipcode"),
+            ),
+        ),
+        StringField(
+            name="city",
+            schemata="urban_description",
+            widget=StringField._properties["widget"](
+                label=_("urban_label_city", default="City"),
+            ),
+        ),
+        DataGridField(
+            name="manualParcels",
+            schemata="urban_description",
+            widget=DataGridWidget(
+                columns={
+                    "ref": Column("Référence cadastrale"),
+                    "capakey": Column("Capakey"),
+                },
+                label=_("urban_label_manualParcels", default="Manualparcels"),
+            ),
+            allow_oddeven=True,
+            columns=("ref", "capakey"),
+        ),
+    ),
+)
+
+setOptionalAttributes(schema, optional_fields)
+
+CODT_UniqueBorderingLicence_schema = (
+    BaseFolderSchema.copy()
+    + getattr(CODT_UniqueLicence, "schema", Schema(())).copy()
+    + schema.copy()
+)
+
+
+class CODT_UniqueBorderingLicence(BaseFolder, CODT_UniqueLicence, BrowserDefaultMixin):
+    """ """
+
+    security = ClassSecurityInfo()
+    implements(interfaces.ICODT_UniqueBorderingLicence)
+
+    meta_type = "CODT_UniqueBorderingLicence"
+    _at_rename_after_creation = True
+
+    schema = CODT_UniqueBorderingLicence_schema
+
+    security.declarePublic("getDefaultWorkLocationSignaletic")
+
+    def getDefaultWorkLocationSignaletic(self, auto_back_to_the_line=False):
+        """
+        Returns a string reprensenting the different worklocations
+        """
+        signaletic = ""
+
+        for wl in self.getWorkLocations():
+            streetName = wl["street"]
+            number = wl["number"]
+            city = self.getCity()
+            zipcode = self.getZipcode()
+            if signaletic:
+                signaletic += " %s " % translate(
+                    "and", "urban", context=self.REQUEST
+                ).encode("utf8")
+            if number:
+                signaletic += "%s %s à %s %s" % (
+                    streetName,
+                    number.encode("utf8"),
+                    zipcode,
+                    city,
+                )
+            else:
+                signaletic += "%s - %s %s" % (streetName, zipcode, city)
+            if auto_back_to_the_line:
+                signaletic += "\n"
+
+        return signaletic
+
+    security.declarePublic("getDefaultStreetAndNumber")
+
+    def getDefaultStreetAndNumber(self, separator=""):
+        """
+        Returns a string reprensenting the different streets and numbers
+        """
+        signaletic = ""
+
+        for wl in self.getWorkLocations():
+            street = wl["street"]
+            number = wl["number"]
+            if number:
+                signaletic = "{} {}{} {}".format(signaletic, street, separator, number)
+            else:
+                signaletic = "{} {}".format(signaletic, street)
+
+        return signaletic
+
+
+registerType(CODT_UniqueBorderingLicence, PROJECTNAME)
+
+
+def finalizeSchema(schema):
+    """
+    Finalizes the type schema to alter some fields
+    """
+    schema.moveField("city", after="workLocations")
+    schema.moveField("zipcode", after="city")
+    schema.moveField("manualParcels", after="zipcode")
+    schema.moveField("foldermanagers", after="manualParcels")
+    schema.moveField("description", after="additionalLegalConditions")
+    schema.moveField("missingPartsDetails", after="missingParts")
+    return schema
+
+
+finalizeSchema(CODT_UniqueBorderingLicence_schema)

--- a/src/Products/urban/dashboard/config/codt_uniqueborderinglicences.xml
+++ b/src/Products/urban/dashboard/config/codt_uniqueborderinglicences.xml
@@ -1,0 +1,188 @@
+<?xml version="1.0"?>
+<object name="codt_uniqueborderinglicences" meta_type="ATFolder">
+ <criteria>
+  <criterion name="c1">
+   <property name="widget">sorting</property>
+   <property name="title">Tri</property>
+   <property name="position">top</property>
+   <property name="section">default</property>
+   <property name="hidden">True</property>
+   <property
+      name="vocabulary">eea.faceted.vocabularies.SortingCatalogIndexes</property>
+   <property name="default">created(reverse)</property>
+  </criterion>
+  <criterion name="c2">
+   <property name="widget">collection-link</property>
+   <property name="title">Procédures</property>
+   <property name="position">top</property>
+   <property name="section">default</property>
+   <property name="hidden">True</property>
+   <property name="count"></property>
+   <property name="sortcountable"></property>
+   <property name="hidezerocount"></property>
+   <property
+      name="vocabulary">collective.eeafaceted.collectionwidget.cachedcollectionvocabulary</property>
+   <property name="hidealloption">True</property>
+   <property name="hide_category">True</property>
+   <property name="sortreversed"></property>
+   <property name="default">e52f951ad5264b74aa010f30375002e8</property>
+  </criterion>
+  <criterion name="c11">
+   <property name="widget">daterange</property>
+   <property name="title">Date de la décision</property>
+   <property name="position">top</property>
+   <property name="section">advanced</property>
+   <property name="hidden">False</property>
+   <property name="index">getDecisionDate</property>
+   <property name="default"></property>
+   <property name="calYearRange">c-10:c+10</property>
+  </criterion>
+  <criterion name="c99">
+   <property name="widget">daterange</property>
+   <property name="title">Date de validité</property>
+   <property name="position">top</property>
+   <property name="section">advanced</property>
+   <property name="hidden">False</property>
+   <property name="index">getValidityDate</property>
+   <property name="default"></property>
+   <property name="calYearRange">c-10:c+10</property>
+  </criterion>
+  <criterion name="c10">
+   <property name="widget">text</property>
+   <property name="title">Demandeur</property>
+   <property name="position">top</property>
+   <property name="section">advanced</property>
+   <property name="hidden">False</property>
+   <property name="index">applicantInfosIndex</property>
+   <property name="default"></property>
+   <property name="onlyallelements">True</property>
+   <property name="wildcard">True</property>
+  </criterion>
+  <criterion name="c9">
+   <property name="widget">autocomplete</property>
+   <property name="title">Architecte</property>
+   <property name="position">top</property>
+   <property name="section">advanced</property>
+   <property name="hidden">False</property>
+   <property name="index">representatives</property>
+   <property name="default"></property>
+   <property
+      name="autocomplete_view">architects-autocomplete-suggest</property>
+   <property name="onlyallelements">True</property>
+  </criterion>
+  <criterion name="c4">
+   <property name="widget">autocomplete</property>
+   <property name="title">Rue</property>
+   <property name="position">top</property>
+   <property name="section">advanced</property>
+   <property name="hidden">False</property>
+   <property name="index">StreetsUID</property>
+   <property name="default"></property>
+   <property name="autocomplete_view">sreets-autocomplete-suggest</property>
+   <property name="onlyallelements">True</property>
+  </criterion>
+  <criterion name="c7">
+   <property name="widget">text</property>
+   <property name="title">N° de police</property>
+   <property name="position">top</property>
+   <property name="section">advanced</property>
+   <property name="hidden">False</property>
+   <property name="index">StreetNumber</property>
+   <property name="default"></property>
+   <property name="onlyallelements">True</property>
+   <property name="wildcard"></property>
+  </criterion>
+  <criterion name="c8">
+   <property name="widget">autocomplete</property>
+   <property name="title">Référence cadastrale</property>
+   <property name="position">top</property>
+   <property name="section">advanced</property>
+   <property name="hidden">False</property>
+   <property name="index">parcelInfosIndex</property>
+   <property name="default"></property>
+   <property
+      name="autocomplete_view">cadastral-autocomplete-suggest</property>
+   <property name="onlyallelements">True</property>
+  </criterion>
+  <criterion name="c98">
+   <property name="widget">text</property>
+   <property name="title">Référence supplémentaire</property>
+   <property name="position">top</property>
+   <property name="section">advanced</property>
+   <property name="hidden">False</property>
+   <property name="index">getAdditionalReference</property>
+   <property name="default"></property>
+   <property name="onlyallelements">True</property>
+   <property name="wildcard">True</property>
+  </criterion>
+  <criterion name="c5">
+   <property name="widget">text</property>
+   <property name="title">Titre, référence</property>
+   <property name="position">center</property>
+   <property name="section">default</property>
+   <property name="hidden">False</property>
+   <property name="index">Title</property>
+   <property name="default"></property>
+   <property name="onlyallelements">True</property>
+   <property name="wildcard">True</property>
+  </criterion>
+  <criterion name="c6">
+   <property name="widget">select</property>
+   <property name="title">Agent traitant</property>
+   <property name="position">center</property>
+   <property name="section">default</property>
+   <property name="hidden">False</property>
+   <property name="count"></property>
+   <property name="sortcountable"></property>
+   <property name="hidezerocount"></property>
+   <property name="index">folder_manager</property>
+   <property name="vocabulary">urban.folder_managers</property>
+   <property name="catalog"></property>
+   <property name="sortreversed"></property>
+   <property name="default"></property>
+  </criterion>
+  <criterion name="c3">
+   <property name="widget">checkbox</property>
+   <property name="title">État</property>
+   <property name="position">center</property>
+   <property name="section">default</property>
+   <property name="hidden">False</property>
+   <property name="count">0</property>
+   <property name="sortcountable">0</property>
+   <property name="hidezerocount">0</property>
+   <property name="index">review_state</property>
+   <property name="operator">or</property>
+   <property name="operator_visible">0</property>
+   <property name="vocabulary">urban.rootfolder_licence_state</property>
+   <property name="catalog"></property>
+   <property name="sortreversed">0</property>
+  </criterion>
+  <criterion name="c0">
+   <property name="widget">resultsperpage</property>
+   <property name="title">Results per page</property>
+   <property name="position">center</property>
+   <property name="section">default</property>
+   <property name="hidden">False</property>
+   <property name="start">0</property>
+   <property name="end">50</property>
+   <property name="step">10</property>
+   <property name="default">20</property>
+  </criterion>
+ <criterion name="c97">
+   <property name="widget">select2</property>
+   <property name="title">Prorogation complémentaire</property>
+   <property name="index">getComplementary_delay</property>
+   <property
+      name="vocabulary">urban.vocabularies.complementary_delay</property>
+   <property name="catalog"></property>
+   <property name="hidealloption">False</property>
+   <property name="position">center</property>
+   <property name="section">default</property>
+   <property name="hidden">False</property>
+   <property name="count">False</property>
+   <property name="sortcountable">False</property>
+   <property name="hidezerocount">False</property>
+   <property name="sortreversed">False</property>
+  </criterion>
+ </criteria>
+</object>

--- a/src/Products/urban/indexes.py
+++ b/src/Products/urban/indexes.py
@@ -158,7 +158,7 @@ def genericlicence_modified(licence):
 
 @indexer(interfaces.IGenericLicence)
 def genericlicence_streetsuid(licence):
-    if licence.portal_type in ["EnvClassBordering"]:
+    if licence.portal_type in ["EnvClassBordering", "CODT_UniqueBorderingLicence"]:
         return []
     streets = [location["street"] for location in licence.getWorkLocations()]
     return streets

--- a/src/Products/urban/interfaces.py
+++ b/src/Products/urban/interfaces.py
@@ -315,6 +315,10 @@ class ICODT_IntegratedLicence(ICODT_BaseBuildLicence):
     """Marker interface for  CODT_ IntegratedLicence"""
 
 
+class ICODT_UniqueBorderingLicence(ICODT_UniqueLicence):
+    """Marker interface for CODT_UniqueLicenceBordering"""
+
+
 class ILicenceContainer(Interface):
     """
     Marker interface for a folder containing Licences

--- a/src/Products/urban/locales/fr/LC_MESSAGES/urban.po
+++ b/src/Products/urban/locales/fr/LC_MESSAGES/urban.po
@@ -214,6 +214,9 @@ msgstr "Lettre de notaire (CODT)"
 msgid "CODT_ParcelOutLicence"
 msgstr "Permis d'urbanisation (CODT)"
 
+msgid "CODT_UniqueBorderingLicence"
+msgstr "Permis Unique commune limitrophe (CODT)"
+
 msgid "CODT_UniqueLicence"
 msgstr "Permis Unique (CODT)"
 
@@ -1445,6 +1448,9 @@ msgstr "Paramètres des lettres de notaire (CODT)"
 
 msgid "codt_parceloutlicence_urbanconfig_title"
 msgstr "Paramètres des permis d'urbanisation (CODT)"
+
+msgid "codt_uniqueborderinglicence_urbanconfig_title"
+msgstr "Paramètres des permis uniques communes limitrophes (CODT)"
 
 msgid "codt_uniquelicence_urbanconfig_title"
 msgstr "Paramètres des permis uniques (CODT)"

--- a/src/Products/urban/locales/urban-manual.pot
+++ b/src/Products/urban/locales/urban-manual.pot
@@ -56,6 +56,9 @@ msgstr ""
 msgid "CODT_UniqueLicence"
 msgstr ""
 
+msgid "CODT_UniqueBorderingLicence"
+msgstr ""
+
 msgid "CODT_UrbanCertificateOne"
 msgstr ""
 
@@ -216,6 +219,9 @@ msgid "codt_parceloutlicence_urbanconfig_title"
 msgstr ""
 
 msgid "codt_uniquelicence_urbanconfig_title"
+msgstr ""
+
+msgid "codt_uniqueborderinglicence_urbanconfig_title"
 msgstr ""
 
 msgid "codt_urbancertificateone_urbanconfig_title"

--- a/src/Products/urban/migration/update_290.py
+++ b/src/Products/urban/migration/update_290.py
@@ -3,6 +3,7 @@ from Products.CMFCore.utils import getToolByName
 from Products.urban import URBAN_TYPES
 from Products.urban import UrbanMessage as _
 from Products.urban.migration.utils import cook_javascript_resources
+from Products.urban.setuphandlers import add_new_urban_licence_type
 from Products.urban.utils import moveElementAfter
 from dm.historical import getHistory
 from plone import api
@@ -283,3 +284,29 @@ def add_architect_folder_view(context):
     architects_folder = portal["urban"]["architects"]
     architects_folder.setLayout("architects_folderview")
     logger.info("upgrade step done!")
+
+
+def add_codt_uniquebordering_licences(context):
+    """
+    Note: the events must be added by upgrade step in `urban.events`
+    """
+
+    logger = logging.getLogger("urban: Add CODT unique bordering licences")
+
+    portal_setup = api.portal.get_tool("portal_setup")
+    portal_setup.runImportStepFromProfile(
+        "profile-Products.urban:preinstall", "workflow"
+    )
+    portal_setup.runImportStepFromProfile(
+        "profile-Products.urban:preinstall", "update-workflow-rolemap"
+    )
+    portal_setup.runImportStepFromProfile(
+        "profile-Products.urban:urbantypes", "typeinfo"
+    )
+    portal_setup.runImportStepFromProfile(
+        "profile-Products.urban:urbantypes", "factorytool"
+    )
+
+    add_new_urban_licence_type("CODT_UniqueBorderingLicence")
+
+    logger.info("Upgrade done!")

--- a/src/Products/urban/migration/upgrades_290.zcml
+++ b/src/Products/urban/migration/upgrades_290.zcml
@@ -60,4 +60,12 @@
         handler=".update_290.add_architect_folder_view"
         profile="Products.urban:default" />
 
+    <gs:upgradeStep
+        title="Add CODT unique bordering licences"
+        description=""
+        source="2906"
+        destination="2907"
+        handler=".update_290.add_codt_uniquebordering_licences"
+        profile="Products.urban:default" />
+
 </configure>

--- a/src/Products/urban/notice/notification.py
+++ b/src/Products/urban/notice/notification.py
@@ -114,6 +114,11 @@ class NoticeNotification(NoticeElement):
                             "2": "EnvClassTwo",
                             "3": "EnvClassThree",
                         }.get(penv_classe, None)
+            elif self.notice_type == "DEMANDE_EP_EXTRA":
+                self._licence_type = {
+                    "PU": "CODT_UniqueBorderingLicence",
+                    "PE": "EnvClassBordering",
+                }.get(self.notification_subtype)
             else:
                 existing_licence = self.licence
                 if existing_licence:

--- a/src/Products/urban/profiles/default/metadata.xml
+++ b/src/Products/urban/profiles/default/metadata.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <metadata>
-  <version>2906</version>
+  <version>2907</version>
   <dependencies>
     <dependency>profile-Products.urban:preinstall</dependency>
   </dependencies>

--- a/src/Products/urban/profiles/extra/config_default_values.py
+++ b/src/Products/urban/profiles/extra/config_default_values.py
@@ -1870,7 +1870,7 @@ default_values = {
         ],
         "foldertendencies": [
             "UrbanVocabularyTerm",
-            ["UniqueLicence", "CODT_UniqueLicence"],
+            ["UniqueLicence", "CODT_UniqueLicence", "CODT_UniqueBorderingLicence"],
             {"id": "env", "title": u"Environnementale"},
             {"id": "urb", "title": u"Urbanistique"},
         ],
@@ -1938,6 +1938,7 @@ default_values = {
             [
                 "CODT_IntegratedLicence",
                 "CODT_UniqueLicence",
+                "CODT_UniqueBorderingLicence",
                 "EnvClassOne",
                 "EnvClassTwo",
                 "EnvClassBordering",
@@ -2670,6 +2671,7 @@ default_values = {
                 "ParcelOutLicence",
                 "UrbanCertificateTwo",
                 "CODT_UniqueLicence",
+                "CODT_UniqueBorderingLicence",
                 "CODT_IntegratedLicence",
                 "CODT_CommercialLicence",
                 "RoadDecree",
@@ -2722,6 +2724,7 @@ default_values = {
                 "ParcelOutLicence",
                 "UrbanCertificateTwo",
                 "CODT_UniqueLicence",
+                "CODT_UniqueBorderingLicence",
                 "CODT_IntegratedLicence",
                 "CODT_CommercialLicence",
             ],
@@ -2744,6 +2747,7 @@ default_values = {
                 "CODT_ParcelOutLicence",
                 "CODT_UrbanCertificateTwo",
                 "CODT_UniqueLicence",
+                "CODT_UniqueBorderingLicence",
                 "CODT_IntegratedLicence",
                 "CODT_CommercialLicence",
             ],
@@ -3947,6 +3951,180 @@ default_values = {
                 "id": "rez-de-chaussee", 
                 "title": "Rez-de-chaussée",
             },
+        ],
+    },
+    "CODT_UniqueBorderingLicence": {
+        "folderdelays": [
+            "UrbanDelay",
+            {"id": "90j", "title": u"90 jours", "deadLineDelay": 90, "alertDelay": 20},
+            {
+                "id": "120j",
+                "title": u"120 jours",
+                "deadLineDelay": 120,
+                "alertDelay": 20,
+            },
+            {
+                "id": "140j",
+                "title": u"140 jours",
+                "deadLineDelay": 140,
+                "alertDelay": 20,
+            },
+            {
+                "id": "170j",
+                "title": u"170 jours",
+                "deadLineDelay": 170,
+                "alertDelay": 20,
+            },
+            {"id": "50j", "title": u"50 jours", "deadLineDelay": 50, "alertDelay": 20},
+            {
+                "id": "inconnu",
+                "title": u"Inconnu",
+                "deadLineDelay": 0,
+                "alertDelay": 20,
+            },
+        ],
+        "investigationarticles": [
+            "UrbanVocabularyTerm",
+            {
+                "id": "enquete-derogation",
+                "title": u"Article D.IV.40 - Dérogation à un plan ou aux normes d'un guide régional",
+                "description": u"<p>Application de l'article D.IV.40 : Les demandes impliquant une ou plusieurs dérogations au plan de secteur ou aux normes du guide régional sont soumises à enquête publique.</p> ",
+            },
+            {
+                "id": "enquete-derogation-facultative",
+                "title": u'Article D.VIII.13 - Procédure d\'enquête publique "facultative"',
+                "description": u"<p>Application de l'article D.VIII.13. L’autorité compétente pour adopter le plan, périmètre, schéma ou le guide et pour délivrer les<br /> permis et certificats d’urbanisme no 2, ainsi que les collèges communaux des communes organisant l’annonce de projet<br /> ou l’enquête publique, peuvent procéder à toute forme supplémentaire de publicité et d’information dans le respect des<br /> délais de décision qui sont impartis à l’autorité compétente.</p>",
+            },
+            {
+                "id": "R.IV.40-1.1.1",
+                "title": u"R.IV.40-1.§1-1° - Hauteur des constructions",
+                "description": u"<p> Article R.IV.40-1.§1-1° du CoDT : 1° la construction ou la reconstruction de bâtiments dont la hauteur est d’au moins six niveaux ou dix-huit mètres sous corniche et dépasse de trois mètres ou plus la moyenne des hauteurs sous corniche des bâtiments situés dans la même rue jusqu’à cinquante mètres de part et d’autre de la construction projetée, la transformation de bâtiments ayant pour effet de placer ceux-ci dans les mêmes conditions ;</p>",
+            },
+            {
+                "id": "R.IV.40-1.1.2",
+                "title": u"R.IV.40-1.§1-2°- Magasin de plus de 400m2",
+                "description": u"<p>Article R.IV.40-1.§1-2° du CoDT : «&nbsp;la construction, la reconstruction d'un magasin ou la modification de la destination d'un bâtiment en magasin dont la surface commerciale nette est supérieure à quatre cents mètres carrés ; la transformation de bâtiments ayant pour effet de placer ceux-ci dans les mêmes conditions&nbsp;»</p> ",
+            },
+            {
+                "id": "R.IV.40-1.1.3",
+                "title": u"R.IV.40-1.§1.3° - Usage destiné aux bureaux de plus de 650m2",
+                "description": u"<p>Article R.IV.40-1.§1.3° du CoDT: «&nbsp;la construction, la reconstruction de bureaux ou la modification de la destination d'un bâtiment en bureaux dont la superficie des planchers est supérieure à sixccent cinquante mètres carrés, la transformation de bâtiments ayant pour effet de placer ceux-ci dans les mêmes conditions&nbsp;»</p>",
+            },
+            {
+                "id": "R.IV.40-1.1.4",
+                "title": u"R.IV.40-1.§1.4° - Destination à usage de stockage supérieur à 400m2",
+                "description": u"<p>Article R.IV.40-1.§1.4° du CoDT : «&nbsp;la construction, la reconstruction ou la modification de la destination d'un bâtiment en atelier, entrepôt ou hall de stockage à caractère non agricole dont la superficie des planchers est supérieure à quatre cents mètres carrés, la transformation de bâtiments ayant pour effet de placer ceux-ci dans les mêmes conditions&nbsp;»</p>",
+            },
+            {
+                "id": "R.IV.40-1.1.5",
+                "title": u"R.IV.40-1.§1.5° - Utilisation habituelle d'un terrain pour le dépôt d'un ou plusieurs véhicules usagés, de mitrailles, de matériaux ou de déchets",
+                "description": u"<p>Article R.IV.40-1.§1.5° du CoDT : «&nbsp;l'utilisation habituelle d'un terrain pour le dépôt d'un ou plusieurs véhicules usagés, de mitrailles, de matériaux ou de déchets&nbsp;»</p> ",
+            },
+            {
+                "id": "R.IV.40-1.1.6",
+                "title": u"R.IV.40-1.§1.6° - Les demandes de permis d'urbanisation et les demandes de permis d'urbanisme relatives à la construction, la reconstruction ou la transformation d'un bâtiment inscrit sur la liste de sauvegarde ou classés",
+                "description": u"<p>Article R.IV.40-1.§1.6° du CoDT : «&nbsp;la construction, la reconstruction ou la transformation d'un bâtiment qui se rapporte à des biens immobiliers inscrits sur la liste de sauvegarde, classés, situés dans une zone de protectioon visée à l'article 209 du Code wallon du Patrimoine ou localisés dans un site repris à l'inventaire du patrimoine archéologique visé à l'article 233 du Code wallon du Patrimoine »</p> ",
+            },
+            {
+                "id": "R.IV.40-1.1.7",
+                "title": u"R.IV.40-1.§1.7° - Ouverture ou modification de la voirie communale",
+                "description": u"i<p>Article R.IV.40-1.§1.7° du CoDT« les demande de permis d'urbanisation, de permis d'urbanisme ou de certificats d'urbanisme n°2 visées à l'article D.IV.41 »</p> ",
+            },
+            {
+                "id": "R.IV.40-1.1.8",
+                "title": u"R.IV.40-1.§1.8° - Voiries régionales",
+                "description": u'<p>Article R.IV.40-1.§1.8° du CoD - " les voiries visées à l\'article R.II.21-1,1° pour autant que les actes et travaux impliquent une modification de leur gabarit"</p>',
+            },
+        ],
+        "announcementarticles": [
+            "UrbanVocabularyTerm",
+            {
+                "id": "ecarts",
+                "title": u"Article D.IV.40 - Écarts à un schéma, à un guide ou à un permis d'urbanisation",
+                "description": u"<p>Application de l'article D.IV.40. : Les demandes impliquant un ou plusieurs écarts aux plans communaux d’aménagement adoptés avant l’entrée en vigueur du Code et devenus schémas d’orientation locaux, aux règlements adoptés avant l’entrée en vigueur du Code et devenus guides et aux permis d’urbanisation sont soumises à annonce de projet, et ce, jusqu’à la révision ou à l’abrogation du schéma ou du guide.</p> ",
+            },
+            {
+                "id": "ecarts-facultatifs",
+                "title": u'Article D.VIII.13 - Procédure d\'annonce de projet "facultative"',
+                "description": u"<p>Art. D.VIII.13. L’autorité compétente pour adopter le plan, périmètre, schéma ou le guide et pour délivrer les<br /> permis et certificats d’urbanisme no 2, ainsi que les collèges communaux des communes organisant l’annonce de projet<br /> ou l’enquête publique, peuvent procéder à toute forme supplémentaire de publicité et d’information dans le respect des<br /> délais de décision qui sont impartis à l’autorité compétente.</p> ",
+            },
+            {
+                "id": "R.IV.40-2-1-1",
+                "title": u"R.IV.40-2.§1.1° - Hauteur des constructions",
+                "description": u"<p>Article R.IV.40-2.§1-1°du CoDT : «&nbsp;la construction ou la reconstruction de bâtiments dont la hauteur est d’au moins trois niveaux ou neuf mètres sous corniche et dépasse de trois mètres ou plus la moyenne des hauteurs sous corniche des bâtiments situés dans la même rue jusqu’à cinquante mètres de part et d’autre de la construction projetée; la transformation de bâtiments ayant pour effet de placer ceux-ci dans les mêmes conditions;»</p> ",
+            },
+            {
+                "id": "R.IV.40-2-1-2",
+                "title": u"R.IV.40-2 § 2° - Profondeur de bâtisse",
+                "description": u"<p>Article R.IV.40-2.§1-2°: «&nbsp;la construction ou la reconstruction de bâtiments dont la profondeur, mesurée à partir de l'alignement ou du front de bâtisse lorsque les constructions voisines ne sont pas implantées sur l'alignement, est supérieure à 15 mètres et dépasse de plus de 4 mètres les bâtiments situés sur les parcelles contiguës, la transformation de bâtiments ayant pour effet de placer ceux-ci dans les mêmes conditions&nbsp;»</p>",
+            },
+            {
+                "id": "R.IV.40-2-1-3",
+                "title": u"R.IV.40-2.§1-3° - Magasin de moins de 400m2",
+                "description": u"<p>Article R.IV.40-2.§1-3 : «&nbsp;la construction, la reconstruction d'un magasin ou la modification de la destination d'un bâtiment en magasin dont la surface commerciale nette est inférieure à quatre cent mètres carrés ; la transformation de bâtiments ayant pour effet de placer ceux-ci dans les mêmes conditions&nbsp;»</p>",
+            },
+        ],
+        "derogations": [
+            "UrbanVocabularyTerm",
+            {"id": "dero-ps", "title": u"au plan de secteur"},
+            {
+                "id": "dero-gru",
+                "title": u"à une ou des norme(s) du Guide Régional d'Urbanisme ",
+            },
+        ],
+        "divergences": [
+            "UrbanVocabularyTerm",
+            {"id": "ecart-purba", "title": u"au permis d'urbanisation"},
+            {"id": "ecart-gcu", "title": u"au Guide Communal d'Urbanisme"},
+            {"id": "ecart-gru", "title": u"au Guide Régional d'Urbanisme"},
+            {"id": "ecart-sol", "title": u"au Schéma d'Orientation Local"},
+        ],
+        "missingparts": [
+            "UrbanVocabularyTerm",
+            {"id": "plan_travaux", "title": u"Plan des travaux en 4 exemplaires"},
+            {
+                "id": "photos",
+                "title": u"3 photos numérotées de la parcelle ou immeuble en 4 exemplaires",
+            },
+            {
+                "id": "notice_environnement",
+                "title": u"Notice d'évaluation préalable d'incidences environnement en 4 exemplaires",
+            },
+            {"id": "plan_secteur", "title": u"Une copie du plan de secteur"},
+            {"id": "peb", "title": u"Formulaire d'engagement PEB en 4 exemplaires"},
+        ],
+        "exemptfdarticle": [
+            "UrbanVocabularyTerm",
+            {
+                "id": "annexe4",
+                "title": u"Annexe 4 - Demande de permis avec concours d'un architecte",
+            },
+            {
+                "id": "annexe5",
+                "title": u"Annexe 5 - Modification de la destination ou modification de la répartition des surfaces de vente",
+            },
+            {
+                "id": "annexe6",
+                "title": u"Annexe 6 - Modification sensible du relief du sol - dépôt de véhicules, de mitrailles, de matériaux ou de déchets - installations mobiles - travaux d'aménagement au sol aux abords d'une construction autorisée",
+            },
+            {
+                "id": "annexe7",
+                "title": u"Annexe 7 - Boisement - déboisement - abattage - culture de sapins de Noël - modification de l'aspect d'un ou plusieurs arbres ou haies remarquables - défrichement - modification de la végétation",
+            },
+            {"id": "annexe8", "title": u"Annexe 8 - Travaux techniques"},
+            {
+                "id": "annexe9",
+                "title": u"Annexe 9 - Permis d'urbanisme dispensé d'un architecte ou autre que les demandes visées aux annexes 5 à 8",
+            },
+        ],
+        "authority": [
+            "UrbanVocabularyTerm",
+            {
+                "id": "fd_ft",
+                "title": u"Fonctionnaire délégué et le Fonctionnaire technique",
+            },
+            {"id": "college", "title": u"Collège"},
+            {"id": "ft", "title": u"Fonctionnaire technique"},
         ],
     },
 }

--- a/src/Products/urban/profiles/preinstall/workflows.xml
+++ b/src/Products/urban/profiles/preinstall/workflows.xml
@@ -41,6 +41,9 @@
       <type type_id="CODT_UniqueLicence">
          <bound-workflow workflow_id="codt_buildlicence_workflow" />
       </type>
+      <type type_id="CODT_UniqueBorderingLicence">
+         <bound-workflow workflow_id="codt_buildlicence_workflow" />
+      </type>
       <type type_id="CODT_UrbanCertificateBase">
          <bound-workflow workflow_id="urban_licence_workflow" />
       </type>

--- a/src/Products/urban/profiles/urban_types/factorytool.xml
+++ b/src/Products/urban/profiles/urban_types/factorytool.xml
@@ -7,6 +7,7 @@
   <type portal_type="CODT_NotaryLetter"/>
   <type portal_type="CODT_ParcelOutLicence"/>
   <type portal_type="CODT_UniqueLicence"/>
+  <type portal_type="CODT_UniqueBorderingLicence"/>
   <type portal_type="CODT_UrbanCertificateBase"/>
   <type portal_type="CODT_UrbanCertificateOne"/>
   <type portal_type="CODT_UrbanCertificateTwo"/>

--- a/src/Products/urban/profiles/urban_types/types.xml
+++ b/src/Products/urban/profiles/urban_types/types.xml
@@ -129,6 +129,8 @@
          meta_type="Factory-based Type Information with dynamic views"/>
  <object name="CODT_UniqueLicence"
          meta_type="Factory-based Type Information with dynamic views"/>
+ <object name="CODT_UniqueBorderingLicence"
+         meta_type="Factory-based Type Information with dynamic views"/>
  <object name="IntegratedLicence"
          meta_type="Factory-based Type Information with dynamic views"/>
  <object name="CODT_IntegratedLicence"

--- a/src/Products/urban/profiles/urban_types/types/CODT_UniqueBorderingLicence.xml
+++ b/src/Products/urban/profiles/urban_types/types/CODT_UniqueBorderingLicence.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0"?>
+<object name="CODT_UniqueBorderingLicence"
+        meta_type="Factory-based Type Information with dynamic views"
+        xmlns:i18n="http://xml.zope.org/namespaces/i18n"
+        i18n:domain="plone">
+
+ <property name="title" i18n:translate="">CODT_UniqueBorderingLicence</property>
+ <property name="description" i18n:translate=""></property>
+ <property name="icon_expr">string:${portal_url}/UniqueBorderingLicence.png</property>
+ <property name="content_meta_type">CODT_UniqueBorderingLicence</property>
+ <property name="product">urban</property>
+ <property name="factory">addCODT_UniqueBorderingLicence</property>
+ <!-- not a mistake, article127 and buildlicence are the same -->
+ <property name="immediate_view">codt_uniqueborderinglicenceview</property>
+ <property name="global_allow">True</property>
+ <property name="filter_content_types">True</property>
+ <property name="allowed_content_types">
+   <element value="Applicant"/>
+   <element value="Couple"/>
+   <element value="Corporation"/>
+   <element value="Parcel"/>
+   <element value="UrbanEvent"/>
+   <element value="UrbanEventNotice"/>
+   <element value="UrbanEventAnnouncement"/>
+   <element value="UrbanEventInquiry"/>
+   <element value="UrbanEventCollege"/>
+   <element value="UrbanEventMayor"/>
+   <element value="UrbanEventNotificationCollege"/>
+   <element value="UrbanEventOpinionRequest"/>
+   <element value="CODT_UniqueLicenceInquiry"/>
+   <element value="File"/>
+   <element value="task"/>
+   <element value="ConfigTest"/>
+ </property>
+ <property name="allow_discussion">False</property>
+ <property name="default_view">codt_uniqueborderinglicenceview</property>
+ <property name="view_methods">
+  <element value="folder_summary_view"/>
+  <element value="folder_tabular_view"/>
+  <element value="atct_album_view"/>
+  <element value="folder_listing"/>
+  <!-- not a mistake, article127 and buildlicence are the same -->
+  <element value="codt_uniqueborderinglicenceview"/>
+ </property>
+ <property name="default_view_fallback">False</property>
+ <alias from="(Default)" to="(dynamic view)"/>
+ <!-- not a mistake, article127 and buildlicence are the same -->
+ <alias from="view" to="codt_uniqueborderinglicenceview"/>
+ <alias from="edit" to="base_edit"/>
+ <alias from="sharing" to="@@sharing"/>
+ <action title="View"
+         action_id="view"
+         category="object"
+         condition_expr=""
+         url_expr="string:${object_url}/view"
+         visible="True">
+  <permission value="View"/>
+ </action>
+ <action title="Edit"
+         action_id="edit"
+         category="object"
+         condition_expr="python:context.mayShowEditAction()"
+         url_expr="string:${object_url}/edit"
+         visible="True">
+  <permission value="Modify portal content"/>
+ </action>
+<!-- ##code-section FOOT -->
+<!-- ##/code-section FOOT -->
+</object>

--- a/src/Products/urban/schedule/config/codt_uniqueborderinglicence.xml
+++ b/src/Products/urban/schedule/config/codt_uniqueborderinglicence.xml
@@ -1,0 +1,70 @@
+<?xml version="1.0"?>
+<object name="schedule" meta_type="ATFolder">
+ <criteria>
+  <criterion name="c1">
+   <property name="widget">collection-link</property>
+   <property name="title">Base collections</property>
+   <property name="position">top</property>
+   <property name="section">default</property>
+   <property name="hidden">True</property>
+   <property name="count"></property>
+   <property name="sortcountable"></property>
+   <property name="hidezerocount"></property>
+   <property name="vocabulary">imio.schedule.collections</property>
+   <property name="hidealloption">True</property>
+   <property name="hide_category">True</property>
+   <property name="maxitems">0</property>
+   <property name="sortreversed"></property>
+   <property name="default"></property>
+  </criterion>
+  <criterion name="c0">
+   <property name="widget">sorting</property>
+   <property name="title">Sort on</property>
+   <property name="position">top</property>
+   <property name="section">default</property>
+   <property name="hidden">True</property>
+   <property name="vocabulary"></property>
+   <property name="default"></property>
+  </criterion>
+  <criterion name="c4">
+   <property name="widget">checkbox</property>
+   <property name="title">Review state</property>
+   <property name="position">top</property>
+   <property name="section">advanced</property>
+   <property name="hidden">False</property>
+   <property name="count"></property>
+   <property name="sortcountable"></property>
+   <property name="hidezerocount"></property>
+   <property name="index">review_state</property>
+   <property name="operator">or</property>
+   <property name="operator_visible"></property>
+   <property
+      name="vocabulary">plone.app.vocabularies.WorkflowStates</property>
+   <property name="catalog"></property>
+   <property name="maxitems">0</property>
+   <property name="sortreversed"></property>
+  </criterion>
+  <criterion name="c2">
+   <property name="widget">text</property>
+   <property name="title">Search</property>
+   <property name="position">center</property>
+   <property name="section">default</property>
+   <property name="hidden">False</property>
+   <property name="index">SearchableText</property>
+   <property name="default"></property>
+   <property name="onlyallelements">True</property>
+   <property name="wildcard">True</property>
+  </criterion>
+  <criterion name="c3">
+   <property name="widget">resultsperpage</property>
+   <property name="title">Per page</property>
+   <property name="position">center</property>
+   <property name="section">default</property>
+   <property name="hidden">False</property>
+   <property name="start">20</property>
+   <property name="end">1000</property>
+   <property name="step">20</property>
+   <property name="default">20</property>
+  </criterion>
+ </criteria>
+</object>

--- a/src/Products/urban/schedule/vocabulary.py
+++ b/src/Products/urban/schedule/vocabulary.py
@@ -17,6 +17,7 @@ URBAN_TYPES_INTERFACES = {
     "CODT_NotaryLetter": interfaces.ICODT_NotaryLetter,
     "CODT_ParcelOutLicence": interfaces.ICODT_ParcelOutLicence,
     "CODT_UniqueLicence": interfaces.ICODT_UniqueLicence,
+    "CODT_UniqueBorderingLicence": interfaces.ICODT_UniqueBorderingLicence,
     "CODT_UrbanCertificateOne": interfaces.ICODT_UrbanCertificateOne,
     "CODT_UrbanCertificateTwo": interfaces.ICODT_UrbanCertificateTwo,
     "Article127": interfaces.IArticle127,

--- a/src/Products/urban/skins/urban_templates/codt_uniqueborderinglicence_edit.pt
+++ b/src/Products/urban/skins/urban_templates/codt_uniqueborderinglicence_edit.pt
@@ -1,0 +1,27 @@
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en-US"
+      lang="en-US"
+      i18n:domain="urban">
+
+<body>
+
+<div metal:define-macro="topslot">
+<metal:listing use-macro="here/@@globalmacros/hide_portlets" />
+</div>
+
+<div metal:define-macro="body">
+
+<metal:base_body use-macro="base_macros/body">
+
+<metal:widgets fill-slot="widgets"
+           tal:define="global body_onload string: init();
+                       member context/@@plone_portal_state/member;
+                       border python: test(member.has_role('Manager'), 'enable_border', 'disable_border');
+                       dummy python:request.set(border, 1);">
+
+      <metal:listing use-macro="here/@@licenceedit/editLicenceMacro" />
+</metal:widgets>
+</metal:base_body>
+</div>
+
+</body>
+</html>


### PR DESCRIPTION
- Adds a new content type for PU bordering licence (the PE one already exists: `EnvClassBordering`)
- Both content types are used when receiving `DEMANDE_EP_EXTRA` notice notifications

Linked pull requests:
- https://github.com/IMIO/plonetheme.imioapps/pull/18
- https://github.com/IMIO/urban.events/pull/8

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Adds a new "Unique Bordering" licence type with full UI: view, edit form, templates, macros and dashboard/schedule facets.
  * Notification handling now creates licences from DEMANDE_EP_EXTRA notices.
  * French translations and configuration entries for the new licence type.
  * Migration/upgrade step and registry entries to install and expose the new licence type.

* **Bug Fixes**
  * Minor robustness fixes for import/export and indexing paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->