### PR TITLE
URB-3578: Ignore missing activated fields on events

### DIFF
--- a/news/URB-3578.bugfix
+++ b/news/URB-3578.bugfix
@@ -1,0 +1,2 @@
+Ignore missing activated fields on events
+[daggelpop]

--- a/src/Products/urban/browser/longtextview.py
+++ b/src/Products/urban/browser/longtextview.py
@@ -51,7 +51,7 @@ class PmSummaryTextView(BrowserView):
             if not activatedField:
                 continue  # in some case, there could be an empty value in activatedFields...
             field = context.getField(activatedField)
-            if hasattr(field, "pm_text_field"):
+            if field and hasattr(field, "pm_text_field"):
                 fields.append(field)
         return fields
 

--- a/src/Products/urban/browser/urbaneventedit.py
+++ b/src/Products/urban/browser/urbaneventedit.py
@@ -43,7 +43,7 @@ class UrbanEventEdit(Edit):
             if not activatedField:
                 continue  # in some case, there could be an empty value in activatedFields...
             field = self.context.getField(activatedField)
-            if field not in fields:
+            if field and field not in fields:
                 fields.append(field)
 
         if ws4pmSettings and ws4pmSettings.checkAlreadySentToPloneMeeting(self.context):

--- a/src/Products/urban/browser/urbaneventviews.py
+++ b/src/Products/urban/browser/urbaneventviews.py
@@ -104,7 +104,7 @@ class UrbanEventView(BrowserView):
             if not activatedField:
                 continue  # in some case, there could be an empty value in activatedFields...
             field = context.getField(activatedField)
-            if field not in fields:
+            if field and field not in fields:
                 fields.append(field)
         return fields
 


### PR DESCRIPTION
In some circumstances, some `UrbanEvent` fields are marked as activated, but are not available on the class.

Fix: make sure an "activated" field can be fetched before using it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed handling of missing activated fields on events to prevent errors during processing. The system now gracefully handles missing field data without interruption.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->