### PR TITLE
Sup 53504 fix get default value genericlicence

### DIFF
--- a/news/SUP-53434.bugfix
+++ b/news/SUP-53434.bugfix
@@ -1,0 +1,2 @@
+Add getLastMissingPartTransmitToSPW method to fix broken merge fields in Avis préalable du Collège template
+[Wiemboudabous]

--- a/news/SUP-53504.bugfix
+++ b/news/SUP-53504.bugfix
@@ -1,0 +1,2 @@
+Fix TypeError in select2 widget when getDefaultValue returns a list instead of a string for non-multivalued fields
+[Wiemboudabous]

--- a/src/Products/urban/content/licence/CODT_UniqueLicence.py
+++ b/src/Products/urban/content/licence/CODT_UniqueLicence.py
@@ -398,6 +398,9 @@ class CODT_UniqueLicence(
     def getLastImpactStudyEvent(self):
         return self.getLastEvent(interfaces.IImpactStudyEvent)
 
+    def getLastMissingPartTransmitToSPW(self):
+        return self.getLastEvent(interfaces.IMissingPartTransmitToSPWEvent)
+
     security.declarePublic("getDefaultSPEReference")
 
     def getDefaultSPEReference(self):

--- a/src/Products/urban/content/licence/GenericLicence.py
+++ b/src/Products/urban/content/licence/GenericLicence.py
@@ -1537,10 +1537,14 @@ class GenericLicence(OrderedBaseFolder, UrbanBase, BrowserDefaultMixin):
     security.declarePublic("getDefaultValue")
 
     def getDefaultValue(self, context=None, field=None):
-        if not context or not field:
-            return [""]
+        if not field:
+            return ""
 
         empty_value = getattr(field, "multivalued", "") and [] or ""
+
+        if not context:
+            return empty_value
+
         if hasattr(field, "vocabulary") and isinstance(
             field.vocabulary, UrbanVocabulary
         ):


### PR DESCRIPTION
This PR fixes TypeError in select2 widget

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* Fixed broken merge fields in the "Avis préalable du Collège" template.
* Resolved a TypeError in Select2 widgets when processing default values returned as lists for single-select fields.
* Improved handling of default values for both single-select and multivalued form fields to ensure proper value formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->