### PR TITLE
fix: ensure getDecisionDate indexer always returns DateTime

### DIFF
--- a/docs/CHANGES.rst
+++ b/docs/CHANGES.rst
@@ -10,6 +10,12 @@ Changelog
 
 2.9.17 (2026-04-10)
 -------------------
+Bug fixes:
+
+-- Fix decisionDate filter: ensure getDecisionDate indexer always 
+returns a DateTime (including PloneMeeting data).
+[WBoudabous] (SUP-52501)
+
 
 Bug fixes:
 

--- a/docs/CHANGES.rst
+++ b/docs/CHANGES.rst
@@ -10,12 +10,6 @@ Changelog
 
 2.9.17 (2026-04-10)
 -------------------
-Bug fixes:
-
--- Fix decisionDate filter: ensure getDecisionDate indexer always 
-returns a DateTime (including PloneMeeting data).
-[WBoudabous] (SUP-52501)
-
 
 Bug fixes:
 

--- a/news/SUP-52501.fix
+++ b/news/SUP-52501.fix
@@ -1,0 +1,2 @@
+Fix decisionDate filter: ensure getDecisionDate indexer always returns a DateTime (including PloneMeeting data).
+[WBoudabous]

--- a/src/Products/urban/indexes.py
+++ b/src/Products/urban/indexes.py
@@ -274,8 +274,9 @@ def genericlicence_decisiondate(licence):
                     )
                 return decision_date
         if linked_pm_items:
-            if "date" in linked_pm_items[0]["extra_include_meeting"].keys():
-                return linked_pm_items[0]["extra_include_meeting"]["date"]
+            date_str = linked_pm_items[0]["extra_include_meeting"].get("date")
+            if date_str:
+                return DateTime(date_str)
         return decision_event.getDecisionDate() or decision_event.getEventDate()
 
 


### PR DESCRIPTION
This PR ensures that the getDecisionDate indexer always returns a DateTime.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed decision date filtering to consistently return properly formatted dates from all data sources, including imported meeting information. This ensures accurate and reliable date-based filtering throughout the application.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->