### PR TITLE
 URB-3641 handle PM_PROROGATION_COURRIER_COMMUNE notification

### DIFF
--- a/news/URB-3641.feature
+++ b/news/URB-3641.feature
@@ -1,1 +1,2 @@
-Handle PM_PROROGATION_COURRIER_COMMUNE notification.
+Handle PM_PROROGATION_COURRIER_COMMUNE notification
+[WBoudabous]

--- a/news/URB-3641.feature
+++ b/news/URB-3641.feature
@@ -1,0 +1,1 @@
+Handle PM_PROROGATION_COURRIER_COMMUNE notification.

--- a/src/Products/urban/browser/cron/notice.py
+++ b/src/Products/urban/browser/cron/notice.py
@@ -220,7 +220,10 @@ class ImportFromNoticeView(BrowserView):
             handler = PublicSurveyHandler
         elif detailed_notification.notice_type == "DEMANDE_EP_EXTRA":
             handler = BorderingPublicSurveyHandler
-        elif detailed_notification.notice_type == "NOTIFICATION_PROROGATION_COMMUNE":
+        elif detailed_notification.notice_type in (
+            "NOTIFICATION_PROROGATION_COMMUNE",
+            "PM_PROROGATION_COURRIER_COMMUNE",
+        ):
             handler = DeadlineExtensionHandler
         elif detailed_notification.notice_type in (
             "NOTIFICATION_RS_COMMUNE",

--- a/src/Products/urban/locales/fr/LC_MESSAGES/urban.po
+++ b/src/Products/urban/locales/fr/LC_MESSAGES/urban.po
@@ -914,6 +914,9 @@ msgstr "Impossibilité de transmettre un rapport de synthèse suite aux plans mo
 msgid "NOTIFICATION_PROROGATION_COMMUNE"
 msgstr "Notification à la commune de la prolongation du délai d'instruction"
 
+msgid "PM_PROROGATION_COURRIER_COMMUNE"
+msgstr "Notification à la commune de la prolongation du délai d'instruction (Plans modificatifs)"
+
 msgid "NOTIFICATION_RS_COMMUNE"
 msgstr "Transmission du rapport de synthèse"
 

--- a/src/Products/urban/locales/urban-manual.pot
+++ b/src/Products/urban/locales/urban-manual.pot
@@ -1698,5 +1698,6 @@ msgstr ""
 
 msgid "PM_ENVOI_RS_HD_SFD_COMMUNE"
 msgstr ""
+
 msgid "PM_PROROGATION_COURRIER_COMMUNE"
 msgstr ""

--- a/src/Products/urban/locales/urban-manual.pot
+++ b/src/Products/urban/locales/urban-manual.pot
@@ -1698,3 +1698,5 @@ msgstr ""
 
 msgid "PM_ENVOI_RS_HD_SFD_COMMUNE"
 msgstr ""
+msgid "PM_PROROGATION_COURRIER_COMMUNE"
+msgstr ""

--- a/src/Products/urban/locales/urban.pot
+++ b/src/Products/urban/locales/urban.pot
@@ -5931,5 +5931,6 @@ msgstr ""
 
 msgid "PM_ENVOI_RS_HD_SFD_COMMUNE"
 msgstr ""
+
 msgid "PM_PROROGATION_COURRIER_COMMUNE"
 msgstr ""

--- a/src/Products/urban/locales/urban.pot
+++ b/src/Products/urban/locales/urban.pot
@@ -5931,3 +5931,5 @@ msgstr ""
 
 msgid "PM_ENVOI_RS_HD_SFD_COMMUNE"
 msgstr ""
+msgid "PM_PROROGATION_COURRIER_COMMUNE"
+msgstr ""

--- a/src/Products/urban/notice/notification.py
+++ b/src/Products/urban/notice/notification.py
@@ -167,6 +167,7 @@ class NoticeNotification(NoticeElement):
             "DEMANDE_EP_DOSSIER_PRECEDENT": "ns3:PublicSurveyRequest",
             "DEMANDE_EP_EXTRA": "ns3:PublicSurveyRequest",
             "NOTIFICATION_PROROGATION_COMMUNE": "ns3:TwiceDefaultRequest",
+            "PM_PROROGATION_COURRIER_COMMUNE": "ns3:TwiceDefaultRequest",
             "NOTIFICATION_RS_COMMUNE": "ns3:SummaryReportRequest",
             "NOTIFICATION_RS_COMMUNE_RETARD": "ns3:SummaryReportRequest",
             "NOTIFICATION_RS_COMMUNE_RETARD_SFD": "ns3:SummaryReportRequest",


### PR DESCRIPTION
This PR handles the PM_PROROGATION_COURRIER_COMMUNE notification.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for handling **PM_PROROGATION_COURRIER_COMMUNE** notifications by routing them as deadline-extension/prorogation messages for modified permit plans, enabling municipalities to receive and process extended instruction deadline notices.
* **Documentation / Localization**
  * Added the new **French** translation for **PM_PROROGATION_COURRIER_COMMUNE** and updated the localization templates/catalog to include the new message key.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->