### PR TITLE
URB-3702: Set up cron4plone for notice import

### DIFF
--- a/news/URB-3702.feature
+++ b/news/URB-3702.feature
@@ -1,0 +1,2 @@
+Add cron4plone instruction for notice import
+[daggelpop]

--- a/news/URB-3702.feature
+++ b/news/URB-3702.feature
@@ -1,2 +1,3 @@
 Add cron4plone instruction for notice import
+Switch NOTICe API default URL to production
 [daggelpop]

--- a/src/Products/urban/browser/notice_settings.py
+++ b/src/Products/urban/browser/notice_settings.py
@@ -16,7 +16,7 @@ class INoticeSettings(Interface):
     url = schema.URI(
         title=_("Webservice URL"),
         required=True,
-        default="https://api-staging.imio.be/spw/notice/v1/",
+        default="https://api.imio.be/spw/notice/v1/",
     )
 
     municipality_id = schema.TextLine(

--- a/src/Products/urban/migration/update_290.py
+++ b/src/Products/urban/migration/update_290.py
@@ -3,6 +3,7 @@
 from textwrap import dedent
 
 from Products.CMFCore.utils import getToolByName
+from Products.cron4plone.browser.configlets.cron_configuration import ICronConfiguration
 from Products.urban import URBAN_TYPES
 from Products.urban import UrbanMessage as _
 from Products.urban.contentrules.notice import INoticeImportFailedEvent
@@ -20,6 +21,7 @@ from plone.registry import field
 from plone.registry import Record
 from plone.registry.interfaces import IRegistry
 from zope.component import getUtility
+from zope.component import queryUtility
 from zope.event import notify
 
 import logging
@@ -643,3 +645,18 @@ def normalize_externaldecisions_vocabulary(context):
             new_term = getattr(voc_folder, vocabulary_term)
             new_term.setDescription(DESCRIPTION)
             logger.info("Created missing vocabulary term: %s", vocabulary_term)
+
+
+def setup_cron4plone_notice_import(context):
+    logger = logging.getLogger("urban: Setup cron4plone notice import")
+
+    cron_cfg = queryUtility(
+        ICronConfiguration, name="cron4plone_config", context=api.portal.get()
+    )
+
+    line_to_add = u"0 * * * portal/@@import-from-notice"
+    if line_to_add not in cron_cfg.cronjobs:
+        new_list = list(cron_cfg.cronjobs) + [line_to_add]
+        cron_cfg.cronjobs = new_list
+
+    logger.info("upgrade step done!")

--- a/src/Products/urban/migration/upgrades_290.zcml
+++ b/src/Products/urban/migration/upgrades_290.zcml
@@ -140,4 +140,12 @@
         handler=".update_290.normalize_externaldecisions_vocabulary"
         profile="Products.urban:default" />
 
+    <gs:upgradeStep
+        title="Setup cron4plone notice import"
+        description=""
+        source="2917"
+        destination="2918"
+        handler=".update_290.setup_cron4plone_notice_import"
+        profile="Products.urban:default" />
+
 </configure>

--- a/src/Products/urban/profiles/default/metadata.xml
+++ b/src/Products/urban/profiles/default/metadata.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <metadata>
-  <version>2916</version>
+  <version>2918</version>
   <dependencies>
     <dependency>profile-Products.urban:preinstall</dependency>
   </dependencies>

--- a/src/Products/urban/setuphandlers.py
+++ b/src/Products/urban/setuphandlers.py
@@ -303,6 +303,7 @@ def addDefaultCronJobs(context):
         u"0 1 * * portal/@@mailings",
         u"0 2 * * portal/@@inquiry_radius",
         u"0 4 * * portal/@@claimants_import",
+        u"0 * * * portal/@@import-from-notice",
     ]
 
 


### PR DESCRIPTION

- Add cron4plone instruction for notice import
- Switch NOTICe API default URL to production

Note: metadata version goes from 2916 to 2918 because 2917 was forgotten in another PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an automatic hourly import task for notice data.
  * Updated the default notice API endpoint to use the production service.
  * Included the new notice import setup in the next upgrade step.

* **Chores**
  * Bumped the package metadata version to reflect the latest upgrade.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->