### PR TITLE
URB-3705: Handle irregular parcel data from NOTICe

### DIFF
--- a/news/URB-3705.bugfix
+++ b/news/URB-3705.bugfix
@@ -1,0 +1,2 @@
+Handle irregular parcel data from NOTICe
+[daggelpop]

--- a/src/Products/urban/notice/parcel.py
+++ b/src/Products/urban/notice/parcel.py
@@ -54,19 +54,31 @@ class NoticeParcel(NoticeElement):
 
     @property
     def radical(self):
-        return self._get_data("radical").lstrip("0")
+        raw = self._get_data("radical")
+        if raw and isinstance(raw, basestring):
+            raw = raw.lstrip("0")
+        return raw
 
     @property
     def bis(self):
-        return self._get_data("bisTer").lstrip("0")
+        raw = self._get_data("bisTer")
+        if raw and isinstance(raw, basestring):
+            raw = raw.lstrip("0")
+        return raw
 
     @property
     def exposant(self):
-        return self._get_data("exponent")
+        raw = self._get_data("exponent")
+        if raw == "_":
+            return None
+        return raw
 
     @property
     def puissance(self):
-        return self._get_data("power").lstrip("0")
+        raw = self._get_data("power")
+        if raw and isinstance(raw, basestring):
+            raw = raw.lstrip("0")
+        return raw
 
     @property
     def partie(self):


### PR DESCRIPTION

Possible field types for a parcel, gathered from existing staging data:
- `codeDivision`: 5-digit string; could be `null` before, but that has been patched since
- `section`: one letter string
- `radical`: string of numbers, sometimes zero-padded, maximum 4 characters
- `bisTer`: `"0"`, `"00"` or `null`
- `exponent`: one character string; either a letter or `"_"`
- `power`: string of 1 or 3 digits (zero-padded), or `null`
- `part`: `true`, `false`, `null`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of irregular parcel data from NOTICe.
  * Parcel numeric fields now handle non-text values safely and normalize leading zeros correctly.
  * Missing exponent values are now recognized and displayed appropriately.

* **Documentation**
  * Added a changelog entry for the parcel data handling improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->