### PR TITLE
Revert "SUP-53131: Change widget for prevent reset value when editing…

### DIFF
--- a/news/SUP-53692.bugfix
+++ b/news/SUP-53692.bugfix
@@ -1,0 +1,2 @@
+Revert "SUP-53131: Change widget for prevent reset value when editing (#562)"
+[jchandelle]

--- a/src/Products/urban/content/Inquiry.py
+++ b/src/Products/urban/content/Inquiry.py
@@ -63,7 +63,7 @@ schema = Schema(
         ),
         StringField(
             name="investigation_radius",
-            widget=Select2Widget(
+            widget=SelectionWidget(
                 label=_(
                     "urban_label_investigation_radius", default="Investigation_radius"
                 ),

--- a/src/Products/urban/content/licence/BaseBuildLicence.py
+++ b/src/Products/urban/content/licence/BaseBuildLicence.py
@@ -34,7 +34,6 @@ from Products.urban.content.licence.GenericLicence import GenericLicence
 from Products.urban.utils import setOptionalAttributes
 from Products.urban.utils import setSchemataForInquiry
 from Products.urban.widget.select2widget import MultiSelect2Widget
-from Products.urban.widget.select2widget import Select2Widget
 from dateutil.relativedelta import relativedelta
 from plone import api
 from zope.i18n import translate
@@ -197,7 +196,7 @@ schema = Schema(
         ),
         StringField(
             name="annoncedDelay",
-            widget=Select2Widget(
+            widget=SelectionWidget(
                 label=_("urban_label_annoncedDelay", default="Annonceddelay"),
             ),
             schemata="urban_analysis",
@@ -570,7 +569,7 @@ schema = Schema(
         ),
         StringField(
             name="delayAfterModifiedBlueprints",
-            widget=Select2Widget(
+            widget=SelectionWidget(
                 label=_(
                     "urban_label_delayAfterModifiedBlueprints",
                     default="Delayaftermodifiedblueprints",

--- a/src/Products/urban/content/licence/EnvironmentBase.py
+++ b/src/Products/urban/content/licence/EnvironmentBase.py
@@ -37,7 +37,6 @@ from Products.urban.widget.historizereferencewidget import (
     HistorizeReferenceBrowserWidget,
 )
 from Products.urban.widget.select2widget import MultiSelect2Widget
-from Products.urban.widget.select2widget import Select2Widget
 from collective.datagridcolumns.ReferenceColumn import ReferenceColumn
 
 ##code-section module-header #fill in your manual code here
@@ -230,7 +229,7 @@ schema = Schema(
         ),
         StringField(
             name="annoncedDelay",
-            widget=Select2Widget(
+            widget=SelectionWidget(
                 format="select",
                 label=_("urban_label_annoncedDelay", default="Annonceddelay"),
             ),

--- a/src/Products/urban/content/licence/RoadDecree.py
+++ b/src/Products/urban/content/licence/RoadDecree.py
@@ -14,7 +14,6 @@ from Products.urban.UrbanVocabularyTerm import UrbanVocabulary
 from Products.urban.config import *
 from Products.urban.content.licence.CODT_BuildLicence import CODT_BuildLicence
 from Products.urban.content.licence.CODT_BaseBuildLicence import CODT_BaseBuildLicence
-from Products.urban.widget.select2widget import Select2Widget
 
 from plone import api
 from zope.interface import implements
@@ -118,7 +117,7 @@ schema = Schema(
         ),
         StringField(
             name="decisional_delay",
-            widget=Select2Widget(
+            widget=SelectionWidget(
                 label=_("urban_label_decisional_delay", default="DecisionalDelay"),
             ),
             schemata="urban_analysis",

--- a/src/Products/urban/content/licence/UrbanCertificateBase.py
+++ b/src/Products/urban/content/licence/UrbanCertificateBase.py
@@ -34,7 +34,6 @@ from Products.urban.config import *
 from Products.urban.content.licence.GenericLicence import GenericLicence
 from Products.urban.utils import setOptionalAttributes
 from Products.urban.widget.select2widget import MultiSelect2Widget
-from Products.urban.widget.select2widget import Select2Widget
 from collective.datagridcolumns.TextAreaColumn import TextAreaColumn
 
 ##code-section module-header #fill in your manual code here
@@ -328,7 +327,7 @@ schema = Schema(
         ),
         StringField(
             name="annoncedDelay",
-            widget=Select2Widget(
+            widget=SelectionWidget(
                 label=_("urban_label_annoncedDelay", default="Annonceddelay"),
             ),
             schemata="urban_description",

--- a/src/Products/urban/widget/select2widget.py
+++ b/src/Products/urban/widget/select2widget.py
@@ -69,8 +69,7 @@ def resolve_vocabulary(context, field, values):
 
 class Select2Widget(CollectiveSelect2Widget):
     def view(self, context, field, request):
-        value = super(Select2Widget, self).view(context, field, request)
-        values = [value]
+        values = super(Select2Widget, self).view(context, field, request)
         try:
             vocabulary = resolve_vocabulary(context, field, values)
         except AttributeError:


### PR DESCRIPTION
… (#562)"

This reverts commit 10e41648a76c0df903a60192a95dd3b1ab4abf2f.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Reverted widget configuration changes from a prior release that affected form field selection behavior across multiple content types. Form fields now use the standard selection interface instead of the enhanced version, restoring the expected user experience for selecting values in administrative forms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->