### PR TITLE
URB-3704: Handle an empty list of NOTICe notifications

### DIFF
--- a/news/URB-3704.bugfix
+++ b/news/URB-3704.bugfix
@@ -1,0 +1,2 @@
+Handle an empty list of NOTICe notifications
+[daggelpop]

--- a/src/Products/urban/services/notice.py
+++ b/src/Products/urban/services/notice.py
@@ -135,7 +135,9 @@ class WebserviceNotice(WebService):
         result = response.json()
         if result["status"] != "PROCESSED":
             raise ValueError("Error in response '{}'".format(result["status"]["value"]))
-        return result["notices"]["notice"]
+        notices_obj = result.get("notices") or {}
+        notices_list = notices_obj.get("notice") or []
+        return notices_list
 
     def _get_notification(self, notification_id):
         """Get a notification informations response from REST API"""


### PR DESCRIPTION
Only happens to municipalities freshly connected to the NOTICe streams, before receiving their first notification.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of REST responses with no NOTICe notifications.
  * The system now returns an empty notification list instead of producing an error when notification data is missing or empty.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->