### PR TITLE
SUP-51053: Fix broken `eventType` in Event config

### DIFF
--- a/news/SUP-51053.bugfix
+++ b/news/SUP-51053.bugfix
@@ -1,0 +1,2 @@
+Fix broken eventType data introduced by a previous upgrade step
+[daggelpop]

--- a/setup.py
+++ b/setup.py
@@ -64,6 +64,7 @@ setup(
         "collective.wfadaptations",
         "collective.z3cform.datagridfield>=0.15",
         "collective.archetypes.select2",
+        "dm.historical",
         "five.grok",
         "grokcore.component",
         "imio.actionspanel",

--- a/src/Products/urban/migration/update_290.py
+++ b/src/Products/urban/migration/update_290.py
@@ -126,7 +126,7 @@ def add_event_config_types_notice(context):
                 old_interfaces = folder_event.getEventType()
                 missing_interfaces = set(uet.get("eventType", [])) - set(old_interfaces)
                 if missing_interfaces:
-                    new_interfaces = list(old_fields) + list(missing_interfaces)
+                    new_interfaces = tuple(list(old_interfaces) + list(missing_interfaces))
                     setattr(folder_event, "eventType", new_interfaces)
 
             last_urbaneventype_id = id

--- a/src/Products/urban/migration/update_290.py
+++ b/src/Products/urban/migration/update_290.py
@@ -4,6 +4,7 @@ from Products.urban import URBAN_TYPES
 from Products.urban import UrbanMessage as _
 from Products.urban.migration.utils import cook_javascript_resources
 from Products.urban.utils import moveElementAfter
+from dm.historical import getHistory
 from plone import api
 from plone.app.textfield import RichTextValue
 from plone.registry import field
@@ -190,4 +191,68 @@ def add_folder_manager_notice(context):
 def refresh_javascript(context):
     logger = logging.getLogger("urban: Cook javascript resources")
     cook_javascript_resources()
+    logger.info("Upgrade done!")
+
+
+def recover_event_config_interfaces(context):
+    from Products.urban.profiles.extra.data import EventConfigs
+
+    logger = logging.getLogger("urban: Recover event config interfaces")
+
+    def get_previous_event_type_interfaces(event):
+        history = getHistory(event)
+        for version in history:
+            old_obj = version["obj"]
+            event_type_interfaces = old_obj.getEventType()
+            broken_data_present = any(
+                [
+                    ".interfaces." not in event_type
+                    for event_type in event_type_interfaces
+                ]
+            )
+            if not broken_data_present:
+                return event_type_interfaces
+
+    # migrate event configs
+    tool = getToolByName(context, "portal_urban")
+    for urban_config_id in EventConfigs:
+        try:
+            uet_folder = getattr(
+                tool.getLicenceConfig(None, urbanConfigId=urban_config_id),
+                "eventconfigs",
+            )
+        except AttributeError:
+            continue  # TODO: log ?
+
+        for uet in EventConfigs[urban_config_id]:
+            portal_type = uet.get("portal_type", "EventConfig")
+            if portal_type == "OpinionEventConfig":
+                continue
+            id = uet["id"]
+            folder_event = getattr(uet_folder, id, None)
+
+            if folder_event:  # patch existing eventConfig
+                # look for broken data in eventType field
+                event_type_interfaces = folder_event.getEventType()
+                broken_data_present = any(
+                    [
+                        ".interfaces." not in event_type
+                        for event_type in event_type_interfaces
+                    ]
+                )
+                if broken_data_present:
+                    old_interfaces = get_previous_event_type_interfaces(folder_event)
+                    if old_interfaces:
+                        # restore old interfaces
+                        setattr(folder_event, "eventType", old_interfaces)
+                        # continue treatment from add_event_config_types_notice
+                        missing_interfaces = set(uet.get("eventType", [])) - set(
+                            old_interfaces
+                        )
+                        if missing_interfaces:
+                            new_interfaces = tuple(
+                                list(old_interfaces) + list(missing_interfaces)
+                            )
+                            setattr(folder_event, "eventType", new_interfaces)
+
     logger.info("Upgrade done!")

--- a/src/Products/urban/migration/upgrades_notice.zcml
+++ b/src/Products/urban/migration/upgrades_notice.zcml
@@ -35,4 +35,12 @@
         handler=".update_290.refresh_javascript"
         profile="Products.urban:default" />
 
+    <gs:upgradeStep
+        title="Recover event config interfaces"
+        description=""
+        source="2903"
+        destination="2904"
+        handler=".update_290.recover_event_config_interfaces"
+        profile="Products.urban:default" />
+
 </configure>

--- a/src/Products/urban/profiles/default/metadata.xml
+++ b/src/Products/urban/profiles/default/metadata.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <metadata>
-  <version>2903</version>
+  <version>2904</version>
   <dependencies>
     <dependency>profile-Products.urban:preinstall</dependency>
   </dependencies>


### PR DESCRIPTION
Fixes bug introduced by upgrade step  `add_event_config_types_notice`

Related PR: https://github.com/IMIO/server.urban/pull/12

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved corrupted eventType configuration data introduced in a previous upgrade. An automated recovery mechanism has been added to detect and restore valid interface information from historical data, ensuring all event type configurations are properly recovered.

* **Chores**
  * Updated product version to 2904 and added system dependencies required for the recovery process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->