### PR TITLE
URB-2540 Add  missing translation of warning_add_a_proprietary

### DIFF
--- a/news/URB-2540.bugFix
+++ b/news/URB-2540.bugFix
@@ -1,0 +1,2 @@
+Add  missing translation of warning_add_a_proprietary
+[WBoudabous]

--- a/src/Products/urban/locales/fr/LC_MESSAGES/plone.po
+++ b/src/Products/urban/locales/fr/LC_MESSAGES/plone.po
@@ -556,3 +556,6 @@ msgstr "Constat annuel"
 
 msgid "ComplementaryDelayTerm"
 msgstr "Prorogation complémentaire"
+
+msgid "warning_add_a_proprietary"
+msgstr "Veuillez renseigner le ou les demandeur(s)"

--- a/src/Products/urban/locales/plone.pot
+++ b/src/Products/urban/locales/plone.pot
@@ -556,3 +556,6 @@ msgstr ""
 
 msgid "ComplementaryDelayTerm"
 msgstr ""
+
+msgid "warning_add_a_proprietary"
+msgstr ""


### PR DESCRIPTION
This PR fixes a missing translation for `warning_add_a_proprietary`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated warning message translations so French users see the correct validation text when additional information is required.
  * Added the new translation key to the translation template and ensured it’s available for proper localization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->