### PR TITLE
URB-3562: Add missing configuration values for transfer to DPA forms

### DIFF
--- a/news/URB-3562.bugfix
+++ b/news/URB-3562.bugfix
@@ -1,0 +1,2 @@
+Add missing configuration values for transfer to DPA forms
+[daggelpop]

--- a/src/Products/urban/browser/notice_forms.py
+++ b/src/Products/urban/browser/notice_forms.py
@@ -262,6 +262,8 @@ class ITransferFolderToDPAActionForm(ITransferBaseActionForm):
         source=OpenIncomingNotifications(
             [
                 "TRANSFERT_DOSSIER",
+                "TRANSFERT_DOSSIER_DRC",
+                "TRANSFERT_DOSSIER_PM",
             ],
             ["transfer_folder_to_dpa"]
         ),

--- a/src/Products/urban/notice/notification.py
+++ b/src/Products/urban/notice/notification.py
@@ -155,6 +155,8 @@ class NoticeNotification(NoticeElement):
     def _specific_code(self):
         specific = {
             "TRANSFERT_DOSSIER": "ns3:TwiceDefaultRequest",
+            "TRANSFERT_DOSSIER_PM": "ns3:TwiceDefaultRequest",
+            "TRANSFERT_DOSSIER_DRC": "ns3:TwiceDefaultRequest",
             "NOTIF_COMPLETUDE1_IRRECEVABLE_COMMUNE": "ns3:TwiceDefaultRequest",
             "NOTIF_COMPLETUDE1_INCOMPLET_COMMUNE": "ns3:TwiceDefaultRequest",
             "NOTIF_COMPLETUDE1_NON_RECEVABLE_COMMUNE": "ns3:TwiceDefaultRequest",


### PR DESCRIPTION
Fixes empty notification selector on `TransferFolderToDPAActionForm`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed missing configuration values for "transfer to DPA forms" functionality
* Expanded support for additional notification types in folder transfer to DPA workflows, enabling proper handling of new transfer notification sources

<!-- end of auto-generated comment: release notes by coderabbit.ai -->