### PR TITLE
SUP-53504 Fix TypeError in select2 widget

### DIFF
--- a/news/SUP-53504.bugfix
+++ b/news/SUP-53504.bugfix
@@ -1,0 +1,2 @@
+Fix TypeError in select2 widget when getDefaultValue returns a list instead of a string for non-multivalued fields
+[Wiemboudabous]

--- a/src/Products/urban/content/licence/GenericLicence.py
+++ b/src/Products/urban/content/licence/GenericLicence.py
@@ -1537,10 +1537,14 @@ class GenericLicence(OrderedBaseFolder, UrbanBase, BrowserDefaultMixin):
     security.declarePublic("getDefaultValue")
 
     def getDefaultValue(self, context=None, field=None):
-        if not context or not field:
-            return [""]
+        if not field:
+            return ""
 
         empty_value = getattr(field, "multivalued", "") and [] or ""
+
+        if not context:
+            return empty_value
+
         if hasattr(field, "vocabulary") and isinstance(
             field.vocabulary, UrbanVocabulary
         ):


### PR DESCRIPTION
THis PR fixes  getDefaultValue in genericlicence.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a TypeError in the select2 widget that occurred when default values were not properly handled for non-multivalued fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->