### PR TITLE
Urb 3639 handle pm notif irrecevable commune

### DIFF
--- a/news/URB-3639.feature
+++ b/news/URB-3639.feature
@@ -1,0 +1,2 @@
+Handle PM_NOTIF_IRRECEVABLE_COMMUNE notification
+[WBoudabous]

--- a/src/Products/urban/browser/cron/notice.py
+++ b/src/Products/urban/browser/cron/notice.py
@@ -193,6 +193,7 @@ class ImportFromNoticeView(BrowserView):
             "NOTIF_COMPLETUDE1_IRRECEVABLE_COMMUNE",
             "NOTIF_COMPLETUDE2_IRRECEVABLE_COMMUNE",
             "NOTIF_COMPLETUDE2_NON_RECEVABLE_COMMUNE",
+            "PM_NOTIF_IRRECEVABLE_COMMUNE",
         ):
             handler = InadmissibleHandler
         elif detailed_notification.notice_type in (

--- a/src/Products/urban/locales/fr/LC_MESSAGES/urban.po
+++ b/src/Products/urban/locales/fr/LC_MESSAGES/urban.po
@@ -369,9 +369,6 @@ msgstr "Demande d'organisation d'une enquête publique (interrogée précédemme
 msgid "DEMANDE_EP_EXTRA"
 msgstr "Demande d'organisation d'une enquête publique (hors territoire)"
 
-msgid "PM_EP_COURRIER_COMMUNE"
-msgstr "Demande d'organisation d'une enquête publique - Plans Modificatifs"
-
 #: ../browser/offdays_settings.py:47
 msgid "Date"
 msgstr "Date"

--- a/src/Products/urban/locales/fr/LC_MESSAGES/urban.po
+++ b/src/Products/urban/locales/fr/LC_MESSAGES/urban.po
@@ -369,6 +369,9 @@ msgstr "Demande d'organisation d'une enquête publique (interrogée précédemme
 msgid "DEMANDE_EP_EXTRA"
 msgstr "Demande d'organisation d'une enquête publique (hors territoire)"
 
+msgid "PM_EP_COURRIER_COMMUNE"
+msgstr "Demande d'organisation d'une enquête publique - Plans Modificatifs"
+
 #: ../browser/offdays_settings.py:47
 msgid "Date"
 msgstr "Date"
@@ -927,6 +930,9 @@ msgstr "Notification à la commune que la demande est irrecevable (2e tour)"
 
 msgid "NOTIF_COMPLETUDE2_NON_RECEVABLE_COMMUNE"
 msgstr "Notification à la commune que la demande est non recevable (2e tour)"
+
+msgid "PM_NOTIF_IRRECEVABLE_COMMUNE"
+msgstr "Notification à la commune que le Plan Modificatif est irrecevable"
 
 #: ../browser/urban_configfolderview.py:22
 msgid "Name"

--- a/src/Products/urban/locales/urban-manual.pot
+++ b/src/Products/urban/locales/urban-manual.pot
@@ -1600,6 +1600,9 @@ msgstr ""
 msgid "NOTIF_COMPLETUDE2_NON_RECEVABLE_COMMUNE"
 msgstr ""
 
+msgid "PM_NOTIF_IRRECEVABLE_COMMUNE"
+msgstr ""
+
 msgid "DEMANDE_EP"
 msgstr ""
 

--- a/src/Products/urban/locales/urban.pot
+++ b/src/Products/urban/locales/urban.pot
@@ -940,6 +940,9 @@ msgstr ""
 msgid "NOTIF_COMPLETUDE2_NON_RECEVABLE_COMMUNE"
 msgstr ""
 
+msgid "PM_NOTIF_IRRECEVABLE_COMMUNE"
+msgstr ""
+
 #: ../browser/urban_configfolderview.py:22
 msgid "Name"
 msgstr ""

--- a/src/Products/urban/notice/notification.py
+++ b/src/Products/urban/notice/notification.py
@@ -159,6 +159,7 @@ class NoticeNotification(NoticeElement):
             "NOTIF_COMPLETUDE1_NON_RECEVABLE_COMMUNE": "ns3:TwiceDefaultRequest",
             "NOTIF_COMPLETUDE2_IRRECEVABLE_COMMUNE": "ns3:TwiceDefaultRequest",
             "NOTIF_COMPLETUDE2_NON_RECEVABLE_COMMUNE": "ns3:TwiceDefaultRequest",
+            "PM_NOTIF_IRRECEVABLE_COMMUNE": "ns3:TwiceDefaultRequest",
             "DEMANDE_EP": "ns3:PublicSurveyRequest",
             "DEMANDE_EP_DOSSIER_PRECEDENT": "ns3:PublicSurveyRequest",
             "DEMANDE_EP_EXTRA": "ns3:PublicSurveyRequest",


### PR DESCRIPTION
This PR implements notification handling for PM_NOTIF_IRRECEVABLE_COMMUNE.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for handling a new notification type for inadmissible "Plan Modificatif" requests with proper system routing and French language translations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->