### PR TITLE
URB-3683: NOTICE form special cases

### DIFF
--- a/news/URB-3683.bugfix
+++ b/news/URB-3683.bugfix
@@ -1,0 +1,2 @@
+Avoid handling the same incoming NOTICE notification twice
+[daggelpop]

--- a/news/URB-3683.bugfix
+++ b/news/URB-3683.bugfix
@@ -1,4 +1,3 @@
 Avoid handling the same incoming NOTICE notification twice
-[daggelpop]
 Hide NOTICE response forms from events with a final notification
 [daggelpop]

--- a/news/URB-3683.bugfix
+++ b/news/URB-3683.bugfix
@@ -1,2 +1,4 @@
 Avoid handling the same incoming NOTICE notification twice
 [daggelpop]
+Hide NOTICE response forms from events with a final notification
+[daggelpop]

--- a/src/Products/urban/browser/cron/notice.py
+++ b/src/Products/urban/browser/cron/notice.py
@@ -11,12 +11,14 @@ from Products.urban.notice.exceptions import ErrorProcessingNotificationExceptio
 from Products.urban.notice.exceptions import FailedGettingRecentNotificationsException
 from Products.urban.notice.exceptions import NoImplementationFoundException
 from Products.urban.notice.exceptions import NoLicenceFoundException
+from Products.urban.notice.exceptions import NotificationAlreadyHandledException
 from Products.urban.services import notice
 from StringIO import StringIO
 from datetime import datetime
 from plone import api
 from plone.api.exc import InvalidParameterError
 from plone.stringinterp.interfaces import IContextWrapper
+from zope.annotation.interfaces import IAnnotations
 from zope.event import notify
 from zope.i18n import translate
 from zope.lifecycleevent import ObjectModifiedEvent
@@ -292,6 +294,7 @@ class IncomingNoticeHandler(object):
 
     def process(self):
         if self.licence:
+            self.ensure_no_duplicates()
             self.update_licence()
         elif self.create_licence_if_missing:
             self.create_licence()
@@ -441,6 +444,19 @@ class IncomingNoticeHandler(object):
         if notification_ref and licence_ref != notification_ref:
             self.licence.setReferenceDGATLP(notification_ref)
             self.licence.reindexObject(idxs=["referenceDGATLP"])
+
+    def ensure_no_duplicates(self):
+        """Make sure that no event pertaining to this notification already exists in this licence"""
+        all_licence_events = sorted(
+            self.licence.getAllEvents(), key=lambda e: e.created()
+        )
+        for event in all_licence_events:
+            annotations = IAnnotations(event)
+            key = "notice_notification"
+            notice = annotations.get(key, {})
+            incoming = notice.get("incoming", {})
+            if self.notification.noticeId == incoming.get("notice_id"):
+                raise NotificationAlreadyHandledException(event)
 
     def _add_error(self, msg, serialized_data):
         error = _(

--- a/src/Products/urban/browser/urbaneventviews.py
+++ b/src/Products/urban/browser/urbaneventviews.py
@@ -30,6 +30,7 @@ from z3c.form import button
 from z3c.form import field
 from z3c.form import form
 from zope.annotation import interfaces
+from zope.annotation.interfaces import IAnnotations
 from zope.component import getMultiAdapter
 from zope.component import getUtility
 from zope.interface import Interface
@@ -1314,6 +1315,7 @@ class CanTransferNoticeBaseView(BrowserView):
             and self.event_has_any_matching_markers
             and self.is_transmit_to_spw_event
             and self.is_notice_setup
+            and self.event_has_no_final_outgoing_notification
             and self.licence_has_open_incoming_notifications
         )
 
@@ -1340,6 +1342,17 @@ class CanTransferNoticeBaseView(BrowserView):
     def is_notice_setup(self):
         webservice = WebserviceNotice()
         return webservice.is_setup
+
+    @property
+    def event_has_no_final_outgoing_notification(self):
+        annotations = IAnnotations(self.context)
+        key = "notice_notification"
+        notice = annotations.get(key, {})
+        outgoings = notice.get("outgoing", [])
+        for outgoing in outgoings:
+            if outgoing.get("partial_or_final") == "FINAL":
+                return False
+        return True
 
     @property
     def licence_has_open_incoming_notifications(self):

--- a/src/Products/urban/notice/exceptions.py
+++ b/src/Products/urban/notice/exceptions.py
@@ -133,3 +133,13 @@ class NoPreviousEventFoundException(NoticeException):
     def __init__(self, event_type, entity_id):
         msg = "No previous {} has been found for {}".format(event_type, entity_id)
         super(NoPreviousEventFoundException, self).__init__(msg)
+
+
+class NotificationAlreadyHandledException(NoticeException):
+    """Raised when trying to handle a notification more than once"""
+
+    def __init__(self, existing_event):
+        msg = "An event matching this notification has been found on the licence: {}".format(
+            existing_event.absolute_url()
+        )
+        super(NotificationAlreadyHandledException, self).__init__(msg)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Prevented duplicate handling of incoming NOTICE notifications by detecting previously processed notice IDs and stopping re-import attempts.
  * NOTICE response forms are now hidden when an event already has a final outgoing notification (to avoid showing forms for completed notifications).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->