### PR TITLE
SUP-51303 Fix encoding in work location in EnvClassBordering licence

### DIFF
--- a/news/SUP-51303.bugfix
+++ b/news/SUP-51303.bugfix
@@ -1,0 +1,2 @@
+Fix encoding in work location in EnvClassBordering licence
+[jchandelle]

--- a/src/Products/urban/content/licence/EnvClassBordering.py
+++ b/src/Products/urban/content/licence/EnvClassBordering.py
@@ -5,6 +5,7 @@ from AccessControl import ClassSecurityInfo
 from Products.Archetypes.atapi import *
 
 ##code-section module-header #fill in your manual code here
+from Products.CMFPlone.utils import safe_unicode
 from Products.DataGridField import DataGridField
 from Products.DataGridField import DataGridWidget
 from Products.DataGridField.Column import Column
@@ -115,7 +116,7 @@ class EnvClassBordering(EnvClassOne):
             if number:
                 signaletic += "%s %s à %s %s" % (
                     streetName,
-                    number.encode("utf8"),
+                    safe_unicode(number).encode("utf8"),
                     zipcode,
                     city,
                 )


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved character encoding handling for work location data in environmental class bordering licenses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->