### PR TITLE
URB-3531 Change documentation url

### DIFF
--- a/news/URB-3531.bugfix
+++ b/news/URB-3531.bugfix
@@ -1,0 +1,2 @@
+Change documentation url
+[jchandelle]

--- a/src/Products/urban/migration/configure.zcml
+++ b/src/Products/urban/migration/configure.zcml
@@ -5,7 +5,7 @@
     i18n_domain="urban">
 
   <include file="upgrades.zcml" />
-  <include file="upgrades_notice.zcml" />
+  <include file="upgrades_290.zcml" />
   <include package=".to_DX" />
 
   <browser:page

--- a/src/Products/urban/migration/update_290.py
+++ b/src/Products/urban/migration/update_290.py
@@ -256,3 +256,16 @@ def recover_event_config_interfaces(context):
                             setattr(folder_event, "eventType", new_interfaces)
 
     logger.info("Upgrade done!")
+
+
+def update_documentation_url(context):
+    """
+    Update documentation url
+    """
+    logger = logging.getLogger(
+        "urban: Update documentation url"
+    )
+    logger.info("starting upgrade steps")
+    setup_tool = api.portal.get_tool("portal_setup")
+    setup_tool.runImportStepFromProfile("profile-Products.urban:default", "actions")
+    logger.info("upgrade step done!")

--- a/src/Products/urban/migration/upgrades_290.zcml
+++ b/src/Products/urban/migration/upgrades_290.zcml
@@ -43,4 +43,13 @@
         handler=".update_290.recover_event_config_interfaces"
         profile="Products.urban:default" />
 
+     <gs:upgradeStep
+        title="Update documentation url"
+        description=""
+        source="2904"
+        destination="2905"
+        handler=".update_290.update_documentation_url"
+        profile="Products.urban:default"
+        />
+
 </configure>

--- a/src/Products/urban/profiles/default/actions.xml
+++ b/src/Products/urban/profiles/default/actions.xml
@@ -22,9 +22,9 @@
    <property name="title">Documentation</property>
    <property name="description"></property>
    <property
-      name="url_expr">string:https://docs.imio.be/imio-doc/ia.urban/</property>
+      name="url_expr">string:https://docs.imio.be/iaurban/</property>
    <property
-      name="link_target">https://docs.imio.be/imio-doc/ia.urban/</property>
+      name="link_target">https://docs.imio.be/iaurban/</property>
    <property name="icon_expr"></property>
    <property name="available_expr"></property>
    <property name="permissions">

--- a/src/Products/urban/profiles/default/metadata.xml
+++ b/src/Products/urban/profiles/default/metadata.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <metadata>
-  <version>2904</version>
+  <version>2905</version>
   <dependencies>
     <dependency>profile-Products.urban:preinstall</dependency>
   </dependencies>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the in-app Documentation action so help links now point to the new documentation portal.

* **Chores**
  * Added an upgrade step and bumped the profile version so the documentation URL change is applied during migrations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->