### PR TITLE
Urb 3488 fix vocabularies values

### DIFF
--- a/news/URB-3488.feature
+++ b/news/URB-3488.feature
@@ -1,0 +1,2 @@
+Add the missing vocabulary terms for the RoadDecree procedure.
+[WBoudabous]

--- a/src/Products/urban/migration/update_290.py
+++ b/src/Products/urban/migration/update_290.py
@@ -372,7 +372,7 @@ def update_folder_manager_notice(context):
     logger.info("manageableLicences updated for notice FolderManager")
 
 
-def add_roaddecree_vocabularies(context):
+def add_missing_roaddecree_vocabularies(context):
     logger = logging.getLogger("urban: Add RoadDecree buildworktypes vocabulary")
     logger.info("starting upgrade steps")
     portal_urban = api.portal.get_tool("portal_urban")
@@ -401,6 +401,7 @@ def add_roaddecree_vocabularies(context):
         roaddecree_folder, "divergences", site, allowedtypes=portal_type
     )
     createFolderDefaultValues(divergences_folder, terms, portal_type)
+
     derogations_config = default_values["RoadDecree"]["derogations"]
     portal_type = derogations_config[0]
     terms = derogations_config[1:]

--- a/src/Products/urban/migration/update_290.py
+++ b/src/Products/urban/migration/update_290.py
@@ -3,6 +3,9 @@ from Products.CMFCore.utils import getToolByName
 from Products.urban import URBAN_TYPES
 from Products.urban import UrbanMessage as _
 from Products.urban.migration.utils import cook_javascript_resources
+from Products.urban.profiles.extra.config_default_values import default_values
+from Products.urban.setuphandlers import createFolderDefaultValues
+from Products.urban.setuphandlers import createVocabularyFolder
 from Products.urban.utils import moveElementAfter
 from Products.urban.setuphandlers import set_licence_folder_security
 from dm.historical import getHistory
@@ -43,9 +46,9 @@ def initialize_notice_settings(context):
         )
         registry_record = Record(registry_field)
         registry_record.value = None
-        registry.records[
-            "{0}.sent_on_behalf_of_municipality_id".format(base)
-        ] = registry_record
+        registry.records["{0}.sent_on_behalf_of_municipality_id".format(base)] = (
+            registry_record
+        )
     if "{0}.last_import_date".format(base) not in registry.records:
         registry_field = field.Datetime(title=INoticeSettings["last_import_date"].title)
         registry_record = Record(registry_field)
@@ -129,7 +132,9 @@ def add_event_config_types_notice(context):
                 old_interfaces = folder_event.getEventType()
                 missing_interfaces = set(uet.get("eventType", [])) - set(old_interfaces)
                 if missing_interfaces:
-                    new_interfaces = tuple(list(old_interfaces) + list(missing_interfaces))
+                    new_interfaces = tuple(
+                        list(old_interfaces) + list(missing_interfaces)
+                    )
                     setattr(folder_event, "eventType", new_interfaces)
 
             last_urbaneventype_id = id
@@ -264,9 +269,7 @@ def update_documentation_url(context):
     """
     Update documentation url
     """
-    logger = logging.getLogger(
-        "urban: Update documentation url"
-    )
+    logger = logging.getLogger("urban: Update documentation url")
     logger.info("starting upgrade steps")
     setup_tool = api.portal.get_tool("portal_setup")
     setup_tool.runImportStepFromProfile("profile-Products.urban:default", "actions")
@@ -277,9 +280,7 @@ def add_architect_folder_view(context):
     """
     Add architect folder view
     """
-    logger = logging.getLogger(
-        "urban: Add architect folder view"
-    )
+    logger = logging.getLogger("urban: Add architect folder view")
     logger.info("starting upgrade steps")
     portal = api.portal.get()
     architects_folder = portal["urban"]["architects"]
@@ -290,7 +291,9 @@ def add_architect_folder_view(context):
 def recover_event_config_portal_types(context):
     from Products.urban.profiles.extra.data import EventConfigs
 
-    logger = logging.getLogger("urban: Recover `UrbanEventCollege` portal type in relevant EventConfig")
+    logger = logging.getLogger(
+        "urban: Recover `UrbanEventCollege` portal type in relevant EventConfig"
+    )
 
     tool = getToolByName(context, "portal_urban")
     for urban_config_id in EventConfigs:
@@ -311,7 +314,10 @@ def recover_event_config_portal_types(context):
 
             if folder_event:  # patch existing eventConfig
                 should_be_college = "pmTitle" in folder_event.getActivatedFields()
-                if should_be_college and folder_event.getEventPortalType() != "UrbanEventCollege":
+                if (
+                    should_be_college
+                    and folder_event.getEventPortalType() != "UrbanEventCollege"
+                ):
                     setattr(folder_event, "eventPortalType", "UrbanEventCollege")
 
     logger.info("upgrade step done!")
@@ -331,7 +337,9 @@ def setup_index_referenceFT(context):
 def fix_housing_roaddecree(context):
     logger = logging.getLogger("urban: Fix housing and roaddecree security")
     setup_tool = api.portal.get_tool("portal_setup")
-    setup_tool.runImportStepFromProfile("profile-Products.urban:urbantypes", "factorytool")
+    setup_tool.runImportStepFromProfile(
+        "profile-Products.urban:urbantypes", "factorytool"
+    )
     portal_types = ["Housing", "RoadDecree"]
     for portal_type in portal_types:
         set_licence_folder_security(portal_type)
@@ -358,7 +366,93 @@ def update_folder_manager_notice(context):
         return
 
     notice_folder_manager = foldermanagers.notice
-    notice_folder_manager.manageableLicences = UPDATED_URBAN_TYPES  
+    notice_folder_manager.manageableLicences = UPDATED_URBAN_TYPES
     notice_folder_manager.reindexObject()
 
     logger.info("manageableLicences updated for notice FolderManager")
+
+
+def add_roaddecree_vocabularies(context):
+    logger = logging.getLogger("urban: Add RoadDecree buildworktypes vocabulary")
+    logger.info("starting upgrade steps")
+    portal_urban = api.portal.get_tool("portal_urban")
+    roaddecree_folder = getattr(portal_urban, "roaddecree", None)
+
+    if roaddecree_folder is None:
+        logger.warning("RoadDecree config folder not found, skipping")
+        return
+
+    site = api.portal.get()
+
+    buildworktypes_config = default_values["shared_vocabularies"][
+        "folderbuildworktypes"
+    ]
+    portal_type = buildworktypes_config[0]
+    terms = buildworktypes_config[2:]
+    buildworktypes_folder = createVocabularyFolder(
+        roaddecree_folder, "folderbuildworktypes", site, allowedtypes=portal_type
+    )
+    createFolderDefaultValues(buildworktypes_folder, terms, portal_type)
+
+    divergences_config = default_values["RoadDecree"]["divergences"]
+    portal_type = divergences_config[0]
+    terms = divergences_config[1:]
+    divergences_folder = createVocabularyFolder(
+        roaddecree_folder, "divergences", site, allowedtypes=portal_type
+    )
+    createFolderDefaultValues(divergences_folder, terms, portal_type)
+    derogations_config = default_values["RoadDecree"]["derogations"]
+    portal_type = derogations_config[0]
+    terms = derogations_config[1:]
+    derogations_folder = createVocabularyFolder(
+        roaddecree_folder, "derogations", site, allowedtypes=portal_type
+    )
+    createFolderDefaultValues(derogations_folder, terms, portal_type)
+
+    investigationarticles_config = default_values["RoadDecree"]["investigationarticles"]
+    portal_type = investigationarticles_config[0]
+    terms = investigationarticles_config[1:]
+    investigationarticles_folder = createVocabularyFolder(
+        roaddecree_folder, "investigationarticles", site, allowedtypes=portal_type
+    )
+    createFolderDefaultValues(investigationarticles_folder, terms, portal_type)
+
+    townships_config = default_values["RoadDecree"]["townships"]
+    portal_type = townships_config[0]
+    terms = townships_config[1:]
+    createVocabularyFolder(
+        roaddecree_folder, "townships", site, allowedtypes=portal_type
+    )
+    exemptfdarticle_config = default_values["RoadDecree"]["exemptfdarticle"]
+    portal_type = exemptfdarticle_config[0]
+    terms = exemptfdarticle_config[1:]
+    exemptfdarticle_folder = createVocabularyFolder(
+        roaddecree_folder, "exemptfdarticle", site, allowedtypes=portal_type
+    )
+    createFolderDefaultValues(exemptfdarticle_folder, terms, portal_type)
+
+    pebcategories_config = default_values["shared_vocabularies"]["pebcategories"]
+    portal_type = pebcategories_config[0]
+    terms = pebcategories_config[2:]
+    pebcategories_folder = createVocabularyFolder(
+        roaddecree_folder, "pebcategories", site, allowedtypes=portal_type
+    )
+    createFolderDefaultValues(pebcategories_folder, terms, portal_type)
+
+    foldercategories_config = default_values["RoadDecree"]["foldercategories"]
+    portal_type = foldercategories_config[0]
+    terms = foldercategories_config[1:]
+    foldercategories_folder = createVocabularyFolder(
+        roaddecree_folder, "foldercategories", site, allowedtypes=portal_type
+    )
+    createFolderDefaultValues(foldercategories_folder, terms, portal_type)
+
+    missingparts_config = default_values["RoadDecree"]["missingparts"]
+    portal_type = missingparts_config[0]
+    terms = missingparts_config[1:]
+    missingparts_folder = createVocabularyFolder(
+        roaddecree_folder, "missingparts", site, allowedtypes=portal_type
+    )
+    createFolderDefaultValues(missingparts_folder, terms, portal_type)
+
+    logger.info("migration step done!")

--- a/src/Products/urban/migration/upgrades_290.zcml
+++ b/src/Products/urban/migration/upgrades_290.zcml
@@ -83,7 +83,7 @@
         destination="2909"
         handler=".update_290.fix_housing_roaddecree"
         profile="Products.urban:default" />
-    
+
     <gs:upgradeStep
         title="Update manageableLicences for notice FolderManager"
         description=""
@@ -93,11 +93,11 @@
         profile="Products.urban:default" />
 
     <gs:upgradeStep
-        title="Add RoadDecree vocabularies"
+        title="Add Missing RoadDecree vocabularies"
         description=""
         source="2910"
         destination="2911"
-        handler=".update_290.add_roaddecree_vocabularies"
+        handler=".update_290.add_missing_roaddecree_vocabularies"
         profile="Products.urban:default" />
 
 </configure>

--- a/src/Products/urban/migration/upgrades_290.zcml
+++ b/src/Products/urban/migration/upgrades_290.zcml
@@ -92,4 +92,12 @@
         handler=".update_290.update_folder_manager_notice"
         profile="Products.urban:default" />
 
+    <gs:upgradeStep
+        title="Add RoadDecree vocabularies"
+        description=""
+        source="2910"
+        destination="2911"
+        handler=".update_290.add_roaddecree_vocabularies"
+        profile="Products.urban:default" />
+
 </configure>

--- a/src/Products/urban/profiles/default/metadata.xml
+++ b/src/Products/urban/profiles/default/metadata.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <metadata>
-  <version>2910</version>
+  <version>2911</version>
   <dependencies>
     <dependency>profile-Products.urban:preinstall</dependency>
   </dependencies>

--- a/src/Products/urban/profiles/extra/config_default_values.py
+++ b/src/Products/urban/profiles/extra/config_default_values.py
@@ -1884,6 +1884,7 @@ default_values = {
                 "CODT_Article127",
                 "CODT_IntegratedLicence",
                 "CODT_CommercialLicence",
+                "RoadDecree",
             ],
             {"id": "not_applicable", "title": "Non applicable"},
             {"id": "complete_process", "title": "Procédure complète"},
@@ -2746,6 +2747,7 @@ default_values = {
                 "CODT_UniqueLicence",
                 "CODT_IntegratedLicence",
                 "CODT_CommercialLicence",
+                "RoadDecree",
             ],
             {"id": "AUTRE", "title": u"Autres", "extraValue": "AUTRE"},
             {"id": "DEM", "title": u"Démolition", "extraValue": "DEM"},
@@ -3949,4 +3951,234 @@ default_values = {
             },
         ],
     },
+    "RoadDecree":{
+        "townships": [
+            "UrbanVocabularyTerm",
+        ],
+        "roadmissingparts": [
+            "UrbanVocabularyTerm",
+            {
+                "id": "form_demande",
+                "title": u"Formulaire de demande (annexe 20) en 2 exemplaires",
+            },
+            {"id": "plan_travaux", "title": u"Plan des travaux en 4 exemplaires"},
+            {
+                "id": "attestation_archi",
+                "title": u"Attestation de l'architecte (annexe 21) en 2 exemplaires",
+            },
+            {
+                "id": "attestation_ordre_archi",
+                "title": u"Attestation de l'architecte soumis au visa du conseil de l'ordre (annexe 22) en 2 exemplaires",
+            },
+            {
+                "id": "photos",
+                "title": u"3 photos numérotées de la parcelle ou immeuble en 2 exemplaires",
+            },
+            {
+                "id": "notice_environnement",
+                "title": u"Notice d'évaluation préalable incid'ences environnement (annexe 1C) en 2 exemplaires",
+            },
+            {"id": "plan_secteur", "title": u"Une copie du plan de secteur"},
+            {
+                "id": "isolation",
+                "title": u"Notice relative aux exigences d'isolation thermique et de ventilation (formulaire K) en 2 exemplaires",
+            },
+            {
+                "id": "peb",
+                "title": u"Formulaire d'engagement PEB (ou formulaire 1 ou formulaire 2) en 3 exemplaires",
+            },
+        ],
+        "divergences": [
+            "UrbanVocabularyTerm",
+            {"id": "ecart-purba", "title": u"au permis d'urbanisation"},
+            {"id": "ecart-gcu", "title": u"au Guide Communal d'Urbanisme"},
+            {"id": "ecart-gru", "title": u"au Guide Régional d'Urbanisme"},
+            {"id": "ecart-sol", "title": u"au Schéma d'Orientation Local"},
+        ],
+        "derogations": [
+            "UrbanVocabularyTerm",
+            {"id": "dero-ps", "title": u"au plan de secteur"},
+            {
+                "id": "dero-gru",
+                "title": u"à une ou des norme(s) du Guide Régional d'Urbanisme ",
+            },],
+        "investigationarticles": [
+            "UrbanVocabularyTerm",
+            {
+                "id": "enquete-derogation",
+                "title": u"Article D.IV.40 - Dérogation à un plan ou aux normes d'un guide régional",
+                "description": u"<p>Application de l'article D.IV.40 : Les demandes impliquant une ou plusieurs dérogations au plan de secteur ou aux normes du guide régional sont soumises à enquête publique.</p> ",
+            },
+            {
+                "id": "enquete-derogation-facultative",
+                "title": u'Article D.VIII.13 - Procédure d\'enquête publique "facultative"',
+                "description": u"<p>Application de l'article D.VIII.13. L’autorité compétente pour adopter le plan, périmètre, schéma ou le guide et pour délivrer les<br /> permis et certificats d’urbanisme no 2, ainsi que les collèges communaux des communes organisant l’annonce de projet<br /> ou l’enquête publique, peuvent procéder à toute forme supplémentaire de publicité et d’information dans le respect des<br /> délais de décision qui sont impartis à l’autorité compétente.</p>",
+            },
+            {
+                "id": "R.IV.40-1.1.1",
+                "title": u"R.IV.40-1.§1-1° - Hauteur des constructions",
+                "description": u"<p> Article R.IV.40-1.§1-1° du CoDT : 1° la construction ou la reconstruction de bâtiments dont la hauteur est d’au moins six niveaux ou dix-huit mètres sous corniche et dépasse de trois mètres ou plus la moyenne des hauteurs sous corniche des bâtiments situés dans la même rue jusqu’à cinquante mètres de part et d’autre de la construction projetée, la transformation de bâtiments ayant pour effet de placer ceux-ci dans les mêmes conditions ;</p>",
+            },
+            {
+                "id": "R.IV.40-1.1.2",
+                "title": u"R.IV.40-1.§1-2°- Magasin de plus de 400m2",
+                "description": u"<p>Article R.IV.40-1.§1-2° du CoDT : «&nbsp;la construction, la reconstruction d'un magasin ou la modification de la destination d'un bâtiment en magasin dont la surface commerciale nette est supérieure à quatre cents mètres carrés ; la transformation de bâtiments ayant pour effet de placer ceux-ci dans les mêmes conditions&nbsp;»</p> ",
+            },
+            {
+                "id": "R.IV.40-1.1.3",
+                "title": u"R.IV.40-1.§1.3° - Usage destiné aux bureaux de plus de 650m2",
+                "description": u"<p>Article R.IV.40-1.§1.3° du CoDT: «&nbsp;la construction, la reconstruction de bureaux ou la modification de la destination d'un bâtiment en bureaux dont la superficie des planchers est supérieure à sixccent cinquante mètres carrés, la transformation de bâtiments ayant pour effet de placer ceux-ci dans les mêmes conditions&nbsp;»</p>",
+            },
+            {
+                "id": "R.IV.40-1.1.4",
+                "title": u"R.IV.40-1.§1.4° - Destination à usage de stockage supérieur à 400m2",
+                "description": u"<p>Article R.IV.40-1.§1.4° du CoDT : «&nbsp;la construction, la reconstruction ou la modification de la destination d'un bâtiment en atelier, entrepôt ou hall de stockage à caractère non agricole dont la superficie des planchers est supérieure à quatre cents mètres carrés, la transformation de bâtiments ayant pour effet de placer ceux-ci dans les mêmes conditions&nbsp;»</p>",
+            },
+            {
+                "id": "R.IV.40-1.1.5",
+                "title": u"R.IV.40-1.§1.5° - Utilisation habituelle d'un terrain pour le dépôt d'un ou plusieurs véhicules usagés, de mitrailles, de matériaux ou de déchets",
+                "description": u"<p>Article R.IV.40-1.§1.5° du CoDT : «&nbsp;l'utilisation habituelle d'un terrain pour le dépôt d'un ou plusieurs véhicules usagés, de mitrailles, de matériaux ou de déchets&nbsp;»</p> ",
+            },
+            {
+                "id": "R.IV.40-1.1.6",
+                "title": u"R.IV.40-1.§1.6° - Les demandes de permis d'urbanisation et les demandes de permis d'urbanisme relatives à la construction, la reconstruction ou la transformation d'un bâtiment inscrit sur la liste de sauvegarde ou classés",
+                "description": u"<p>Article R.IV.40-1.§1.6° du CoDT : «&nbsp;la construction, la reconstruction ou la transformation d'un bâtiment qui se rapporte à des biens immobiliers inscrits sur la liste de sauvegarde, classés, situés dans une zone de protectioon visée à l'article 209 du Code wallon du Patrimoine ou localisés dans un site repris à l'inventaire du patrimoine archéologique visé à l'article 233 du Code wallon du Patrimoine »</p> ",
+            },
+            {
+                "id": "R.IV.40-1.1.7",
+                "title": u"R.IV.40-1.§1.7° - Ouverture ou modification de la voirie communale",
+                "description": u"i<p>Article R.IV.40-1.§1.7° du CoDT« les demande de permis d'urbanisation, de permis d'urbanisme ou de certificats d'urbanisme n°2 visées à l'article D.IV.41 »</p> ",
+            },
+            {
+                "id": "R.IV.40-1.1.8",
+                "title": u"R.IV.40-1.§1.8° - Voiries régionales",
+                "description": u'<p>Article R.IV.40-1.§1.8° du CoD - " les voiries visées à l\'article R.II.21-1,1° pour autant que les actes et travaux impliquent une modification de leur gabarit"</p>',
+            },
+            {
+                "id": "div_40_alinea_2_dash_1",
+                "title": u"D.IV.40 Alinéa 2/1",
+                "extraValue": u"D.IV.40 Alinéa 2/1",
+                "description": u"""<p>Les demandes visant à implanter un commerce au sens de l'article D.IV.4, alinéa 1er, 8°, sont soumises à enquête publique, sauf lorsque la demande porte sur l'implantation d'un commerce de quatre-cents mètres carrés et moins soumis à permis en exécution de l'article D.IV.4, alinéa 4. </p>""",
+                "startValidity": codt_2024_start_validity_date,
+            },
+        ],
+        "exemptfdarticle": [
+            "UrbanVocabularyTerm",
+            {
+                "id": "annexe4",
+                "title": u"Annexe 4 - Demande de permis avec concours d'un architecte",
+            },
+            {
+                "id": "annexe5",
+                "title": u"Annexe 5 - Modification de la destination ou modification de la répartition des surfaces de vente",
+            },
+            {
+                "id": "annexe6",
+                "title": u"Annexe 6 - Modification sensible du relief du sol - dépôt de véhicules, de mitrailles, de matériaux ou de déchets - installations mobiles - travaux d'aménagement au sol aux abords d'une construction autorisée",
+            },
+            {
+                "id": "annexe7",
+                "title": u"Annexe 7 - Boisement - déboisement - abattage - culture de sapins de Noël - modification de l'aspect d'un ou plusieurs arbres ou haies remarquables - défrichement - modification de la végétation",
+            },
+            {"id": "annexe8", "title": u"Annexe 8 - Travaux techniques"},
+            {
+                "id": "annexe9",
+                "title": u"Annexe 9 - Permis d'urbanisme dispensé d'un architecte ou autre que les demandes visées aux annexes 5 à 8",
+            },
+            {
+                "id": "div_16_1a",
+                "title": u"DIV.16 1° a) SD pluricommunal ou SDC qui vise l’optimisation spatiale (uniquement les actes et travaux entièrement dans une centralité)",
+                "startValidity": codt_2024_start_validity_date,
+            },
+            {
+                "id": "div_16_1b",
+                "title": u"DIV.16 1° b) une commission communale, un GCU et soit : (1) SD pluricommunal, (2) SDC, (3) SD pluricommunal et un SDC qui a partiellement cessé de produire ses effets",
+                "startValidity": codt_2024_start_validity_date,
+            },
+            {
+                "id": "div_16_1c",
+                "title": u"DIV.16 1° c) SOL",
+                "startValidity": codt_2024_start_validity_date,
+            },
+            {
+                "id": "div_16_1d",
+                "title": u"DIV.16 1° d) permis d’urbanisation non périmé",
+                "startValidity": codt_2024_start_validity_date,
+            },
+            {
+                "id": "div_16_2",
+                "title": u"DIV.16 2° pas d’écart par rapport aux schémas, à la carte d’affectation des sols, aux guides d’urbanisme ou au permis d’urbanisation, si entièrement dans une zone d’enjeu communal",
+                "startValidity": codt_2024_start_validity_date,
+            },
+            {
+                "id": "div_16_3",
+                "title": u"DIV 16 3° pas d’écart par rapport à la carte d’affectation des sols ou au GRU",
+                "startValidity": codt_2024_start_validity_date,
+            },
+        ],
+        "foldercategories": [
+            "UrbanVocabularyTerm",
+            {
+                "id": "uco",
+                "title": u"UCO: permis d’urbanisme du Collège avec AVIS du FD (sans «écart»)",
+            },
+            {
+                "id": "uco-d",
+                "title": u"UCO/D: permis d'urbanisme avec dérogation du FD pour Plan Secteur / norme GRU ",
+            },
+            {
+                "id": "uco-a",
+                "title": u"UCO/A: permis d’urbanisme du Collège avec avis FACULTATIF du FD",
+            },
+            {"id": "uco-pd", "title": u"UCO/PD : permis d’urbanisme direct du Collège"},
+            {
+                "id": "uco-fd",
+                "title": u"UCO/ED : permis avec écart et/ou dérogation Plan Secteur / norme GRU",
+            },
+            {
+                "id": "AO",
+                "title": u"/AO: Permis d’urbanisme communal avec avis obligatoire du FD",
+                "description": u"<p>/AO: Permis d’urbanisme communal avec avis obligatoire du FD<br />Pour le cas visé Art. D.IV.15, Al. 1er, et D.IV.17.</p>",
+                "extraValue": "AO",
+                "startValidity": codt_2024_start_validity_date,
+            },
+            {
+                "id": "AF",
+                "title": u"/AF: Permis d’urbanisme communal avec avis facultatif du FD",
+                "description": u"<p>/AF: Permis d’urbanisme communal avec avis facultatif du FD<br />Pour le cas visé à l’Art. D.IV.14, Al. 2 et à la demande du Co</p>",
+                "extraValue": "AF",
+                "startValidity": codt_2024_start_validity_date,
+            },
+            {
+                "id": "PIL",
+                "title": u"/PIL: Permis d’urbanisme communal RELATIF a DES PROJETS D’impact limité.",
+                "description": u"<p>/PIL: Permis d’urbanisme communal RELATIF a DES PROJETS D’impact limité<br />Pour le cas visé à l’Art. R.IV. 1-1 TABLEAU et DISPENSÉ AVIS obligatoire </p>",
+                "extraValue": "PIL",
+                "startValidity": codt_2024_start_validity_date,
+            },
+            {
+                "id": "SA",
+                "title": u"/SA: Permis d’urbanisme communal sans avis du FD (hors du champ d’application du R.IV. 1-1 tableau)",
+                "description": u"<p>/SA: Permis d’urbanisme communal sans avis du FD (hors du champ d’application du R.IV. 1-1 tableau)<br />DISPENSÉ AVIS obligatoire du FD, Art. D.IV. 16, Al. 1, 1° et 2°</p>",
+                "extraValue": "SA",
+                "startValidity": codt_2024_start_validity_date,
+            },
+            {"id": "inconnu", "title": u"Inconnu"},
+        ],
+        "missingparts": [
+            "UrbanVocabularyTerm",
+            {"id": "plan_travaux", "title": u"Plan des travaux en 4 exemplaires"},
+            {
+                "id": "photos",
+                "title": u"3 photos numérotées de la parcelle ou immeuble en 4 exemplaires",
+            },
+            {
+                "id": "notice_environnement",
+                "title": u"Notice d'évaluation préalable d'incidences environnement en 4 exemplaires",
+            },
+            {"id": "plan_secteur", "title": u"Une copie du plan de secteur"},
+            {"id": "peb", "title": u"Formulaire d'engagement PEB en 4 exemplaires"},
+        ],
+        
+        }
 }


### PR DESCRIPTION
This PR adds the missing vocabulary terms for the road decree procedure and applies the upgrade step.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Established RoadDecree vocabulary framework including townships, categories, work types, and classification systems for divergences, derogations, investigations, exemptions, and missing parts.

* **Chores**
  * System upgrade to version 2911.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->