### PR TITLE
SUP-52184 Fix `getDecisionDate` indexer because of webservice change

### DIFF
--- a/news/SUP-52184.bugfix
+++ b/news/SUP-52184.bugfix
@@ -1,0 +1,2 @@
+Fix `getDecisionDate` indexer because of webservice change
+[jchandelle]

--- a/src/Products/urban/indexes.py
+++ b/src/Products/urban/indexes.py
@@ -21,6 +21,7 @@ from Products.urban import interfaces
 from Products.urban.schedule.interfaces import ILicenceDeliveryTask
 from Products.urban.utils import get_ws_meetingitem_infos
 from datetime import date
+from datetime import datetime
 from imio.schedule.content.task import IAutomatedTask
 from plone import api
 from plone.indexer import indexer
@@ -275,7 +276,13 @@ def genericlicence_decisiondate(licence):
                 return decision_date
         if linked_pm_items:
             if "date" in linked_pm_items[0]["extra_include_meeting"].keys():
-                return linked_pm_items[0]["extra_include_meeting"]["date"]
+                decision_date = linked_pm_items[0]["extra_include_meeting"]["date"]
+                if isinstance(decision_date, unicode):
+                    decision_date = datetime.strptime(
+                        decision_date,
+                        "%Y-%m-%dT%H:%M:%S"
+                    ).date()
+                return decision_date
         return decision_event.getDecisionDate() or decision_event.getEventDate()
 
 

--- a/src/Products/urban/migration/update_290.py
+++ b/src/Products/urban/migration/update_290.py
@@ -530,3 +530,11 @@ def setup_notice_mailing_content_rules(context):
         ContentRulesUtils.enable_rule(portal, rule_id, bubbles=True)
 
     logger.info("Upgrade done!")
+
+
+def reindex_getDecisionDate(context):
+    logger = logging.getLogger("urban: Reindex getDecisionDate")
+
+    reindexIndexes(None, ["getDecisionDate"])
+
+    logger.info("upgrade step done!")

--- a/src/Products/urban/migration/upgrades_290.zcml
+++ b/src/Products/urban/migration/upgrades_290.zcml
@@ -116,4 +116,12 @@
         handler=".update_290.setup_notice_mailing_content_rules"
         profile="Products.urban:default" />
 
+    <gs:upgradeStep
+        title="Reindex getDecisionDate"
+        description=""
+        source="2914"
+        destination="2915"
+        handler=".update_290.reindex_getDecisionDate"
+        profile="Products.urban:default" />
+
 </configure>

--- a/src/Products/urban/profiles/default/metadata.xml
+++ b/src/Products/urban/profiles/default/metadata.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <metadata>
-  <version>2914</version>
+  <version>2915</version>
   <dependencies>
     <dependency>profile-Products.urban:preinstall</dependency>
   </dependencies>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected decision date handling so dates returned from linked meetings are parsed and displayed consistently, fixing incorrect or missing decision dates.
* **Chores**
  * An automatic reindex runs as part of the upgrade to refresh decision-date data; package version metadata updated for the upgrade step.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->