### PR TITLE
URB-3703: reference_FT (Plans modificatifs)

### DIFF
--- a/news/URB-3703.bugfix
+++ b/news/URB-3703.bugfix
@@ -1,0 +1,2 @@
+Fill missing keys for specific code mapping
+[daggelpop]

--- a/news/URB-3703.feature
+++ b/news/URB-3703.feature
@@ -1,0 +1,2 @@
+Store and index `referenceFT_PM`, coming from TWICE
+[daggelpop]

--- a/src/Products/urban/browser/cron/notice.py
+++ b/src/Products/urban/browser/cron/notice.py
@@ -311,6 +311,7 @@ class IncomingNoticeHandler(object):
             raise NoLicenceFoundException(
                 self.notification.reference,
                 self.notification.referenceFT,
+                self.notification.referenceFT_PM,
                 self.notification.referenceDGATLP,
             )
         self.create_incoming_event()
@@ -430,6 +431,7 @@ class IncomingNoticeHandler(object):
 
     def update_licence(self):
         self.set_reference_ft()
+        self.set_reference_ft_pm()
         self.set_reference_dgatlp()
 
     def set_reference_ft(self):
@@ -442,6 +444,17 @@ class IncomingNoticeHandler(object):
         if notification_ref and licence_ref != notification_ref:
             self.licence.setReferenceFT(notification_ref)
             self.licence.reindexObject(idxs=["referenceFT"])
+
+    def set_reference_ft_pm(self):
+        try:
+            licence_ref = self.licence.getReferenceFT_PM()
+        except AttributeError:
+            return
+
+        notification_ref = self.notification.referenceFT_PM
+        if notification_ref and licence_ref != notification_ref:
+            self.licence.setReferenceFT_PM(notification_ref)
+            self.licence.reindexObject(idxs=["referenceFT_PM"])
 
     def set_reference_dgatlp(self):
         try:

--- a/src/Products/urban/content/licence/CODT_UniqueLicence.py
+++ b/src/Products/urban/content/licence/CODT_UniqueLicence.py
@@ -57,6 +57,7 @@ from zope.interface import implements
 optional_fields = [
     "referenceSPE",
     "referenceFT",
+    "referenceFT_PM",
     "environmentTechnicalRemarks",
     "claimsSynthesis",
     "conclusions",
@@ -446,6 +447,7 @@ def finalizeSchema(schema):
     """
     schema.moveField("referenceSPE", after="reference")
     schema.moveField("referenceFT", after="referenceDGATLP")
+    schema.moveField("referenceFT_PM", before="additionalReference")
     schema.moveField("authority", before="folderCategory")
     schema.moveField("folderTendency", after="folderCategory")
     schema.moveField("rubrics", after="folderTendency")

--- a/src/Products/urban/content/licence/EnvironmentBase.py
+++ b/src/Products/urban/content/licence/EnvironmentBase.py
@@ -56,6 +56,7 @@ optional_fields = [
     "environmentTechnicalRemarks",
     "rubricsDetails",
     "referenceFT",
+    "referenceFT_PM",
     "divergences",
     "divergenceDetails",
     "prorogation",
@@ -101,6 +102,14 @@ schema = Schema(
             widget=StringField._properties["widget"](
                 size=30,
                 label=_("urban_label_referenceFT", default="Referenceft"),
+            ),
+            schemata="urban_description",
+        ),
+        StringField(
+            name="referenceFT_PM",
+            widget=StringField._properties["widget"](
+                size=30,
+                label=_("urban_label_referenceFT_PM", default="reference FT PM"),
             ),
             schemata="urban_description",
         ),
@@ -639,6 +648,7 @@ def finalizeSchema(schema, folderish=False, moveDiscussion=True):
     schema.moveField("description", after="additionalLegalConditions")
     schema.moveField("referenceFT", after="referenceDGATLP")
     schema.moveField("isTransferOfLicence", after="referenceFT")
+    schema.moveField("referenceFT_PM", before="additionalReference")
 
     return schema
 

--- a/src/Products/urban/content/licence/EnvironmentLicence.py
+++ b/src/Products/urban/content/licence/EnvironmentLicence.py
@@ -46,6 +46,7 @@ optional_fields = [
     "previousLicences",
     "referenceSPE",
     "referenceFT",
+    "referenceFT_PM",
     "claimsSynthesis",
     "conclusions",
     "commentsOnSPWOpinion",

--- a/src/Products/urban/locales/fr/LC_MESSAGES/urban.po
+++ b/src/Products/urban/locales/fr/LC_MESSAGES/urban.po
@@ -5077,6 +5077,11 @@ msgstr "Référence SPW Economie, Emploi, Recherche"
 msgid "urban_label_referenceFT"
 msgstr "Référence FT (ARNE)"
 
+#. Default: "reference FT PM"
+#: ../content/licence/EnvironmentBase.py:112
+msgid "urban_label_referenceFT_PM"
+msgstr "Référence FT (Plans modifiés)"
+
 #. Default: "Referenceprosecution"
 #: ../content/licence/Inspection.py:38
 #: ../content/licence/Ticket.py:39

--- a/src/Products/urban/locales/urban.pot
+++ b/src/Products/urban/locales/urban.pot
@@ -5110,6 +5110,11 @@ msgstr ""
 msgid "urban_label_referenceFT"
 msgstr ""
 
+#. Default: "reference FT PM"
+#: ../content/licence/EnvironmentBase.py:112
+msgid "urban_label_referenceFT_PM"
+msgstr ""
+
 #. Default: "Referenceprosecution"
 #: ../content/licence/Inspection.py:137
 #: ../content/licence/Ticket.py:138

--- a/src/Products/urban/migration/update_290.py
+++ b/src/Products/urban/migration/update_290.py
@@ -700,3 +700,24 @@ def normalize_externaldecisions_vocabulary(context):
             logger.info("Created missing vocabulary term: %s", vocabulary_term)
 
     logger.info("Upgrade done!")
+
+
+def setup_referenceFT_PM(context):
+    logger = logging.getLogger("urban: Set up `referenceFT_PM` index and attribute")
+
+    # activate optional attribute
+    portal_urban = api.portal.get_tool("portal_urban")
+    for config in portal_urban.objectValues("LicenceConfig"):
+        if (
+            "referenceFT_PM" in config.listUsedAttributes()
+            and "referenceFT_PM" not in config.getUsedAttributes()
+        ):
+            to_set = ("referenceFT_PM",)
+            config.setUsedAttributes(config.getUsedAttributes() + to_set)
+
+    # set up index
+    setup_tool = api.portal.get_tool("portal_setup")
+    setup_tool.runImportStepFromProfile("profile-Products.urban:urbantypes", "catalog")
+    reindexIndexes(None, ["referenceFT_PM"])
+
+    logger.info("upgrade step done!")

--- a/src/Products/urban/migration/upgrades_290.zcml
+++ b/src/Products/urban/migration/upgrades_290.zcml
@@ -148,4 +148,12 @@
         handler=".update_290.setup_notice_form_error_mailing_content_rule"
         profile="Products.urban:default" />
 
+    <gs:upgradeStep
+        title="Set up `referenceFT_PM` index"
+        description=""
+        source="2918"
+        destination="2919"
+        handler=".update_290.setup_referenceFT_PM"
+        profile="Products.urban:default" />
+
 </configure>

--- a/src/Products/urban/notice/exceptions.py
+++ b/src/Products/urban/notice/exceptions.py
@@ -106,10 +106,12 @@ class NoImplementationFoundException(NoticeException):
 class NoLicenceFoundException(NoticeException):
     """Raised when no licence is found for given references."""
 
-    def __init__(self, urban_reference, referenceFT=None, referenceDGATLP=None):
+    def __init__(self, urban_reference, referenceFT=None, referenceFT_PM=None, referenceDGATLP=None):
         msg_parts = ["No licence found for URBAN reference {}".format(urban_reference)]
         if referenceFT:
             msg_parts.append("reference FT {}".format(referenceFT))
+        if referenceFT_PM:
+            msg_parts.append("reference FT (PM) {}".format(referenceFT_PM))
         if referenceDGATLP:
             msg_parts.append("reference DGATLP {}".format(referenceDGATLP))
         msg = ", or ".join(msg_parts)

--- a/src/Products/urban/notice/notification.py
+++ b/src/Products/urban/notice/notification.py
@@ -88,10 +88,18 @@ class NoticeNotification(NoticeElement):
 
     @property
     def referenceFT(self):
-        if self.original_application == "TWICE":
+        if self.original_application == "TWICE" and self.notification_type == "PE_PU":
             return self._get_data("BO", "idBO")
         else:
             return None
+
+    @property
+    def referenceFT_PM(self):
+        if self.original_application == "TWICE" and self.notification_type == "PLANS_MODIFICATIFS":
+            return self._get_data("BO", "idBO")
+        else:
+            return None
+
 
     @property
     def referenceDGATLP(self):
@@ -276,6 +284,15 @@ class NoticeNotification(NoticeElement):
         if self.referenceFT:
             brains = catalog.unrestrictedSearchResults(
                 referenceFT=self.referenceFT,
+                object_provides=IGenericLicence.__identifier__,
+            )
+            if brains:
+                licence = brains[0].getObject()
+                return licence
+
+        if self.referenceFT_PM:
+            brains = catalog.unrestrictedSearchResults(
+                referenceFT_PM=self.referenceFT_PM,
                 object_provides=IGenericLicence.__identifier__,
             )
             if brains:

--- a/src/Products/urban/notice/notification.py
+++ b/src/Products/urban/notice/notification.py
@@ -154,6 +154,7 @@ class NoticeNotification(NoticeElement):
     @property
     def _specific_code(self):
         specific = {
+            # Twice Default
             "TRANSFERT_DOSSIER": "ns3:TwiceDefaultRequest",
             "TRANSFERT_DOSSIER_PM": "ns3:TwiceDefaultRequest",
             "TRANSFERT_DOSSIER_DRC": "ns3:TwiceDefaultRequest",
@@ -163,11 +164,15 @@ class NoticeNotification(NoticeElement):
             "NOTIF_COMPLETUDE2_IRRECEVABLE_COMMUNE": "ns3:TwiceDefaultRequest",
             "NOTIF_COMPLETUDE2_NON_RECEVABLE_COMMUNE": "ns3:TwiceDefaultRequest",
             "PM_NOTIF_IRRECEVABLE_COMMUNE": "ns3:TwiceDefaultRequest",
+            "NOTIFICATION_PROROGATION_COMMUNE": "ns3:TwiceDefaultRequest",
+            "PM_PROROGATION_COURRIER_COMMUNE": "ns3:TwiceDefaultRequest",
+
+            # Public Survey
             "DEMANDE_EP": "ns3:PublicSurveyRequest",
             "DEMANDE_EP_DOSSIER_PRECEDENT": "ns3:PublicSurveyRequest",
             "DEMANDE_EP_EXTRA": "ns3:PublicSurveyRequest",
-            "NOTIFICATION_PROROGATION_COMMUNE": "ns3:TwiceDefaultRequest",
-            "PM_PROROGATION_COURRIER_COMMUNE": "ns3:TwiceDefaultRequest",
+
+            # Summary Report
             "NOTIFICATION_RS_COMMUNE": "ns3:SummaryReportRequest",
             "NOTIFICATION_RS_COMMUNE_RETARD": "ns3:SummaryReportRequest",
             "NOTIFICATION_RS_COMMUNE_RETARD_SFD": "ns3:SummaryReportRequest",
@@ -175,9 +180,16 @@ class NoticeNotification(NoticeElement):
             "NOTIFICATION_PAS_ENVOI_RS_SFD": "ns3:SummaryReportRequest",
             "PM_RS_PAS_ENVOYE": "ns3:SummaryReportRequest",
             "PM_ENVOI_RS_COMMUNE": "ns3:SummaryReportRequest",
+            "PM_ENVOI_RS_HD_SFD_COMMUNE": "ns3:SummaryReportRequest",
+            "PM_RS_PAS_ENVOYE_SFD": "ns3:SummaryReportRequest",
+
+            # Decision
             "NOTIFICATION_DECISION_COMMUNE": "ns3:DecisionRequest",
             "NOTIFICATION_DEC_RS_COMMUNE": "ns3:DecisionRequest",
             "NOTIFICATION_DECRS_REFUS_TACITE_COMMUNE": "ns3:DecisionRequest",
+            "PM_ENVOI_DECISION_FT_COURRIER_COMMUNE": "ns3:DecisionRequest",
+            "PM_REFUS_TACITE_COMMUNE": "ns3:DecisionRequest",
+            "PM_RS_DECISION_COMMUNE": "ns3:DecisionRequest",
         }
         return specific.get(self.notice_type)
 

--- a/src/Products/urban/profiles/default/metadata.xml
+++ b/src/Products/urban/profiles/default/metadata.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <metadata>
-  <version>2918</version>
+  <version>2919</version>
   <dependencies>
     <dependency>profile-Products.urban:preinstall</dependency>
   </dependencies>

--- a/src/Products/urban/profiles/urban_types/catalog.xml
+++ b/src/Products/urban/profiles/urban_types/catalog.xml
@@ -133,6 +133,11 @@
   </index>
   <column value="referenceFT"/>
 
+  <index name="referenceFT_PM" meta_type="FieldIndex">
+    <indexed_attr value="referenceFT_PM"/>
+  </index>
+  <column value="referenceFT_PM"/>
+
   <index name="referenceDGATLP" meta_type="FieldIndex">
     <indexed_attr value="referenceDGATLP"/>
   </index>


### PR DESCRIPTION
2 commits:

- Some keys for specific code mapping are missing: fill and sort.

- Add and index a second field for reference FT: the SPW creates a new internal ID when reaching the Modified Plan phase. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for storing and indexing the FT (Plans modifiés) reference.
  * Added French labeling for the new reference field.
  * Improved licence matching for relevant modification notices.
  * Added mappings for additional notice types.

* **Bug Fixes**
  * Filled missing code mappings and synchronized reference data during notice imports.

* **Migration**
  * Existing licences are updated and reindexed through the upgrade process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->