### PR TITLE
URB-3649  Fix TypeError in selecte2widget

### DIFF
--- a/news/URB-3649.bugfix
+++ b/news/URB-3649.bugfix
@@ -1,0 +1,2 @@
+Fix TypeError when opening dossiers
+[WBoudabous]

--- a/src/Products/urban/tests/test_select2widget.py
+++ b/src/Products/urban/tests/test_select2widget.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+from Products.urban.widget.select2widget import Select2Widget
+from mock import Mock, patch
+
+import unittest
+
+
+class TestSelect2Widget(unittest.TestCase):
+
+    def test_view_list_value_does_not_raise(self):
+        """Regression: list stored value no longer raises TypeError."""
+        widget = Select2Widget()
+        field = Mock()
+        field.__name__ = "test_field"
+        field.getAccessor.return_value.return_value = ["value1", "value2"]
+
+        with patch(
+            "Products.urban.widget.select2widget.resolve_vocabulary",
+            return_value="value1, value2",
+        ):
+            result = widget.view(Mock(), field, Mock())
+            self.assertEqual(result, "value1, value2")

--- a/src/Products/urban/widget/select2widget.py
+++ b/src/Products/urban/widget/select2widget.py
@@ -70,7 +70,10 @@ def resolve_vocabulary(context, field, values):
 class Select2Widget(CollectiveSelect2Widget):
     def view(self, context, field, request):
         value = super(Select2Widget, self).view(context, field, request)
-        values = [value]
+        if isinstance(value, (list, tuple)):
+            values = list(value)
+        else:
+            values = [value]
         try:
             vocabulary = resolve_vocabulary(context, field, values)
         except AttributeError:


### PR DESCRIPTION
This PR fixes a `TypeError` in `Select2Widget.view()` when opening dossiers and adds a regression test to ensure the fix continues to work correctly.
