### PR TITLE
Urb 3487 move decisional delay vocabulary to config

### DIFF
--- a/news/URB-3487.feature
+++ b/news/URB-3487.feature
@@ -1,0 +1,2 @@
+Extract the “decisional delay” vocabulary from the code.
+[WBoudabous]

--- a/src/Products/urban/content/licence/RoadDecree.py
+++ b/src/Products/urban/content/licence/RoadDecree.py
@@ -121,7 +121,7 @@ schema = Schema(
                 label=_("urban_label_decisional_delay", default="DecisionalDelay"),
             ),
             schemata="urban_analysis",
-            vocabulary="list_decisional_delay",
+            vocabulary=UrbanVocabulary("decisionaldelay", inUrbanConfig=True),
             default_method="getDefaultValue",
         ),
     ),

--- a/src/Products/urban/content/licence/RoadDecree.py
+++ b/src/Products/urban/content/licence/RoadDecree.py
@@ -284,17 +284,6 @@ class RoadDecree(BaseFolder, CODT_BaseBuildLicence, BrowserDefaultMixin):
         )
         return DisplayList(vocab)
 
-    security.declarePublic("list_decisional_delay")
-
-    def list_decisional_delay(self):
-        vocabulary = (
-            ("ukn", _("unknown")),
-            ("75j", _("75 days")),
-            ("105j", _("105 days")),
-            ("150j", _("150 days")),
-            ("210j", _("210 days")),
-        )
-        return DisplayList(vocabulary)
 
     def get_decisional_delays(self, *values):
         selection = [v["val"] for v in values if v["selected"]]

--- a/src/Products/urban/locales/fr/LC_MESSAGES/urban.po
+++ b/src/Products/urban/locales/fr/LC_MESSAGES/urban.po
@@ -5718,3 +5718,6 @@ msgstr "Partie de l'immeuble concernée"
 
 msgid "urban_label_buildingType"
 msgstr "Nature de l'immeuble"
+
+msgid "decisionaldelay_folder_title"
+msgstr " Délai de décision du conseil "

--- a/src/Products/urban/locales/fr/LC_MESSAGES/urban.po
+++ b/src/Products/urban/locales/fr/LC_MESSAGES/urban.po
@@ -36,29 +36,13 @@ msgstr "%s_folder_title"
 msgid "%s_urbanconfig_title"
 msgstr "%s_urbanconfig_title"
 
-#: ../content/licence/RoadDecree.py:288
-msgid "105 days"
-msgstr "105 jours"
-
-#: ../content/licence/RoadDecree.py:289
-msgid "150 days"
-msgstr "150 jours"
-
 #: ../content/licence/ExplosivesPossession.py:140
 msgid "1st class"
 msgstr "1ère classe : Collège provincial"
 
-#: ../content/licence/RoadDecree.py:290
-msgid "210 days"
-msgstr "210 jours"
-
 #: ../content/licence/ExplosivesPossession.py:141
 msgid "2nd class"
 msgstr "2ème classe : Collège communal"
-
-#: ../content/licence/RoadDecree.py:287
-msgid "75 days"
-msgstr "75 jours"
 
 #: ../contentrules/event_type.py:70
 msgid "A Event type condition makes the rule apply only if Event type correspond to the one from the context."
@@ -2751,10 +2735,6 @@ msgstr "Par"
 
 msgid "uniquelicence_urbanconfig_title"
 msgstr "Paramètres des permis uniques"
-
-#: ../content/licence/RoadDecree.py:286
-msgid "unknown"
-msgstr "Non déterminé"
 
 msgid "unknown_worktype_on_licence"
 msgstr "nature des travaux ${worktype} inconnue sur le permis ${reference}"

--- a/src/Products/urban/migration/update_290.py
+++ b/src/Products/urban/migration/update_290.py
@@ -4,6 +4,9 @@ from Products.urban import URBAN_TYPES
 from Products.urban import UrbanMessage as _
 from Products.urban.migration.utils import cook_javascript_resources
 from Products.urban.utils import moveElementAfter
+from Products.urban.profiles.extra.config_default_values import default_values
+from Products.urban.setuphandlers import createFolderDefaultValues
+from Products.urban.setuphandlers import createVocabularyFolder
 from dm.historical import getHistory
 from imio.helpers.catalog import reindexIndexes
 from plone import api
@@ -325,3 +328,32 @@ def setup_index_referenceFT(context):
     reindexIndexes(None, ["referenceFT"])
 
     logger.info("upgrade step done!")
+
+def extract_decision_delay_vocabulary(context):
+    """ """
+    logger = logging.getLogger(
+        "urban: Add new vocabulary for investigation_radius field"
+    )
+    logger.info("starting upgrade steps")
+
+    container = api.portal.get_tool("portal_urban")
+    
+    roaddecree_folder = getattr(container, "roaddecree", None)
+
+    if roaddecree_folder is None:
+        return
+    delay_config = default_values["RoadDecree"][
+        "decisionaldelay"
+    ]
+    allowedtypes = delay_config[0]
+    delay_config = createVocabularyFolder(
+        roaddecree_folder, "decisionaldelay", context, allowedtypes
+    )
+    createFolderDefaultValues(
+        delay_config,
+        default_values["RoadDecree"]["decisionaldelay"][1:],
+        default_values["RoadDecree"]["decisionaldelay"][0],
+    )
+    
+
+    logger.info("migration step done!")

--- a/src/Products/urban/migration/update_290.py
+++ b/src/Products/urban/migration/update_290.py
@@ -4,7 +4,13 @@ from Products.urban import URBAN_TYPES
 from Products.urban import UrbanMessage as _
 from Products.urban.migration.utils import cook_javascript_resources
 from Products.urban.utils import moveElementAfter
+<<<<<<< HEAD
 from Products.urban.setuphandlers import set_licence_folder_security
+=======
+from Products.urban.profiles.extra.config_default_values import default_values
+from Products.urban.setuphandlers import createFolderDefaultValues
+from Products.urban.setuphandlers import createVocabularyFolder
+>>>>>>> 69bcb7885 ( Move decisional delay vocabulary from code to configuration)
 from dm.historical import getHistory
 from imio.helpers.catalog import reindexIndexes
 from plone import api
@@ -362,3 +368,31 @@ def update_folder_manager_notice(context):
     notice_folder_manager.reindexObject()
 
     logger.info("manageableLicences updated for notice FolderManager")
+def extract_decision_delay_vocabulary(context):
+    """ """
+    logger = logging.getLogger(
+        "urban: Extract decision delay vocabulary from code"
+    )
+    logger.info("starting upgrade steps")
+
+    container = api.portal.get_tool("portal_urban")
+    
+    roaddecree_folder = getattr(container, "roaddecree", None)
+
+    if roaddecree_folder is None:
+        return
+    delay_config = default_values["RoadDecree"][
+        "decisionaldelay"
+    ]
+    allowedtypes = delay_config[0]
+    delay_config = createVocabularyFolder(
+        roaddecree_folder, "decisionaldelay", context, allowedtypes
+    )
+    createFolderDefaultValues(
+        delay_config,
+        default_values["RoadDecree"]["decisionaldelay"][1:],
+        default_values["RoadDecree"]["decisionaldelay"][0],
+    )
+    
+
+    logger.info("migration step done!")

--- a/src/Products/urban/migration/upgrades_290.zcml
+++ b/src/Products/urban/migration/upgrades_290.zcml
@@ -83,7 +83,7 @@
         destination="2909"
         handler=".update_290.fix_housing_roaddecree"
         profile="Products.urban:default" />
-    
+
     <gs:upgradeStep
         title="Update manageableLicences for notice FolderManager"
         description=""
@@ -91,5 +91,14 @@
         destination="2910"
         handler=".update_290.update_folder_manager_notice"
         profile="Products.urban:default" />
+
+    <gs:upgradeStep
+        title="Extract decision delay vocabulary from codes"
+        description=""
+        source="2910"
+        destination="2911"
+        handler=".update_290.extract_decision_delay_vocabulary"
+        profile="Products.urban:default"
+        />
 
 </configure>

--- a/src/Products/urban/migration/upgrades_290.zcml
+++ b/src/Products/urban/migration/upgrades_290.zcml
@@ -75,5 +75,13 @@
         destination="2908"
         handler=".update_290.setup_index_referenceFT"
         profile="Products.urban:default" />
+    <gs:upgradeStep
+        title="Extract decision delay vocabulary from codes"
+        description=""
+        source="2908"
+        destination="2909"
+        handler=".update_290.extract_decision_delay_vocabulary"
+        profile="Products.urban:default"
+        />
 
 </configure>

--- a/src/Products/urban/profiles/default/metadata.xml
+++ b/src/Products/urban/profiles/default/metadata.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <metadata>
-  <version>2908</version>
+  <version>2909</version>
   <dependencies>
     <dependency>profile-Products.urban:preinstall</dependency>
   </dependencies>

--- a/src/Products/urban/profiles/default/metadata.xml
+++ b/src/Products/urban/profiles/default/metadata.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <metadata>
-  <version>2910</version>
+  <version>2911</version>
   <dependencies>
     <dependency>profile-Products.urban:preinstall</dependency>
   </dependencies>

--- a/src/Products/urban/profiles/extra/config_default_values.py
+++ b/src/Products/urban/profiles/extra/config_default_values.py
@@ -3952,11 +3952,11 @@ default_values = {
     "RoadDecree":{
         "decisionaldelay": [
             "UrbanVocabularyTerm",
-            {"id": "ukn", "title": "unknown"},
-            {"id": "75j", "title": "75 days"},
-            {"id": "105j", "title": "105 days"},
-            {"id": "150j", "title": "150 days"},
-            {"id": "210j", "title": "210 days"},
+            {"id": "ukn", "title": "Non déterminé"},
+            {"id": "75j", "title": "75 jours"},
+            {"id": "105j", "title": "105 jours"},
+            {"id": "150j", "title": "150 jours"},
+            {"id": "210j", "title": "210 jours"},
             
             ],},
 }

--- a/src/Products/urban/profiles/extra/config_default_values.py
+++ b/src/Products/urban/profiles/extra/config_default_values.py
@@ -3949,4 +3949,14 @@ default_values = {
             },
         ],
     },
+    "RoadDecree":{
+        "decisionaldelay": [
+            "UrbanVocabularyTerm",
+            {"id": "ukn", "title": "unknown"},
+            {"id": "75j", "title": "75 days"},
+            {"id": "105j", "title": "105 days"},
+            {"id": "150j", "title": "150 days"},
+            {"id": "210j", "title": "210 days"},
+            
+            ],},
 }


### PR DESCRIPTION
This PR extracts the decision delay vocabulary from the code.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Decisional delay options for road decrees are now managed through a configurable vocabulary system instead of hardcoded values, enabling greater flexibility and maintainability.

* **Localization**
  * Updated French translations for decisional delay terminology to align with the new vocabulary system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->