### PR TITLE
 SUP-51505 remove filter for all licences except RoadDecree permits and Tickets

### DIFF
--- a/news/SUP-51505.feature
+++ b/news/SUP-51505.feature
@@ -1,0 +1,2 @@
+Remove bound_licences filter for all licences except RoadDecree and Tickets
+[WBoudabous]

--- a/src/Products/urban/content/licence/CODT_BaseBuildLicence.py
+++ b/src/Products/urban/content/licence/CODT_BaseBuildLicence.py
@@ -547,18 +547,7 @@ schema = Schema(
                 restrict_browsing_to_startup_directory=True,
                 label=_("urban_label_bound_licences", default="Bound licences"),
             ),
-            allowed_types=[
-                t
-                for t in URBAN_TYPES
-                if t
-                not in [
-                    "Inspection",
-                    "Ticket",
-                    "ProjectMeeting",
-                    "CODT_UrbanCertificateOne",
-                    "UrbanCertificateOne",
-                ]
-            ],
+            allowed_types=[t for t in URBAN_TYPES],
             schemata="urban_description",
             multiValued=True,
             relationship="bound_licences",

--- a/src/Products/urban/content/licence/Inspection.py
+++ b/src/Products/urban/content/licence/Inspection.py
@@ -162,19 +162,7 @@ schema = Schema(
                 restrict_browsing_to_startup_directory=True,
                 label=_("urban_label_bound_licences", default="Bound licences"),
             ),
-            allowed_types=[
-                t
-                for t in URBAN_TYPES
-                if t
-                not in [
-                    "Inspection",
-                    "Ticket",
-                    "ProjectMeeting",
-                    "PatrimonyCertificate",
-                    "CODT_UrbanCertificateOne",
-                    "UrbanCertificateOne",
-                ]
-            ],
+            allowed_types=[t for t in URBAN_TYPES],
             schemata="urban_description",
             multiValued=True,
             relationship="bound_licences",

--- a/src/Products/urban/content/licence/PatrimonyCertificate.py
+++ b/src/Products/urban/content/licence/PatrimonyCertificate.py
@@ -149,18 +149,7 @@ schema = Schema(
                 restrict_browsing_to_startup_directory=True,
                 label=_("urban_label_bound_licences", default="Bound licences"),
             ),
-            allowed_types=[
-                t
-                for t in URBAN_TYPES
-                if t
-                not in [
-                    "Inspection",
-                    "Ticket",
-                    "ProjectMeeting",
-                    "CODT_UrbanCertificateOne",
-                    "UrbanCertificateOne",
-                ]
-            ],
+            allowed_types=[t for t in URBAN_TYPES],
             schemata="urban_description",
             multiValued=True,
             relationship="bound_licences",


### PR DESCRIPTION
This PR updates the bound_licences field to allow all licence types,
while keeping restrictions for:

- Roadcree
-  Tickets


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Expanded licence type compatibility by removing restrictions on linked licence types, allowing a broader range of licence combinations to be referenced within the system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->