### PR TITLE
SUP-53434 Add getLastMissingPartTransmitToSPW method in codt unique licence

### DIFF
--- a/news/SUP-53434.bugfix
+++ b/news/SUP-53434.bugfix
@@ -1,0 +1,2 @@
+Add getLastMissingPartTransmitToSPW method to fix broken merge fields in Avis préalable du Collège template
+[Wiemboudabous]

--- a/src/Products/urban/content/licence/CODT_UniqueLicence.py
+++ b/src/Products/urban/content/licence/CODT_UniqueLicence.py
@@ -398,6 +398,9 @@ class CODT_UniqueLicence(
     def getLastImpactStudyEvent(self):
         return self.getLastEvent(interfaces.IImpactStudyEvent)
 
+    def getLastMissingPartTransmitToSPW(self):
+        return self.getLastEvent(interfaces.IMissingPartTransmitToSPWEvent)
+
     security.declarePublic("getDefaultSPEReference")
 
     def getDefaultSPEReference(self):


### PR DESCRIPTION
Add `getLastMissingPartTransmitToSPW()` method to `CODT_UniqueLicence` 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed merge field references in the "Avis préalable du Collège" template.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->