### PR TITLE
SUP-53078 add missing translation for urban_bound_roaddecrees

### DIFF
--- a/news/SUP-53078.fix
+++ b/news/SUP-53078.fix
@@ -1,0 +1,2 @@
+Add missing translation for urban_bound_roaddecrees
+[WBoudabous]

--- a/src/Products/urban/locales/fr/LC_MESSAGES/urban.po
+++ b/src/Products/urban/locales/fr/LC_MESSAGES/urban.po
@@ -3020,7 +3020,7 @@ msgstr "urban_bound_licence"
 #. Default: "Bound roaddecrees"
 #: ../browser/licence/templates/licencetabsmacros.pt:71
 msgid "urban_bound_roaddecrees"
-msgstr "Décrets de la route liée"
+msgstr "Décrets voirie liés"
 
 #. Default: "Browse old parcels (Only works with the parcel reference)"
 #: ../browser/templates/searchparcels.pt:156

--- a/src/Products/urban/locales/fr/LC_MESSAGES/urban.po
+++ b/src/Products/urban/locales/fr/LC_MESSAGES/urban.po
@@ -3020,7 +3020,7 @@ msgstr "urban_bound_licence"
 #. Default: "Bound roaddecrees"
 #: ../browser/licence/templates/licencetabsmacros.pt:71
 msgid "urban_bound_roaddecrees"
-msgstr "urban_bound_roaddecrees"
+msgstr "Décrets de la route liée"
 
 #. Default: "Browse old parcels (Only works with the parcel reference)"
 #: ../browser/templates/searchparcels.pt:156


### PR DESCRIPTION
This PR adds missing translation for urban_bound_roaddecrees


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added the missing translation entry for “road decrees” so the correct label is shown.
  * Updated French localization to display “Décrets voirie liés” instead of a placeholder/incorrect value.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->