### PR TITLE
URB-3314: handle pm rs pas envoye notification

### DIFF
--- a/news/URB-3314.feature
+++ b/news/URB-3314.feature
@@ -1,0 +1,2 @@
+Handle PM_RS_PAS_ENVOYE notification
+[WBoudabous]

--- a/src/Products/urban/browser/cron/notice.py
+++ b/src/Products/urban/browser/cron/notice.py
@@ -210,6 +210,7 @@ class ImportFromNoticeView(BrowserView):
             "NOTIFICATION_RS_COMMUNE_RETARD_SFD",
             "NOTIFICATION_PAS_ENVOI_RS",
             "NOTIFICATION_PAS_ENVOI_RS_SFD",
+            "PM_RS_PAS_ENVOYE",
         ):
             handler = SummaryReportHandler
         elif detailed_notification.notice_type in (

--- a/src/Products/urban/browser/notice_forms.py
+++ b/src/Products/urban/browser/notice_forms.py
@@ -448,6 +448,7 @@ class ITransferDecisionActionForm(ITransferBaseActionForm):
                 "NOTIFICATION_RS_COMMUNE_RETARD_SFD",
                 "NOTIFICATION_PAS_ENVOI_RS",
                 "NOTIFICATION_PAS_ENVOI_RS_SFD",
+                "PM_RS_PAS_ENVOYE",
             ],
             ["transfer_decision"]
         ),
@@ -498,6 +499,7 @@ class ITransferDecisionDisplayActionForm(ITransferBaseActionForm):
                 "NOTIFICATION_RS_COMMUNE_RETARD_SFD",
                 "NOTIFICATION_PAS_ENVOI_RS",
                 "NOTIFICATION_PAS_ENVOI_RS_SFD",
+                "PM_RS_PAS_ENVOYE",
                 "NOTIFICATION_DECISION_COMMUNE",
                 "NOTIFICATION_DEC_RS_COMMUNE",
                 "NOTIFICATION_DECRS_REFUS_TACITE_COMMUNE",
@@ -542,6 +544,7 @@ class TransferDecisionDisplayActionForm(NoticeResponseActionForm):
             "NOTIFICATION_RS_COMMUNE_RETARD_SFD",
             "NOTIFICATION_PAS_ENVOI_RS",
             "NOTIFICATION_PAS_ENVOI_RS_SFD",
+            "PM_RS_PAS_ENVOYE",
         ):
             decision_event, college_decision = self._get_decision_data(incoming_id)
             if not decision_event:

--- a/src/Products/urban/browser/urbaneventviews.py
+++ b/src/Products/urban/browser/urbaneventviews.py
@@ -1417,6 +1417,7 @@ class CanTransferDecisionView(CanTransferNoticeBaseView):
         "NOTIFICATION_RS_COMMUNE_RETARD_SFD",
         "NOTIFICATION_PAS_ENVOI_RS",
         "NOTIFICATION_PAS_ENVOI_RS_SFD",
+        "PM_RS_PAS_ENVOYE",
     ]
     avoided_outgoing_notice_types = [
         "transfer_decision",
@@ -1434,6 +1435,7 @@ class CanTransferDecisionDisplayView(CanTransferNoticeBaseView):
         "NOTIFICATION_RS_COMMUNE_RETARD_SFD",
         "NOTIFICATION_PAS_ENVOI_RS",
         "NOTIFICATION_PAS_ENVOI_RS_SFD",
+        "PM_RS_PAS_ENVOYE",
         "NOTIFICATION_DECISION_COMMUNE",
         "NOTIFICATION_DEC_RS_COMMUNE",
         "NOTIFICATION_DECRS_REFUS_TACITE_COMMUNE",

--- a/src/Products/urban/locales/fr/LC_MESSAGES/urban.po
+++ b/src/Products/urban/locales/fr/LC_MESSAGES/urban.po
@@ -901,6 +901,9 @@ msgstr "Impossibilité de transmettre un rapport de synthèse dans les délais i
 msgid "NOTIFICATION_PAS_ENVOI_RS_SFD"
 msgstr "Impossibilité de transmettre un rapport de synthèse dans les délais impartis"
 
+msgid "PM_RS_PAS_ENVOYE"
+msgstr "Impossibilité de transmettre un rapport de synthèse suite aux plans modificatifs dans les délais impartis"
+
 msgid "NOTIFICATION_PROROGATION_COMMUNE"
 msgstr "Notification à la commune de la prolongation du délai d'instruction"
 

--- a/src/Products/urban/locales/urban-manual.pot
+++ b/src/Products/urban/locales/urban-manual.pot
@@ -1627,6 +1627,9 @@ msgstr ""
 msgid "NOTIFICATION_PAS_ENVOI_RS_SFD"
 msgstr ""
 
+msgid "PM_RS_PAS_ENVOYE"
+msgstr ""
+
 msgid "NOTIFICATION_DECISION_COMMUNE"
 msgstr ""
 

--- a/src/Products/urban/locales/urban.pot
+++ b/src/Products/urban/locales/urban.pot
@@ -913,6 +913,9 @@ msgstr ""
 msgid "NOTIFICATION_PAS_ENVOI_RS_SFD"
 msgstr ""
 
+msgid "PM_RS_PAS_ENVOYE"
+msgstr ""
+
 msgid "NOTIFICATION_PROROGATION_COMMUNE"
 msgstr ""
 

--- a/src/Products/urban/notice/notification.py
+++ b/src/Products/urban/notice/notification.py
@@ -168,6 +168,7 @@ class NoticeNotification(NoticeElement):
             "NOTIFICATION_RS_COMMUNE_RETARD_SFD": "ns3:SummaryReportRequest",
             "NOTIFICATION_PAS_ENVOI_RS": "ns3:SummaryReportRequest",
             "NOTIFICATION_PAS_ENVOI_RS_SFD": "ns3:SummaryReportRequest",
+            "PM_RS_PAS_ENVOYE": "ns3:SummaryReportRequest",
             "NOTIFICATION_DECISION_COMMUNE": "ns3:DecisionRequest",
         }
         return specific.get(self.notice_type)


### PR DESCRIPTION
This PR implements notification handling for PM_RS_PAS_ENVOYE.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * System now recognizes and processes a new notification type for synthesis reports that cannot be transmitted due to modified plans. Decision transfer operations and associated workflows now fully support this notification type for improved process handling.

* **Localization**
  * Added French language translation for the new notification type to enable complete localized support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->