### PR TITLE
URB-3311: implement transmission summary report

### DIFF
--- a/src/Products/urban/browser/cron/notice.py
+++ b/src/Products/urban/browser/cron/notice.py
@@ -595,6 +595,11 @@ class DeadlineExtensionHandler(IncomingNoticeHandler):
 class SummaryReportHandler(IncomingNoticeHandler):
     event_config_marker = "Products.urban.interfaces.IDecisionProjectFromSPWEvent"
 
+    def fill_incoming_event(self):
+        super(SummaryReportHandler, self).fill_incoming_event()
+        if self.notification.proposed_decision_code:
+            self.event.setExternalDecision(self.notification.proposed_decision_code)
+
 
 class DecisionSPWHandler(IncomingNoticeHandler):
     event_config_marker = "Products.urban.interfaces.IWalloonRegionDecisionEvent"

--- a/src/Products/urban/browser/cron/notice.py
+++ b/src/Products/urban/browser/cron/notice.py
@@ -234,6 +234,7 @@ class ImportFromNoticeView(BrowserView):
             "PM_RS_PAS_ENVOYE",
             "PM_RS_PAS_ENVOYE_SFD",
             "PM_ENVOI_RS_HD_SFD_COMMUNE",
+            "PM_ENVOI_RS_COMMUNE",
         ):
             handler = SummaryReportHandler
         elif detailed_notification.notice_type in (

--- a/src/Products/urban/browser/cron/notice.py
+++ b/src/Products/urban/browser/cron/notice.py
@@ -596,6 +596,10 @@ class DeadlineExtensionHandler(IncomingNoticeHandler):
 class SummaryReportHandler(IncomingNoticeHandler):
     event_config_marker = "Products.urban.interfaces.IDecisionProjectFromSPWEvent"
 
+    @property
+    def desired_licence_state(self):
+        return "prepare_final_decision"
+
     def fill_incoming_event(self):
         super(SummaryReportHandler, self).fill_incoming_event()
         if self.notification.proposed_decision_code:

--- a/src/Products/urban/browser/notice_forms.py
+++ b/src/Products/urban/browser/notice_forms.py
@@ -465,6 +465,7 @@ class ITransferDecisionActionForm(ITransferBaseActionForm):
                 "NOTIFICATION_PAS_ENVOI_RS",
                 "NOTIFICATION_PAS_ENVOI_RS_SFD",
                 "PM_RS_PAS_ENVOYE",
+                "PM_ENVOI_RS_COMMUNE",
             ],
             ["transfer_decision"]
         ),
@@ -529,6 +530,7 @@ class ITransferDecisionDisplayActionForm(ITransferBaseActionForm):
                 "NOTIFICATION_PAS_ENVOI_RS",
                 "NOTIFICATION_PAS_ENVOI_RS_SFD",
                 "PM_RS_PAS_ENVOYE",
+                "PM_ENVOI_RS_COMMUNE",
                 "NOTIFICATION_DECISION_COMMUNE",
                 "NOTIFICATION_DEC_RS_COMMUNE",
                 "NOTIFICATION_DECRS_REFUS_TACITE_COMMUNE",
@@ -574,6 +576,7 @@ class TransferDecisionDisplayActionForm(NoticeResponseActionForm):
             "NOTIFICATION_PAS_ENVOI_RS",
             "NOTIFICATION_PAS_ENVOI_RS_SFD",
             "PM_RS_PAS_ENVOYE",
+            "PM_ENVOI_RS_COMMUNE",
         ):
             decision_event, college_decision = self._get_decision_data(incoming_id)
             if not decision_event:

--- a/src/Products/urban/browser/urbaneventviews.py
+++ b/src/Products/urban/browser/urbaneventviews.py
@@ -1422,6 +1422,7 @@ class CanTransferDecisionView(CanTransferNoticeBaseView):
         "PM_RS_PAS_ENVOYE",
         "PM_RS_PAS_ENVOYE_SFD",
         "PM_ENVOI_RS_HD_SFD_COMMUNE",
+        "PM_ENVOI_RS_COMMUNE",
     ]
     avoided_outgoing_notice_types = [
         "transfer_decision",
@@ -1442,6 +1443,7 @@ class CanTransferDecisionDisplayView(CanTransferNoticeBaseView):
         "PM_RS_PAS_ENVOYE",
         "PM_RS_PAS_ENVOYE_SFD",
         "PM_ENVOI_RS_HD_SFD_COMMUNE",
+        "PM_ENVOI_RS_COMMUNE",
         "NOTIFICATION_DECISION_COMMUNE",
         "NOTIFICATION_DEC_RS_COMMUNE",
         "NOTIFICATION_DECRS_REFUS_TACITE_COMMUNE",

--- a/src/Products/urban/locales/fr/LC_MESSAGES/urban.po
+++ b/src/Products/urban/locales/fr/LC_MESSAGES/urban.po
@@ -931,6 +931,8 @@ msgstr "Transmission hors délai du rapport de synthèse sans le volet urbanisme
 
 msgid "PM_RS_PAS_ENVOYE_SFD"
 msgstr "Impossibilité de transmettre un rapport de synthèse dans les délais impartis - Plans Modificatifs"
+msgid "PM_ENVOI_RS_COMMUNE"
+msgstr "Transmission du rapport de synthèse suite aux plans modificatifs"
 
 msgid "NOTIF_COMPLETUDE1_INCOMPLET_COMMUNE"
 msgstr "Notification à la commune que la demande est incomplète"

--- a/src/Products/urban/locales/fr/LC_MESSAGES/urban.po
+++ b/src/Products/urban/locales/fr/LC_MESSAGES/urban.po
@@ -931,6 +931,7 @@ msgstr "Transmission hors délai du rapport de synthèse sans le volet urbanisme
 
 msgid "PM_RS_PAS_ENVOYE_SFD"
 msgstr "Impossibilité de transmettre un rapport de synthèse dans les délais impartis - Plans Modificatifs"
+
 msgid "PM_ENVOI_RS_COMMUNE"
 msgstr "Transmission du rapport de synthèse suite aux plans modificatifs"
 

--- a/src/Products/urban/locales/urban-manual.pot
+++ b/src/Products/urban/locales/urban-manual.pot
@@ -1701,3 +1701,6 @@ msgstr ""
 
 msgid "PM_PROROGATION_COURRIER_COMMUNE"
 msgstr ""
+
+msgid "PM_ENVOI_RS_COMMUNE"
+msgstr ""

--- a/src/Products/urban/locales/urban.pot
+++ b/src/Products/urban/locales/urban.pot
@@ -933,6 +933,9 @@ msgstr ""
 msgid "NOTIFICATION_RS_COMMUNE_RETARD_SFD"
 msgstr ""
 
+msgid "PM_ENVOI_RS_COMMUNE"
+msgstr ""
+
 msgid "NOTIF_COMPLETUDE1_INCOMPLET_COMMUNE"
 msgstr ""
 

--- a/src/Products/urban/notice/notification.py
+++ b/src/Products/urban/notice/notification.py
@@ -365,6 +365,13 @@ class NoticeNotification(NoticeElement):
         return []
 
     @property
+    def proposed_decision_code(self):
+        """Return proposed decision code from a SummaryReportRequest"""
+        return self._get_data(
+            "specific", "ns3:SummaryReportRequest", "ns3:proposedDecisionCode", "code"
+        )
+
+    @property
     def decision_code(self):
         """Return decision code from a DecisionRequest"""
 

--- a/src/Products/urban/notice/notification.py
+++ b/src/Products/urban/notice/notification.py
@@ -174,6 +174,7 @@ class NoticeNotification(NoticeElement):
             "NOTIFICATION_PAS_ENVOI_RS": "ns3:SummaryReportRequest",
             "NOTIFICATION_PAS_ENVOI_RS_SFD": "ns3:SummaryReportRequest",
             "PM_RS_PAS_ENVOYE": "ns3:SummaryReportRequest",
+            "PM_ENVOI_RS_COMMUNE": "ns3:SummaryReportRequest",
             "NOTIFICATION_DECISION_COMMUNE": "ns3:DecisionRequest",
             "NOTIFICATION_DEC_RS_COMMUNE": "ns3:DecisionRequest",
             "NOTIFICATION_DECRS_REFUS_TACITE_COMMUNE": "ns3:DecisionRequest",


### PR DESCRIPTION
This PR implements the transmission summary report notification.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added end-to-end support for the new notification type (**PM_ENVOI_RS_COMMUNE**) across transfer and display decision flows.
  * Updated routing so RS-related notifications are handled by summary reporting.
  * Enhanced decision handling by using the proposed decision code to set the external decision and move to the final-decision preparation stage.
* **Localization**
  * Added French translations for **PM_ENVOI_RS_COMMUNE** (“Transmission du rapport de synthèse suite aux plans modificatifs”).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->