### PR TITLE
URB-3313: pm rs pas envoye sfd and pm envoi rs hd sfd commune notifications

### DIFF
--- a/news/URB-3313.feature
+++ b/news/URB-3313.feature
@@ -1,0 +1,2 @@
+Handle PM_RS_PAS_ENVOYE_SFD and PM_ENVOI_RS_HD_SFD_COMMUNE notification
+[WBoudabous]

--- a/src/Products/urban/browser/cron/notice.py
+++ b/src/Products/urban/browser/cron/notice.py
@@ -229,6 +229,8 @@ class ImportFromNoticeView(BrowserView):
             "NOTIFICATION_PAS_ENVOI_RS",
             "NOTIFICATION_PAS_ENVOI_RS_SFD",
             "PM_RS_PAS_ENVOYE",
+            "PM_RS_PAS_ENVOYE_SFD",
+            "PM_ENVOI_RS_HD_SFD_COMMUNE",
         ):
             handler = SummaryReportHandler
         elif detailed_notification.notice_type in (

--- a/src/Products/urban/browser/urbaneventviews.py
+++ b/src/Products/urban/browser/urbaneventviews.py
@@ -1420,6 +1420,8 @@ class CanTransferDecisionView(CanTransferNoticeBaseView):
         "NOTIFICATION_PAS_ENVOI_RS",
         "NOTIFICATION_PAS_ENVOI_RS_SFD",
         "PM_RS_PAS_ENVOYE",
+        "PM_RS_PAS_ENVOYE_SFD",
+        "PM_ENVOI_RS_HD_SFD_COMMUNE",
     ]
     avoided_outgoing_notice_types = [
         "transfer_decision",
@@ -1438,6 +1440,8 @@ class CanTransferDecisionDisplayView(CanTransferNoticeBaseView):
         "NOTIFICATION_PAS_ENVOI_RS",
         "NOTIFICATION_PAS_ENVOI_RS_SFD",
         "PM_RS_PAS_ENVOYE",
+        "PM_RS_PAS_ENVOYE_SFD",
+        "PM_ENVOI_RS_HD_SFD_COMMUNE",
         "NOTIFICATION_DECISION_COMMUNE",
         "NOTIFICATION_DEC_RS_COMMUNE",
         "NOTIFICATION_DECRS_REFUS_TACITE_COMMUNE",

--- a/src/Products/urban/locales/fr/LC_MESSAGES/urban.po
+++ b/src/Products/urban/locales/fr/LC_MESSAGES/urban.po
@@ -923,6 +923,12 @@ msgstr "Transmission hors délai du rapport de synthèse"
 msgid "NOTIFICATION_RS_COMMUNE_RETARD_SFD"
 msgstr "Transmission hors délai du rapport de synthèse sans le volet urbanisme"
 
+msgid "PM_ENVOI_RS_HD_SFD_COMMUNE"
+msgstr "Transmission hors délai du rapport de synthèse sans le volet urbanisme - Plans Modificatifs"
+
+msgid "PM_RS_PAS_ENVOYE_SFD"
+msgstr "Impossibilité de transmettre un rapport de synthèse dans les délais impartis - Plans Modificatifs"
+
 msgid "NOTIF_COMPLETUDE1_INCOMPLET_COMMUNE"
 msgstr "Notification à la commune que la demande est incomplète"
 

--- a/src/Products/urban/locales/urban-manual.pot
+++ b/src/Products/urban/locales/urban-manual.pot
@@ -1695,3 +1695,6 @@ msgstr ""
 
 msgid "DECISION_GESPER_2_EME_INSTANCE"
 msgstr ""
+
+msgid "PM_ENVOI_RS_HD_SFD_COMMUNE"
+msgstr ""

--- a/src/Products/urban/locales/urban.pot
+++ b/src/Products/urban/locales/urban.pot
@@ -5928,3 +5928,6 @@ msgstr ""
 
 msgid "zip_folder_title"
 msgstr ""
+
+msgid "PM_ENVOI_RS_HD_SFD_COMMUNE"
+msgstr ""


### PR DESCRIPTION
This PR implements notification handling for:

- PM_RS_PAS_ENVOYE_SFD
- PM_ENVOI_RS_HD_SFD_COMMUNE

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for two new "Plans Modificatifs" notification types related to report submission timing and late transmission.
  * These notifications are now recognized and routed correctly within the decision transfer workflow.
* **Documentation**
  * Added the corresponding French translations for the new notification/alert messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->