### PR TITLE
Add mapping to resolve null values for division code

### DIFF
--- a/src/Products/urban/notice/parcel.py
+++ b/src/Products/urban/notice/parcel.py
@@ -82,12 +82,10 @@ class NoticeParcel(NoticeElement):
         if code:
             return code
         #do mapping 
-        division_name = self._get_data("division")
+        division_name = self.division_text
         if not division_name:
             return None
         division_name = division_name.strip().upper()
-        if not division_name:
-            return None
         urban_tool = api.portal.get_tool("portal_urban")
         divisions = urban_tool.getDivisionsRenaming()
 

--- a/src/Products/urban/notice/parcel.py
+++ b/src/Products/urban/notice/parcel.py
@@ -2,7 +2,7 @@
 
 from Products.urban import services
 from Products.urban.notice.base import NoticeElement
-
+from plone import api
 
 class NoticeParcel(NoticeElement):
     _excluded_keys = (
@@ -71,3 +71,26 @@ class NoticeParcel(NoticeElement):
     @property
     def partie(self):
         return self._get_data("part")
+
+    @property
+    def division_text(self):
+        return self._get_data("division")
+
+    @property
+    def resolved_division(self):
+        code = self._get_data("codeDivision")
+        if code:
+            return code
+        #do mapping 
+        division_name = division_name.strip().upper()
+        if not division_name:
+            return None
+        urban_tool = api.portal.get_tool("portal_urban")
+        divisions = urban_tool.getDivisionsRenaming()
+
+        mapping = {
+            div.get("alternative_name", "").strip().upper(): str(div.get("division"))
+            for div in divisions
+            if div.get("alternative_name") and div.get("division")
+        }
+        return mapping.get(division_name)

--- a/src/Products/urban/notice/parcel.py
+++ b/src/Products/urban/notice/parcel.py
@@ -82,6 +82,9 @@ class NoticeParcel(NoticeElement):
         if code:
             return code
         #do mapping 
+        division_name = self._get_data("division")
+        if not division_name:
+            return None
         division_name = division_name.strip().upper()
         if not division_name:
             return None


### PR DESCRIPTION
This PR introduces a fallback mapping to resolve division codes when codeDivision is not provided.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Parcels now expose raw division text and a resolved division value for more reliable display.
  * When division codes are missing, the system attempts to map alternative division names to canonical division identifiers to improve lookup and presentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->