### PR TITLE
URB-3521 Add the key `pod_portal_types`in drop key in import config view

### DIFF
--- a/news/URB-3521.bugfix
+++ b/news/URB-3521.bugfix
@@ -1,0 +1,2 @@
+Add the key `pod_portal_types`in drop key in import config view
+[jchandelle]

--- a/news/URB-3521.bugfix
+++ b/news/URB-3521.bugfix
@@ -1,2 +1,2 @@
-Add the key `pod_portal_types`in drop key in import config view
+Add the key `pod_portal_types` in drop key in import config view
 [jchandelle]

--- a/src/Products/urban/browser/exportimport/import_config.py
+++ b/src/Products/urban/browser/exportimport/import_config.py
@@ -44,6 +44,7 @@ class ConfigImportContent(ImportContent):
         "OpinionEventConfig": ["internal_service"],
         "UrbanTemplate": [
             "mailing_loop_template",
+            "pod_portal_types"
         ],
     }
     default_value_none = {

--- a/src/Products/urban/browser/exportimport/import_config.py
+++ b/src/Products/urban/browser/exportimport/import_config.py
@@ -44,7 +44,7 @@ class ConfigImportContent(ImportContent):
         "OpinionEventConfig": ["internal_service"],
         "UrbanTemplate": [
             "mailing_loop_template",
-            "pod_portal_types"
+            "pod_portal_types",
         ],
     }
     default_value_none = {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Import configuration now omits pod portal types during import preprocessing, preventing unwanted portal-type data from being imported.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->