### PR TITLE
URB-3445 Add and automatically set “digital” deposit type for MonEspace dossiers

### DIFF
--- a/src/Products/urban/migration/update_290.py
+++ b/src/Products/urban/migration/update_290.py
@@ -536,5 +536,52 @@ def reindex_getDecisionDate(context):
     logger = logging.getLogger("urban: Reindex getDecisionDate")
 
     reindexIndexes(None, ["getDecisionDate"])
+def add_digital_term_to_deposit_type(context):
+    """
+    Add 'digital' term to the global deposittype vocabulary
+    and activate depositType on the depot-de-la-demande event config for
+    licence types.
+    """
+    logger = logging.getLogger("urban: Add MonEspace deposit type")
+    tool = getToolByName(context, "portal_urban")
+
+    if hasattr(tool, "deposittype"):
+        deposittype_folder = tool.deposittype
+        if "digital" not in deposittype_folder.objectIds():
+            deposittype_folder.invokeFactory(
+                "UrbanVocabularyTerm", id="digital", title=u"Dématérialisé"
+            )
+            logger.info("Added 'digital' vocabulary term to global deposittype")
+
+    target_configs = {
+        "codt_uniquelicence": "depot-de-la-demande",
+        "envclassone": "depot-de-la-demande",
+        "envclasstwo": "depot-de-la-demande",
+        "envclassthree": "depot-de-la-demande",
+    }
+    for urban_config_id, event_config_id in target_configs.items():
+        try:
+            licence_config = tool.getLicenceConfig(None, urbanConfigId=urban_config_id)
+            event_config = getattr(licence_config.eventconfigs, event_config_id, None)
+        except AttributeError:
+            logger.warning("Could not find config for %s, skipping", urban_config_id)
+            continue
+
+        if event_config is None:
+            logger.warning(
+                "Event config '%s' not found for %s, skipping",
+                event_config_id,
+                urban_config_id,
+            )
+            continue
+
+        activated = list(event_config.getActivatedFields())
+        if "depositType" not in activated:
+            activated.insert(0, "depositType")
+            setattr(event_config, "activatedFields", activated)
+            logger.info(
+                "Activated depositType on '%s' for %s", event_config_id, urban_config_id
+            )
 
     logger.info("upgrade step done!")
+

--- a/src/Products/urban/migration/update_290.py
+++ b/src/Products/urban/migration/update_290.py
@@ -536,6 +536,8 @@ def reindex_getDecisionDate(context):
     logger = logging.getLogger("urban: Reindex getDecisionDate")
 
     reindexIndexes(None, ["getDecisionDate"])
+
+
 def add_digital_term_to_deposit_type(context):
     """
     Add 'digital' term to the global deposittype vocabulary

--- a/src/Products/urban/migration/upgrades_290.zcml
+++ b/src/Products/urban/migration/upgrades_290.zcml
@@ -124,4 +124,12 @@
         handler=".update_290.reindex_getDecisionDate"
         profile="Products.urban:default" />
 
+    <gs:upgradeStep
+        title="Add 'Dématérialisé' deposit type and activate field on deposit event"
+        description=""
+        source="2914"
+        destination="2915"
+        handler=".update_290.add_digital_term_to_deposit_type"
+        profile="Products.urban:default" />
+
 </configure>

--- a/src/Products/urban/migration/upgrades_290.zcml
+++ b/src/Products/urban/migration/upgrades_290.zcml
@@ -127,8 +127,8 @@
     <gs:upgradeStep
         title="Add 'Dématérialisé' deposit type and activate field on deposit event"
         description=""
-        source="2914"
-        destination="2915"
+        source="2915"
+        destination="2916"
         handler=".update_290.add_digital_term_to_deposit_type"
         profile="Products.urban:default" />
 

--- a/src/Products/urban/profiles/default/metadata.xml
+++ b/src/Products/urban/profiles/default/metadata.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <metadata>
-  <version>2915</version>
+  <version>2916</version>
   <dependencies>
     <dependency>profile-Products.urban:preinstall</dependency>
   </dependencies>


### PR DESCRIPTION
This PR is used to:

- add the digital deposit type vocabulary term,
- activate the depositType field on depot-de-la-demande events,
- automatically set the deposit type to digital for MonEspace dossiers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "Dématérialisé" (digital) deposit type with activated field support for deposit events
<!-- end of auto-generated comment: release notes by coderabbit.ai -->