### PR TITLE
SUP-51436 toggle field visibility

### DIFF
--- a/docs/CHANGES.rst
+++ b/docs/CHANGES.rst
@@ -10,6 +10,10 @@ Changelog
 
 2.9.17 (2026-04-10)
 -------------------
+New features:
+
+-Add option to show or hide the representativeContacts field
+[WBoudabous] (SUP-51436)
 
 Bug fixes:
 

--- a/docs/CHANGES.rst
+++ b/docs/CHANGES.rst
@@ -10,10 +10,6 @@ Changelog
 
 2.9.17 (2026-04-10)
 -------------------
-New features:
-
--Add option to show or hide the representativeContacts field
-[WBoudabous] (SUP-51436)
 
 Bug fixes:
 

--- a/news/SUP-51436.feature
+++ b/news/SUP-51436.feature
@@ -1,0 +1,2 @@
+Add option to show or hide the representativeContacts field
+[WBoudabous] 

--- a/src/Products/urban/content/licence/BaseBuildLicence.py
+++ b/src/Products/urban/content/licence/BaseBuildLicence.py
@@ -68,6 +68,7 @@ optional_fields = [
     "availableParkings",
     "missingParkings",
     "parkingDetails",
+    "representativeContacts",
 ]
 
 slave_fields_habitation = (
@@ -515,6 +516,7 @@ schema = Schema(
                 ),
                 popup_name="contact_reference_popup",
             ),
+            optional=True,
             schemata="urban_description",
             multiValued=1,
             relationship="basebuildlicenceRepresentativeContacts",


### PR DESCRIPTION
This PR adds the ability to show or hide the "representativeContacts" field.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added option to show or hide the representative contacts field.

* **Updates**
  * Made the representative contacts field optional in the schema.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->