### PR TITLE
URBBDC-3225: feature configurable houssing subject

### DIFF
--- a/news/URBBDC-3225.feature
+++ b/news/URBBDC-3225.feature
@@ -1,2 +1,2 @@
-Introduce configurable title formatting for housing and division 
+Introduce configurable title formatting for housing, division and urbanc ertificate
 [WBoudabous]

--- a/news/URBBDC-3225.feature
+++ b/news/URBBDC-3225.feature
@@ -1,0 +1,2 @@
+Introduce configurable title formatting for housing and division 
+[WBoudabous]

--- a/src/Products/urban/LicenceConfig.py
+++ b/src/Products/urban/LicenceConfig.py
@@ -240,6 +240,15 @@ schema = Schema(
             multiValued=True,
             vocabulary_factory="urban.licence_state",
         ),
+        StringField(
+            name="customTitle",
+            widget=StringField._properties["widget"](
+                size=100,
+                label=_("urban_label_customTitle", default="Custom title"),
+            ),
+            schemata="public_settings",
+),
+        
     ),
 )
 

--- a/src/Products/urban/content/licence/CODT_UrbanCertificateBase.py
+++ b/src/Products/urban/content/licence/CODT_UrbanCertificateBase.py
@@ -62,9 +62,10 @@ class CODT_UrbanCertificateBase(BaseFolder, UrbanCertificateBase, BrowserDefault
     schemata_order = ["urban_description", "urban_road", "urban_location"]
     ##/code-section class-header
 
-    # Methods
 
-    # Manually created methods
+    def updateTitle(self):
+        if not self._apply_custom_title():
+            super(CODT_UrbanCertificateBase, self).updateTitle()
 
 
 registerType(CODT_UrbanCertificateBase, PROJECTNAME)

--- a/src/Products/urban/content/licence/Division.py
+++ b/src/Products/urban/content/licence/Division.py
@@ -351,6 +351,8 @@ class Division(BaseFolder, GenericLicence, BrowserDefaultMixin):
         """
         Update the title to set a clearly identify the buildlicence
         """
+        if self._apply_custom_title():
+            return
         notaries = ""
         proprietaries = ""
         if self.getProprietaries:

--- a/src/Products/urban/content/licence/GenericLicence.py
+++ b/src/Products/urban/content/licence/GenericLicence.py
@@ -1564,6 +1564,15 @@ class GenericLicence(OrderedBaseFolder, UrbanBase, BrowserDefaultMixin):
 
         return config_folder
 
+    def _apply_custom_title(self):
+        licence_config = self.getLicenceConfig()
+        custom_title = licence_config.getCustomTitle()
+        if custom_title:
+            self.setTitle(custom_title)
+            self.reindexObject(idxs=("Title", "sortable_title"))
+            return True
+        return False
+
     security.declarePublic("attributeIsUsed")
 
     def attributeIsUsed(self, name):

--- a/src/Products/urban/content/licence/Housing.py
+++ b/src/Products/urban/content/licence/Housing.py
@@ -94,12 +94,7 @@ class Housing(BaseInspection, CODT_BaseBuildLicence):
         return self.getValuesForTemplate("buildingPart")
 
     def updateTitle(self):
-        licence_config = self.getLicenceConfig()
-        custom_title = licence_config.getCustomTitle()
-        if custom_title:
-            self.setTitle(custom_title)
-            self.reindexObject(idxs=("Title", "sortable_title"))
-        else:
+        if not self._apply_custom_title():
             super(Housing, self).updateTitle()
 
 registerType(Housing, PROJECTNAME)

--- a/src/Products/urban/content/licence/Housing.py
+++ b/src/Products/urban/content/licence/Housing.py
@@ -93,6 +93,14 @@ class Housing(BaseInspection, CODT_BaseBuildLicence):
         """Return a list of selected buiding part"""
         return self.getValuesForTemplate("buildingPart")
 
+    def updateTitle(self):
+        licence_config = self.getLicenceConfig()
+        custom_title = licence_config.getCustomTitle()
+        if custom_title:
+            self.setTitle(custom_title)
+            self.reindexObject(idxs=("Title", "sortable_title"))
+        else:
+            super(Housing, self).updateTitle()
 
 registerType(Housing, PROJECTNAME)
 

--- a/src/Products/urban/locales/fr/LC_MESSAGES/urban.po
+++ b/src/Products/urban/locales/fr/LC_MESSAGES/urban.po
@@ -5718,3 +5718,6 @@ msgstr "Partie de l'immeuble concernée"
 
 msgid "urban_label_buildingType"
 msgstr "Nature de l'immeuble"
+
+msgid "urban_label_customTitle"
+msgstr "Libellé personnalisé"

--- a/src/Products/urban/migration/update_290.py
+++ b/src/Products/urban/migration/update_290.py
@@ -363,9 +363,10 @@ def update_folder_manager_notice(context):
 
     logger.info("manageableLicences updated for notice FolderManager")
 
-def update_housing_titles(context):
+
+def update_custom_titles(context):
     catalog = api.portal.get_tool("portal_catalog")
-    brains = catalog(portal_type="Housing")
+    brains = catalog(portal_type=["Housing", "Division"])
     for brain in brains:
         obj = brain.getObject()
         obj.updateTitle()

--- a/src/Products/urban/migration/update_290.py
+++ b/src/Products/urban/migration/update_290.py
@@ -367,7 +367,7 @@ def update_folder_manager_notice(context):
 
 def update_custom_titles(context):
     catalog = api.portal.get_tool("portal_catalog")
-    brains = catalog(portal_type=["Housing", "Division"])
+    brains = catalog(portal_type=["Housing", "Division","CODT_UrbanCertificateBase"])
     for brain in brains:
         obj = brain.getObject()
         obj.updateTitle()

--- a/src/Products/urban/migration/update_290.py
+++ b/src/Products/urban/migration/update_290.py
@@ -362,3 +362,10 @@ def update_folder_manager_notice(context):
     notice_folder_manager.reindexObject()
 
     logger.info("manageableLicences updated for notice FolderManager")
+
+def update_housing_titles(context):
+    catalog = api.portal.get_tool("portal_catalog")
+    brains = catalog(portal_type="Housing")
+    for brain in brains:
+        obj = brain.getObject()
+        obj.updateTitle()

--- a/src/Products/urban/migration/upgrades_290.zcml
+++ b/src/Products/urban/migration/upgrades_290.zcml
@@ -91,5 +91,12 @@
         destination="2910"
         handler=".update_290.update_folder_manager_notice"
         profile="Products.urban:default" />
+    <gs:upgradeStep
+        title="Update manageableLicences for notice FolderManager"
+        description=""
+        source="2910"
+        destination="2911"
+        handler=".update_290.update_housing_titles"
+        profile="Products.urban:default" />
 
 </configure>

--- a/src/Products/urban/migration/upgrades_290.zcml
+++ b/src/Products/urban/migration/upgrades_290.zcml
@@ -109,7 +109,7 @@
         profile="Products.urban:default" />
 
     <gs:upgradeStep
-        title="Update titles for Housing and Division"
+        title="Update titles for Housing, Division and Urbanncertificate"
         description=""
         source="2913"
         destination="2914"

--- a/src/Products/urban/migration/upgrades_290.zcml
+++ b/src/Products/urban/migration/upgrades_290.zcml
@@ -91,12 +91,13 @@
         destination="2910"
         handler=".update_290.update_folder_manager_notice"
         profile="Products.urban:default" />
+
     <gs:upgradeStep
-        title="Update manageableLicences for notice FolderManager"
+        title="Update titles for Housing and Division"
         description=""
         source="2910"
         destination="2911"
-        handler=".update_290.update_housing_titles"
+        handler=".update_290.update_custom_titles"
         profile="Products.urban:default" />
 
 </configure>

--- a/src/Products/urban/profiles/default/metadata.xml
+++ b/src/Products/urban/profiles/default/metadata.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <metadata>
-  <version>2910</version>
+  <version>2911</version>
   <dependencies>
     <dependency>profile-Products.urban:preinstall</dependency>
   </dependencies>


### PR DESCRIPTION
This pull request adds the possibility to configure the dossier subject automatically via configurable title formatting for housing, division and urban certificate dossiers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Users can now configure custom titles for housing, divisions, and urban certificates in system settings.
  * When configured, custom titles automatically replace default title formatting.
  * All existing records have been updated to support the new title configuration capability.

* **Improvements**
  * Added French language support for custom title configuration labels.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/IMIO/Products.urban/pull/565?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->