### PR TITLE
SUP-51548 Fix `getInquiryRadius` method to retrieve correct radius

### DIFF
--- a/news/SUP-51548.bugfix
+++ b/news/SUP-51548.bugfix
@@ -1,0 +1,2 @@
+Fix `getInquiryRadius` method to retrieve correct radius
+[jchandelle]

--- a/src/Products/urban/browser/urbaneventviews.py
+++ b/src/Products/urban/browser/urbaneventviews.py
@@ -1286,8 +1286,8 @@ class UrbanEventInquiryView(UrbanEventInquiryBaseView):
         )
 
     def getInquiryRadius(self):
-        licence = self.context.aq_parent
-        investigation_radius = getattr(licence, "investigation_radius", None)
+        inquiry = self.context.getLinkedInquiry()
+        investigation_radius = getattr(inquiry, "investigation_radius", None)
 
         if investigation_radius is None:
             return 50


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed a critical issue in inquiry radius retrieval where the system was sourcing the radius value from an incorrect location. The radius calculation now correctly references the proper source, ensuring accurate and reliable inquiry operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/IMIO/Products.urban/pull/560?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->