### PR TITLE
Sup 51505 allow all urban types bound licences

### DIFF
--- a/news/SUP-51505.feature
+++ b/news/SUP-51505.feature
@@ -1,0 +1,2 @@
+Remove bound_licences filter for all licences except Roadcree and Tickets
+[WBoudabous]

--- a/src/Products/urban/content/licence/CODT_BaseBuildLicence.py
+++ b/src/Products/urban/content/licence/CODT_BaseBuildLicence.py
@@ -552,11 +552,8 @@ schema = Schema(
                 for t in URBAN_TYPES
                 if t
                 not in [
-                    "Inspection",
+                    "RoadDecree",
                     "Ticket",
-                    "ProjectMeeting",
-                    "CODT_UrbanCertificateOne",
-                    "UrbanCertificateOne",
                 ]
             ],
             schemata="urban_description",

--- a/src/Products/urban/content/licence/Inspection.py
+++ b/src/Products/urban/content/licence/Inspection.py
@@ -162,19 +162,7 @@ schema = Schema(
                 restrict_browsing_to_startup_directory=True,
                 label=_("urban_label_bound_licences", default="Bound licences"),
             ),
-            allowed_types=[
-                t
-                for t in URBAN_TYPES
-                if t
-                not in [
-                    "Inspection",
-                    "Ticket",
-                    "ProjectMeeting",
-                    "PatrimonyCertificate",
-                    "CODT_UrbanCertificateOne",
-                    "UrbanCertificateOne",
-                ]
-            ],
+            allowed_types=[t for t in URBAN_TYPES],
             schemata="urban_description",
             multiValued=True,
             relationship="bound_licences",

--- a/src/Products/urban/content/licence/PatrimonyCertificate.py
+++ b/src/Products/urban/content/licence/PatrimonyCertificate.py
@@ -149,18 +149,7 @@ schema = Schema(
                 restrict_browsing_to_startup_directory=True,
                 label=_("urban_label_bound_licences", default="Bound licences"),
             ),
-            allowed_types=[
-                t
-                for t in URBAN_TYPES
-                if t
-                not in [
-                    "Inspection",
-                    "Ticket",
-                    "ProjectMeeting",
-                    "CODT_UrbanCertificateOne",
-                    "UrbanCertificateOne",
-                ]
-            ],
+            allowed_types=[t for t in URBAN_TYPES],
             schemata="urban_description",
             multiValued=True,
             relationship="bound_licences",

--- a/src/Products/urban/notice/parcel.py
+++ b/src/Products/urban/notice/parcel.py
@@ -82,12 +82,10 @@ class NoticeParcel(NoticeElement):
         if code:
             return code
         #do mapping 
-        division_name = self._get_data("division")
+        division_name = self.division_text
         if not division_name:
             return None
         division_name = division_name.strip().upper()
-        if not division_name:
-            return None
         urban_tool = api.portal.get_tool("portal_urban")
         divisions = urban_tool.getDivisionsRenaming()
 

--- a/src/Products/urban/notice/parcel.py
+++ b/src/Products/urban/notice/parcel.py
@@ -2,7 +2,7 @@
 
 from Products.urban import services
 from Products.urban.notice.base import NoticeElement
-
+from plone import api
 
 class NoticeParcel(NoticeElement):
     _excluded_keys = (
@@ -71,3 +71,26 @@ class NoticeParcel(NoticeElement):
     @property
     def partie(self):
         return self._get_data("part")
+
+    @property
+    def division_text(self):
+        return self._get_data("division")
+
+    @property
+    def resolved_division(self):
+        code = self._get_data("codeDivision")
+        if code:
+            return code
+        #do mapping 
+        division_name = division_name.strip().upper()
+        if not division_name:
+            return None
+        urban_tool = api.portal.get_tool("portal_urban")
+        divisions = urban_tool.getDivisionsRenaming()
+
+        mapping = {
+            div.get("alternative_name", "").strip().upper(): str(div.get("division"))
+            for div in divisions
+            if div.get("alternative_name") and div.get("division")
+        }
+        return mapping.get(division_name)

--- a/src/Products/urban/notice/parcel.py
+++ b/src/Products/urban/notice/parcel.py
@@ -82,6 +82,9 @@ class NoticeParcel(NoticeElement):
         if code:
             return code
         #do mapping 
+        division_name = self._get_data("division")
+        if not division_name:
+            return None
         division_name = division_name.strip().upper()
         if not division_name:
             return None


### PR DESCRIPTION
This PR updates the bound_licences field to allow all licence types,
while keeping restrictions for:
- Roadcree 
- Tickets 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted licence linking restrictions to support improved cross-reference capabilities between different licence and certificate types

* **New Features**
  * Enhanced parcel management with new division data resolution and retrieval capabilities

<!-- end of auto-generated comment: release notes by coderabbit.ai -->