### PR TITLE
URB-3525: Use referenceFT as backup for NOTICE licence lookup

### DIFF
--- a/news/URB-3525.feature
+++ b/news/URB-3525.feature
@@ -1,0 +1,2 @@
+Use `referenceFT` as backup for NOTICE licence lookup
+[daggelpop]

--- a/src/Products/urban/browser/cron/notice.py
+++ b/src/Products/urban/browser/cron/notice.py
@@ -164,6 +164,17 @@ class ImportFromNoticeView(BrowserView):
         licence.description.raw += translate(error, context=self.request)
         licence._p_changed = 1
 
+    def _store_referenceFT(self, detailed_notification, licence):
+        try:
+            licence_ref = licence.getReferenceFT()
+        except AttributeError:
+            return
+
+        notification_ref = detailed_notification.referenceFT
+        if notification_ref and licence_ref != notification_ref:
+            licence.setReferenceFT(notification_ref)
+            licence.reindexObject(idxs=["referenceFT"])
+
     def _demande_ep(self, detailed_notification):
         licence = detailed_notification.licence
         if not licence:
@@ -184,6 +195,8 @@ class ImportFromNoticeView(BrowserView):
             api.content.create(container=event, **document.serialize())
 
         licence.set_notice_id("DEMANDE_EP", detailed_notification.noticeId)
+
+        self._store_referenceFT(detailed_notification, licence)
 
         transaction.commit()
 
@@ -206,6 +219,8 @@ class ImportFromNoticeView(BrowserView):
             api.content.create(container=event, **document.serialize())
 
         licence.set_notice_id("NOTIFICATION_RS", detailed_notification.noticeId)
+
+        self._store_referenceFT(detailed_notification, licence)
 
         transaction.commit()
 
@@ -240,6 +255,8 @@ class ImportFromNoticeView(BrowserView):
             api.content.create(container=event, **document.serialize())
 
         licence.set_notice_id("NOTIFICATION_DECISION", detailed_notification.noticeId)
+
+        self._store_referenceFT(detailed_notification, licence)
 
         transaction.commit()
 
@@ -355,6 +372,8 @@ class ImportFromNoticeView(BrowserView):
         for document in detailed_notification.documents:
             api.content.create(container=event, **document.serialize())
 
+        self._store_referenceFT(detailed_notification, licence)
+
         transaction.commit()
 
     def process_inadmissible_folder_notification(self, detailed_notification):
@@ -373,6 +392,8 @@ class ImportFromNoticeView(BrowserView):
 
         for document in detailed_notification.documents:
             api.content.create(container=event, **document.serialize())
+
+        self._store_referenceFT(detailed_notification, licence)
 
         transaction.commit()
 
@@ -396,5 +417,7 @@ class ImportFromNoticeView(BrowserView):
 
         for document in detailed_notification.documents:
             api.content.create(container=event, **document.serialize())
+
+        self._store_referenceFT(detailed_notification, licence)
 
         transaction.commit()

--- a/src/Products/urban/migration/update_290.py
+++ b/src/Products/urban/migration/update_290.py
@@ -5,6 +5,7 @@ from Products.urban import UrbanMessage as _
 from Products.urban.migration.utils import cook_javascript_resources
 from Products.urban.utils import moveElementAfter
 from dm.historical import getHistory
+from imio.helpers.catalog import reindexIndexes
 from plone import api
 from plone.app.textfield import RichTextValue
 from plone.registry import field
@@ -311,5 +312,16 @@ def recover_event_config_portal_types(context):
                 should_be_college = "pmTitle" in folder_event.getActivatedFields()
                 if should_be_college and folder_event.getEventPortalType() != "UrbanEventCollege":
                     setattr(folder_event, "eventPortalType", "UrbanEventCollege")
+
+    logger.info("upgrade step done!")
+
+
+def setup_index_referenceFT(context):
+    logger = logging.getLogger("urban: Set up `referenceFT` index")
+
+    setup_tool = api.portal.get_tool("portal_setup")
+    setup_tool.runImportStepFromProfile("profile-Products.urban:urbantypes", "catalog")
+
+    reindexIndexes(None, ["referenceFT"])
 
     logger.info("upgrade step done!")

--- a/src/Products/urban/migration/upgrades_290.zcml
+++ b/src/Products/urban/migration/upgrades_290.zcml
@@ -68,4 +68,12 @@
         handler=".update_290.recover_event_config_portal_types"
         profile="Products.urban:default" />
 
+    <gs:upgradeStep
+        title="Set up `referenceFT` index"
+        description=""
+        source="2907"
+        destination="2908"
+        handler=".update_290.setup_index_referenceFT"
+        profile="Products.urban:default" />
+
 </configure>

--- a/src/Products/urban/notice/notification.py
+++ b/src/Products/urban/notice/notification.py
@@ -213,17 +213,31 @@ class NoticeNotification(NoticeElement):
     @property
     def licence(self):
         """Return the licence, if there is already one"""
-        if not self.reference:
-            raise ValueError("No reference found in notification {}".format(self.noticeId))
         catalog = api.portal.get_tool("portal_catalog")
-        brains = catalog.unrestrictedSearchResults(
-            getReference=self.reference,
-            object_provides=IGenericLicence.__identifier__,
+
+        if self.reference:
+            brains = catalog.unrestrictedSearchResults(
+                getReference=self.reference,
+                object_provides=IGenericLicence.__identifier__,
+            )
+            if brains:
+                licence = brains[0].getObject()
+                return licence
+
+        if self.referenceFT:
+            brains = catalog.unrestrictedSearchResults(
+                referenceFT=self.referenceFT,
+                object_provides=IGenericLicence.__identifier__,
+            )
+            if brains:
+                licence = brains[0].getObject()
+                return licence
+
+        raise ValueError(
+            "No licence found with reference number {} / reference FT {}".format(
+                self.reference, self.referenceFT
+            )
         )
-        if len(brains) == 0:
-            raise ValueError("No licence found with reference number {}".format(self.reference))
-        licence = brains[0].getObject()
-        return licence
 
     @property
     def event_configs(self):

--- a/src/Products/urban/profiles/default/metadata.xml
+++ b/src/Products/urban/profiles/default/metadata.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <metadata>
-  <version>2907</version>
+  <version>2908</version>
   <dependencies>
     <dependency>profile-Products.urban:preinstall</dependency>
   </dependencies>

--- a/src/Products/urban/profiles/urban_types/catalog.xml
+++ b/src/Products/urban/profiles/urban_types/catalog.xml
@@ -127,5 +127,11 @@
     <indexed_attr value="getComplementary_delay"/>
   </index>
   <column value="getComplementary_delay"/>
+
+  <index name="referenceFT" meta_type="FieldIndex">
+    <indexed_attr value="referenceFT"/>
+  </index>
+  <column value="referenceFT"/>
+
 <!-- ##/code-section FOOT -->
 </object>


### PR DESCRIPTION
- Store `referenceFT` from incoming NOTICE notifications onto their licence (required for `DEMANDE_EP_EXTRA`).
- Use `referenceFT` as a fallback for NOTICE licence lookups when the primary reference is unavailable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added fallback reference lookup for license identification when primary reference is unavailable.
  * License reference data is now automatically synchronized from notifications to maintain consistency.

* **Chores**
  * Updated product version metadata.
  * Enhanced catalog indexing to support improved license lookup performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->