### PR TITLE
URB-3720: Fix decision display form

### DIFF
--- a/news/URB-3720.bugfix
+++ b/news/URB-3720.bugfix
@@ -1,0 +1,2 @@
+Fix decision display form
+[daggelpop]

--- a/src/Products/urban/browser/notice_forms.py
+++ b/src/Products/urban/browser/notice_forms.py
@@ -151,7 +151,7 @@ class NoticeResponseActionForm(Form):
             annotations = IAnnotations(event)
             key = "notice_notification"
             notice = annotations.get(key, {})
-            incoming = notice.get("incoming", [])
+            incoming = notice.get("incoming", {})
             if incoming.get("notice_id") == incoming_id:
                 return incoming.get("notice_type")
         return None


### PR DESCRIPTION
Fixes parsing of annotation.
`incoming` is a dict, not a list.

```
{
  "notice_notification": {
    "incoming": {
      "notice_id": "123456789",
      "notice_type": "NOTIFICATION_DEC_RS_COMMUNE",
      "reception_date": "2026-07-09T23:59:59"
    }
  }
}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the decision display form.
  * Improved handling of missing notice notification data to prevent display errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->