### PR TITLE
URB-3658: Clarify translations for NOTICE response buttons

### DIFF
--- a/news/URB-3658.bugfix
+++ b/news/URB-3658.bugfix
@@ -1,0 +1,2 @@
+Clarify translations for NOTICE response buttons
+[daggelpop]

--- a/src/Products/urban/locales/fr/LC_MESSAGES/urban.po
+++ b/src/Products/urban/locales/fr/LC_MESSAGES/urban.po
@@ -2918,13 +2918,13 @@ msgid "transfer_opinion"
 msgstr "Envoyer l'avis préalable du Collège vers le SPW"
 
 msgid "transfer_opinion_gesper_ap"
-msgstr "Envoyer l'avis préalable du Collège vers le SPW"
+msgstr "Envoyer l'avis préalable du Collège (A.P.) vers le SPW"
 
 msgid "transfer_opinion_gesper_ep"
-msgstr "Envoyer l'avis préalable du Collège vers le SPW"
+msgstr "Envoyer l'avis préalable du Collège (E.P.) vers le SPW"
 
 msgid "transfer_opinion_gesper_opinion_request"
-msgstr "Envoyer l'avis préalable du Collège vers le SPW"
+msgstr "Envoyer l'avis préalable du Collège (avis seul) vers le SPW"
 
 msgid "transfer_ticket"
 msgstr "Envoyer le PV et les réclamations vers le SPW"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved French translations for mailing actions so the “Avis préalable du Collège” messages now vary correctly by procedure.
  * Clarified NOTICE response button translations in the changelog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->