### PR TITLE
SUP-51022 Fix keydate getter in case date not found

### DIFF
--- a/news/SUP-51022.bugfix
+++ b/news/SUP-51022.bugfix
@@ -1,0 +1,2 @@
+Fix keydate getter in case date not found
+[jchandelle]

--- a/src/Products/urban/browser/licence/licenceview.py
+++ b/src/Products/urban/browser/licence/licenceview.py
@@ -297,7 +297,7 @@ class LicenceView(BrowserView):
                                     {
                                         "date_label": date[0],
                                         "date": urban_tool.formatDate(
-                                            getattr(event, date[1]),
+                                            getattr(event, date[1], None),
                                             translatemonth=False,
                                         ),
                                         "url": event.absolute_url(),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved an issue where missing key date attributes would cause the application to crash unexpectedly. The system now safely handles absent or unavailable date information by returning default values instead of throwing errors, significantly improving application stability and user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->