### PR TITLE
URB-3657: Add GESPER opinion codes

### DIFF
--- a/news/URB-3657.feature
+++ b/news/URB-3657.feature
@@ -1,2 +1,4 @@
 Add college opinion code to GESPER EP & AP final responses
 [daggelpop]
+Validate the presence of a college opinion code in GESPER EP & AP final forms
+[daggelpop]

--- a/news/URB-3657.feature
+++ b/news/URB-3657.feature
@@ -2,3 +2,5 @@ Add college opinion code to GESPER EP & AP final responses
 [daggelpop]
 Validate the presence of a college opinion code in GESPER EP & AP final forms
 [daggelpop]
+Validate the presence of a college decision code in ARNE decision form
+[daggelpop]

--- a/news/URB-3657.feature
+++ b/news/URB-3657.feature
@@ -1,0 +1,2 @@
+Add college opinion code to GESPER EP & AP final responses
+[daggelpop]

--- a/src/Products/urban/browser/notice_forms.py
+++ b/src/Products/urban/browser/notice_forms.py
@@ -489,6 +489,19 @@ class TransferDecisionActionForm(NoticeResponseActionForm):
         self.field_values_to_store["college_decision"] = output
         return output
 
+    def do_additional_validation(self, data, errors):
+        college_decision_code = self.context.getDecision()
+        if type(college_decision_code) is list and len(college_decision_code) > 0:
+            college_decision_code = college_decision_code[0]
+        if not college_decision_code:
+            raise ActionExecutionError(
+                Invalid(
+                    _(
+                        u"No college decision code was provided in the event; please edit it and select a code first."
+                    )
+                )
+            )
+
     def transfer_response(self, data):
         incoming_id = data.get("incoming_notification")
         college_decision = self._get_college_decision_text(data)

--- a/src/Products/urban/browser/notice_forms.py
+++ b/src/Products/urban/browser/notice_forms.py
@@ -4,11 +4,13 @@ from z3c.form import button
 from z3c.form import field
 from z3c.form.browser.checkbox import CheckBoxFieldWidget
 from z3c.form.browser.radio import RadioFieldWidget
+from z3c.form.interfaces import ActionExecutionError
 from z3c.form.form import Form
 from zope import schema
 from zope.annotation.interfaces import IAnnotations
 from zope.i18n import translate
 from zope.interface import Interface
+from zope.interface import Invalid
 from zope.interface import implementer
 from zope.schema.interfaces import IContextSourceBinder
 from zope.schema.vocabulary import SimpleTerm
@@ -202,6 +204,7 @@ class NoticeResponseActionForm(Form):
     @button.buttonAndHandler(_("Send"), name="send_response")
     def handleSendResponse(self, action):
         data, errors = self.extractData()
+        self.do_additional_validation(data, errors)
         if errors:
             self.status = self.formErrorsMessage
             return
@@ -254,6 +257,9 @@ class NoticeResponseActionForm(Form):
         )
 
         self.request.response.redirect(self.context.absolute_url())
+
+    def do_additional_validation(self, data, errors):
+        pass
 
 
 class ITransferFolderToDPAActionForm(ITransferBaseActionForm):
@@ -881,6 +887,19 @@ class TransferOpinionGesperAPActionForm(NoticeResponseActionForm):
         output = college_opinion.output if college_opinion else ""
         self.field_values_to_store["college_opinion"] = output
         return output
+
+    def do_additional_validation(self, data, errors):
+        college_opinion_code = self.context.getCollegeOpinion()
+        if type(college_opinion_code) is list and len(college_opinion_code) > 0:
+            college_opinion_code = college_opinion_code[0]
+        if not college_opinion_code:
+            raise ActionExecutionError(
+                Invalid(
+                    _(
+                        u"No college opinion code was provided in the event; please edit it and select a code first."
+                    )
+                )
+            )
 
     def transfer_response(self, data):
         incoming_id = data.get("incoming_notification")

--- a/src/Products/urban/browser/notice_forms.py
+++ b/src/Products/urban/browser/notice_forms.py
@@ -204,7 +204,8 @@ class NoticeResponseActionForm(Form):
     @button.buttonAndHandler(_("Send"), name="send_response")
     def handleSendResponse(self, action):
         data, errors = self.extractData()
-        self.do_additional_validation(data, errors)
+        if not errors:
+            self.do_additional_validation(data, errors)
         if errors:
             self.status = self.formErrorsMessage
             return

--- a/src/Products/urban/locales/fr/LC_MESSAGES/urban.po
+++ b/src/Products/urban/locales/fr/LC_MESSAGES/urban.po
@@ -944,6 +944,10 @@ msgstr "Nouveau profil d'installation pour iA.Urban."
 msgid "New licence subject"
 msgstr "Nouvel objet"
 
+#: ../browser/notice_forms.py:499
+msgid "No college decision code was provided in the event; please edit it and select a code first."
+msgstr "La décision n'a pas été cochée dans cet événement; veuillez l'éditer avant de procéder à l'envoi."
+
 #: ../browser/notice_forms.py:911
 msgid "No college opinion code was provided in the event; please edit it and select a code first."
 msgstr "L'avis du collège n'a pas été coché dans cet événement; veuillez l'éditer avant de procéder à l'envoi."

--- a/src/Products/urban/locales/fr/LC_MESSAGES/urban.po
+++ b/src/Products/urban/locales/fr/LC_MESSAGES/urban.po
@@ -944,6 +944,10 @@ msgstr "Nouveau profil d'installation pour iA.Urban."
 msgid "New licence subject"
 msgstr "Nouvel objet"
 
+#: ../browser/notice_forms.py:911
+msgid "No college opinion code was provided in the event; please edit it and select a code first."
+msgstr "L'avis du collège n'a pas été coché dans cet événement; veuillez l'éditer avant de procéder à l'envoi."
+
 #: ../browser/templates/coring_update.pt:37
 msgid "No data to update"
 msgstr "Aucune donnée à mettre à jour"

--- a/src/Products/urban/locales/urban.pot
+++ b/src/Products/urban/locales/urban.pot
@@ -961,6 +961,10 @@ msgstr ""
 msgid "No"
 msgstr ""
 
+#: ../browser/notice_forms.py:911
+msgid "No college opinion code was provided in the event; please edit it and select a code first."
+msgstr ""
+
 #: ../browser/templates/coring_update.pt:37
 msgid "No data to update"
 msgstr ""

--- a/src/Products/urban/locales/urban.pot
+++ b/src/Products/urban/locales/urban.pot
@@ -961,6 +961,10 @@ msgstr ""
 msgid "No"
 msgstr ""
 
+#: ../browser/notice_forms.py:499
+msgid "No college decision code was provided in the event; please edit it and select a code first."
+msgstr ""
+
 #: ../browser/notice_forms.py:911
 msgid "No college opinion code was provided in the event; please edit it and select a code first."
 msgstr ""

--- a/src/Products/urban/notice/response.py
+++ b/src/Products/urban/notice/response.py
@@ -364,6 +364,10 @@ class NoticeOutgoingGesperPublicSurveyNotification(NoticeResponse):
         )
 
     @property
+    def _opinion_code(self):
+        return None  # this field is only required for a FINAL response
+
+    @property
     def _notice_college(self):
         return self._college_opinion
 
@@ -398,6 +402,7 @@ class NoticeOutgoingGesperPublicSurveyNotification(NoticeResponse):
     @property
     def specific(self):
         return {
+            "not:notice": self._opinion_code,
             "gns:iaReference": self._reference,
             "gns:minute": self._minute,
             "gns:observations": self._observations,
@@ -443,6 +448,15 @@ class NoticeOutgoingGesperPublicSurveyOpinionNotification(
             event, inquiry_event=inquiry_event, college_opinion=college_opinion
         )
 
+    @property
+    def _opinion_code(self):
+        opinion_codes = {
+            "favorable": "FAVORABLE",
+            "defavorable": "DEFAVORABLE",
+            "favorable-cond": "FAVORABLE_CONDITIONNEL",
+        }
+        return {"cod:code": opinion_codes.get(self.event.getCollegeOpinion())}
+
 
 class NoticeOutgoingGesperPublicSurveyFinalWithoutOpinionNotification(
     NoticeOutgoingGesperPublicSurveyNotification
@@ -453,6 +467,10 @@ class NoticeOutgoingGesperPublicSurveyFinalWithoutOpinionNotification(
         super(
             NoticeOutgoingGesperPublicSurveyFinalWithoutOpinionNotification, self
         ).__init__(event, inquiry_event=event)
+
+    @property
+    def _opinion_code(self):
+        return {"cod:code": "SANS_OBJET"}
 
 
 class NoticeOutgoingGesperProjectAnnouncementDatesNotification(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Submission forms now enforce presence of college decision and opinion codes, blocking incomplete submissions.
  * Public survey notifications include mapped decision and opinion codes (with a fixed code when absent) for more complete notifications.

* **Documentation**
  * Added user-facing validation messages (French translations) guiding users to edit events and select required codes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->