### PR TITLE
URB-3659: Add due date to imported summary report events

### DIFF
--- a/news/URB-3659.feature
+++ b/news/URB-3659.feature
@@ -1,0 +1,2 @@
+Add due date to imported summary report events
+[daggelpop]

--- a/src/Products/urban/browser/cron/notice.py
+++ b/src/Products/urban/browser/cron/notice.py
@@ -605,6 +605,11 @@ class SummaryReportHandler(IncomingNoticeHandler):
 
     def fill_incoming_event(self):
         super(SummaryReportHandler, self).fill_incoming_event()
+
+        if self.notification.due_date:
+            event_date = DateTime(str(self.notification.due_date))
+            self.event.setUltimeDate(event_date)
+
         if self.notification.proposed_decision_code:
             self.event.setExternalDecision(self.notification.proposed_decision_code)
 

--- a/src/Products/urban/notice/notification.py
+++ b/src/Products/urban/notice/notification.py
@@ -241,6 +241,13 @@ class NoticeNotification(NoticeElement):
         raw_date = self._get_data("sendDate")
         if raw_date:
             return datetime.strptime(raw_date[:19], "%Y-%m-%dT%H:%M:%S").date()
+    
+    @property
+    def due_date(self):
+        """Return the due date"""
+        raw_date = self._get_data("dueDate")
+        if raw_date:
+            return datetime.strptime(raw_date[:19], "%Y-%m-%dT%H:%M:%S").date()
 
     @property
     def container(self):


### PR DESCRIPTION
Note: so far, only summary report notifications have had data in the `dueDate` field.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Imported summary report events now include due-date information when available.
  * Notifications can now surface a due date from incoming data, making event deadlines more complete.

* **Bug Fixes**
  * Summary report event details now carry the due date into the event record, improving accuracy for downstream viewing and tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->