### PR TITLE
URB-3540: Recover `UrbanEventCollege` portal type in relevant EventConfig

### DIFF
--- a/news/URB-3540.bugfix
+++ b/news/URB-3540.bugfix
@@ -1,0 +1,2 @@
+Recover `UrbanEventCollege` portal type in relevant EventConfig
+[daggelpop]

--- a/src/Products/urban/migration/update_290.py
+++ b/src/Products/urban/migration/update_290.py
@@ -283,3 +283,33 @@ def add_architect_folder_view(context):
     architects_folder = portal["urban"]["architects"]
     architects_folder.setLayout("architects_folderview")
     logger.info("upgrade step done!")
+
+
+def recover_event_config_portal_types(context):
+    from Products.urban.profiles.extra.data import EventConfigs
+
+    logger = logging.getLogger("urban: Recover `UrbanEventCollege` portal type in relevant EventConfig")
+
+    tool = getToolByName(context, "portal_urban")
+    for urban_config_id in EventConfigs:
+        try:
+            uet_folder = getattr(
+                tool.getLicenceConfig(None, urbanConfigId=urban_config_id),
+                "eventconfigs",
+            )
+        except AttributeError:
+            continue
+
+        for uet in EventConfigs[urban_config_id]:
+            portal_type = uet.get("portal_type", "EventConfig")
+            if portal_type == "OpinionEventConfig":
+                continue
+            id = uet["id"]
+            folder_event = getattr(uet_folder, id, None)
+
+            if folder_event:  # patch existing eventConfig
+                should_be_college = "pmTitle" in folder_event.getActivatedFields()
+                if should_be_college and folder_event.getEventPortalType() != "UrbanEventCollege":
+                    setattr(folder_event, "eventPortalType", "UrbanEventCollege")
+
+    logger.info("upgrade step done!")

--- a/src/Products/urban/migration/upgrades_290.zcml
+++ b/src/Products/urban/migration/upgrades_290.zcml
@@ -60,4 +60,12 @@
         handler=".update_290.add_architect_folder_view"
         profile="Products.urban:default" />
 
+    <gs:upgradeStep
+        title="Recover `UrbanEventCollege` portal type in relevant EventConfig"
+        description=""
+        source="2906"
+        destination="2907"
+        handler=".update_290.recover_event_config_portal_types"
+        profile="Products.urban:default" />
+
 </configure>

--- a/src/Products/urban/profiles/default/metadata.xml
+++ b/src/Products/urban/profiles/default/metadata.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <metadata>
-  <version>2906</version>
+  <version>2907</version>
   <dependencies>
     <dependency>profile-Products.urban:preinstall</dependency>
   </dependencies>


### PR DESCRIPTION

Assumption used in this upgrade step:
if an `EventConfig` uses the field `Titre du point PloneMeeting`, it should be of type `UrbanEventCollege`.

Note:
`setattr` had to be used; `setEventPortalType` raises an `AttributeError`, even though `getEventPortalType` works.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Resolved an issue where certain event configuration portal types were not correctly maintained during system upgrades. The update now properly recovers the appropriate portal types for affected configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->