### PR TITLE
URB-3651: Add index and widget to filter by last received NOTICe notification

### DIFF
--- a/news/URB-3651.feature
+++ b/news/URB-3651.feature
@@ -1,0 +1,2 @@
+Add index and widget to filter by last received NOTICe notification
+[daggelpop]

--- a/src/Products/urban/dashboard/config/all.xml
+++ b/src/Products/urban/dashboard/config/all.xml
@@ -161,5 +161,15 @@
    <property name="hidezerocount">False</property>
    <property name="sortreversed">False</property>
   </criterion>
+  <criterion name="c96">
+   <property name="widget">daterange</property>
+   <property name="title">Dernier événement réceptionné</property>
+   <property name="position">top</property>
+   <property name="section">advanced</property>
+   <property name="hidden">False</property>
+   <property name="index">last_received_notice_notification</property>
+   <property name="default"></property>
+   <property name="calYearRange">c-10:c+10</property>
+  </criterion>
  </criteria>
 </object>

--- a/src/Products/urban/dashboard/config/all.xml
+++ b/src/Products/urban/dashboard/config/all.xml
@@ -163,7 +163,7 @@
   </criterion>
   <criterion name="c96">
    <property name="widget">daterange</property>
-   <property name="title">Dernier événement réceptionné</property>
+   <property name="title">Dernier événement reçu</property>
    <property name="position">top</property>
    <property name="section">advanced</property>
    <property name="hidden">False</property>

--- a/src/Products/urban/dashboard/config/article127s.xml
+++ b/src/Products/urban/dashboard/config/article127s.xml
@@ -175,7 +175,7 @@
   </criterion>
   <criterion name="c96">
    <property name="widget">daterange</property>
-   <property name="title">Dernier événement réceptionné</property>
+   <property name="title">Dernier événement reçu</property>
    <property name="position">top</property>
    <property name="section">advanced</property>
    <property name="hidden">False</property>

--- a/src/Products/urban/dashboard/config/article127s.xml
+++ b/src/Products/urban/dashboard/config/article127s.xml
@@ -173,5 +173,15 @@
    <property name="hidezerocount">False</property>
    <property name="sortreversed">False</property>
   </criterion>
+  <criterion name="c96">
+   <property name="widget">daterange</property>
+   <property name="title">Dernier événement réceptionné</property>
+   <property name="position">top</property>
+   <property name="section">advanced</property>
+   <property name="hidden">False</property>
+   <property name="index">last_received_notice_notification</property>
+   <property name="default"></property>
+   <property name="calYearRange">c-10:c+10</property>
+  </criterion>
  </criteria>
 </object>

--- a/src/Products/urban/dashboard/config/buildlicences.xml
+++ b/src/Products/urban/dashboard/config/buildlicences.xml
@@ -185,5 +185,15 @@
    <property name="hidezerocount">False</property>
    <property name="sortreversed">False</property>
   </criterion>
+  <criterion name="c96">
+   <property name="widget">daterange</property>
+   <property name="title">Dernier événement réceptionné</property>
+   <property name="position">top</property>
+   <property name="section">advanced</property>
+   <property name="hidden">False</property>
+   <property name="index">last_received_notice_notification</property>
+   <property name="default"></property>
+   <property name="calYearRange">c-10:c+10</property>
+  </criterion>
  </criteria>
 </object>

--- a/src/Products/urban/dashboard/config/buildlicences.xml
+++ b/src/Products/urban/dashboard/config/buildlicences.xml
@@ -187,7 +187,7 @@
   </criterion>
   <criterion name="c96">
    <property name="widget">daterange</property>
-   <property name="title">Dernier événement réceptionné</property>
+   <property name="title">Dernier événement reçu</property>
    <property name="position">top</property>
    <property name="section">advanced</property>
    <property name="hidden">False</property>

--- a/src/Products/urban/dashboard/config/codt_article127s.xml
+++ b/src/Products/urban/dashboard/config/codt_article127s.xml
@@ -185,5 +185,15 @@
    <property name="hidezerocount">False</property>
    <property name="sortreversed">False</property>
   </criterion>
+  <criterion name="c96">
+   <property name="widget">daterange</property>
+   <property name="title">Dernier événement réceptionné</property>
+   <property name="position">top</property>
+   <property name="section">advanced</property>
+   <property name="hidden">False</property>
+   <property name="index">last_received_notice_notification</property>
+   <property name="default"></property>
+   <property name="calYearRange">c-10:c+10</property>
+  </criterion>
  </criteria>
 </object>

--- a/src/Products/urban/dashboard/config/codt_article127s.xml
+++ b/src/Products/urban/dashboard/config/codt_article127s.xml
@@ -187,7 +187,7 @@
   </criterion>
   <criterion name="c96">
    <property name="widget">daterange</property>
-   <property name="title">Dernier événement réceptionné</property>
+   <property name="title">Dernier événement reçu</property>
    <property name="position">top</property>
    <property name="section">advanced</property>
    <property name="hidden">False</property>

--- a/src/Products/urban/dashboard/config/codt_buildlicences.xml
+++ b/src/Products/urban/dashboard/config/codt_buildlicences.xml
@@ -195,5 +195,15 @@
    <property name="hidezerocount">False</property>
    <property name="sortreversed">False</property>
   </criterion>
+  <criterion name="c96">
+   <property name="widget">daterange</property>
+   <property name="title">Dernier événement réceptionné</property>
+   <property name="position">top</property>
+   <property name="section">advanced</property>
+   <property name="hidden">False</property>
+   <property name="index">last_received_notice_notification</property>
+   <property name="default"></property>
+   <property name="calYearRange">c-10:c+10</property>
+  </criterion>
  </criteria>
 </object>

--- a/src/Products/urban/dashboard/config/codt_buildlicences.xml
+++ b/src/Products/urban/dashboard/config/codt_buildlicences.xml
@@ -197,7 +197,7 @@
   </criterion>
   <criterion name="c96">
    <property name="widget">daterange</property>
-   <property name="title">Dernier événement réceptionné</property>
+   <property name="title">Dernier événement reçu</property>
    <property name="position">top</property>
    <property name="section">advanced</property>
    <property name="hidden">False</property>

--- a/src/Products/urban/dashboard/config/codt_commerciallicences.xml
+++ b/src/Products/urban/dashboard/config/codt_commerciallicences.xml
@@ -186,7 +186,7 @@
   </criterion>
   <criterion name="c96">
    <property name="widget">daterange</property>
-   <property name="title">Dernier événement réceptionné</property>
+   <property name="title">Dernier événement reçu</property>
    <property name="position">top</property>
    <property name="section">advanced</property>
    <property name="hidden">False</property>

--- a/src/Products/urban/dashboard/config/codt_commerciallicences.xml
+++ b/src/Products/urban/dashboard/config/codt_commerciallicences.xml
@@ -184,5 +184,15 @@
    <property name="hidezerocount">False</property>
    <property name="sortreversed">False</property>
   </criterion>
+  <criterion name="c96">
+   <property name="widget">daterange</property>
+   <property name="title">Dernier événement réceptionné</property>
+   <property name="position">top</property>
+   <property name="section">advanced</property>
+   <property name="hidden">False</property>
+   <property name="index">last_received_notice_notification</property>
+   <property name="default"></property>
+   <property name="calYearRange">c-10:c+10</property>
+  </criterion>
  </criteria>
 </object>

--- a/src/Products/urban/dashboard/config/codt_integratedlicences.xml
+++ b/src/Products/urban/dashboard/config/codt_integratedlicences.xml
@@ -186,7 +186,7 @@
   </criterion>
   <criterion name="c96">
    <property name="widget">daterange</property>
-   <property name="title">Dernier événement réceptionné</property>
+   <property name="title">Dernier événement reçu</property>
    <property name="position">top</property>
    <property name="section">advanced</property>
    <property name="hidden">False</property>

--- a/src/Products/urban/dashboard/config/codt_integratedlicences.xml
+++ b/src/Products/urban/dashboard/config/codt_integratedlicences.xml
@@ -184,5 +184,15 @@
    <property name="hidezerocount">False</property>
    <property name="sortreversed">False</property>
   </criterion>
+  <criterion name="c96">
+   <property name="widget">daterange</property>
+   <property name="title">Dernier événement réceptionné</property>
+   <property name="position">top</property>
+   <property name="section">advanced</property>
+   <property name="hidden">False</property>
+   <property name="index">last_received_notice_notification</property>
+   <property name="default"></property>
+   <property name="calYearRange">c-10:c+10</property>
+  </criterion>
  </criteria>
 </object>

--- a/src/Products/urban/dashboard/config/codt_notaryletters.xml
+++ b/src/Products/urban/dashboard/config/codt_notaryletters.xml
@@ -175,7 +175,7 @@
   </criterion>
   <criterion name="c96">
    <property name="widget">daterange</property>
-   <property name="title">Dernier événement réceptionné</property>
+   <property name="title">Dernier événement reçu</property>
    <property name="position">top</property>
    <property name="section">advanced</property>
    <property name="hidden">False</property>

--- a/src/Products/urban/dashboard/config/codt_notaryletters.xml
+++ b/src/Products/urban/dashboard/config/codt_notaryletters.xml
@@ -173,5 +173,15 @@
    <property name="hidezerocount">False</property>
    <property name="sortreversed">False</property>
   </criterion>
+  <criterion name="c96">
+   <property name="widget">daterange</property>
+   <property name="title">Dernier événement réceptionné</property>
+   <property name="position">top</property>
+   <property name="section">advanced</property>
+   <property name="hidden">False</property>
+   <property name="index">last_received_notice_notification</property>
+   <property name="default"></property>
+   <property name="calYearRange">c-10:c+10</property>
+  </criterion>
  </criteria>
 </object>

--- a/src/Products/urban/dashboard/config/codt_parceloutlicences.xml
+++ b/src/Products/urban/dashboard/config/codt_parceloutlicences.xml
@@ -186,7 +186,7 @@
   </criterion>
   <criterion name="c96">
    <property name="widget">daterange</property>
-   <property name="title">Dernier événement réceptionné</property>
+   <property name="title">Dernier événement reçu</property>
    <property name="position">top</property>
    <property name="section">advanced</property>
    <property name="hidden">False</property>

--- a/src/Products/urban/dashboard/config/codt_parceloutlicences.xml
+++ b/src/Products/urban/dashboard/config/codt_parceloutlicences.xml
@@ -184,5 +184,15 @@
    <property name="hidezerocount">False</property>
    <property name="sortreversed">False</property>
   </criterion>
+  <criterion name="c96">
+   <property name="widget">daterange</property>
+   <property name="title">Dernier événement réceptionné</property>
+   <property name="position">top</property>
+   <property name="section">advanced</property>
+   <property name="hidden">False</property>
+   <property name="index">last_received_notice_notification</property>
+   <property name="default"></property>
+   <property name="calYearRange">c-10:c+10</property>
+  </criterion>
  </criteria>
 </object>

--- a/src/Products/urban/dashboard/config/codt_uniqueborderinglicences.xml
+++ b/src/Products/urban/dashboard/config/codt_uniqueborderinglicences.xml
@@ -186,7 +186,7 @@
   </criterion>
   <criterion name="c96">
    <property name="widget">daterange</property>
-   <property name="title">Dernier événement réceptionné</property>
+   <property name="title">Dernier événement reçu</property>
    <property name="position">top</property>
    <property name="section">advanced</property>
    <property name="hidden">False</property>

--- a/src/Products/urban/dashboard/config/codt_uniqueborderinglicences.xml
+++ b/src/Products/urban/dashboard/config/codt_uniqueborderinglicences.xml
@@ -184,5 +184,15 @@
    <property name="hidezerocount">False</property>
    <property name="sortreversed">False</property>
   </criterion>
+  <criterion name="c96">
+   <property name="widget">daterange</property>
+   <property name="title">Dernier événement réceptionné</property>
+   <property name="position">top</property>
+   <property name="section">advanced</property>
+   <property name="hidden">False</property>
+   <property name="index">last_received_notice_notification</property>
+   <property name="default"></property>
+   <property name="calYearRange">c-10:c+10</property>
+  </criterion>
  </criteria>
 </object>

--- a/src/Products/urban/dashboard/config/codt_uniquelicences.xml
+++ b/src/Products/urban/dashboard/config/codt_uniquelicences.xml
@@ -186,7 +186,7 @@
   </criterion>
   <criterion name="c96">
    <property name="widget">daterange</property>
-   <property name="title">Dernier événement réceptionné</property>
+   <property name="title">Dernier événement reçu</property>
    <property name="position">top</property>
    <property name="section">advanced</property>
    <property name="hidden">False</property>

--- a/src/Products/urban/dashboard/config/codt_uniquelicences.xml
+++ b/src/Products/urban/dashboard/config/codt_uniquelicences.xml
@@ -184,5 +184,15 @@
    <property name="hidezerocount">False</property>
    <property name="sortreversed">False</property>
   </criterion>
+  <criterion name="c96">
+   <property name="widget">daterange</property>
+   <property name="title">Dernier événement réceptionné</property>
+   <property name="position">top</property>
+   <property name="section">advanced</property>
+   <property name="hidden">False</property>
+   <property name="index">last_received_notice_notification</property>
+   <property name="default"></property>
+   <property name="calYearRange">c-10:c+10</property>
+  </criterion>
  </criteria>
 </object>

--- a/src/Products/urban/dashboard/config/codt_urbancertificateones.xml
+++ b/src/Products/urban/dashboard/config/codt_urbancertificateones.xml
@@ -175,7 +175,7 @@
   </criterion>
   <criterion name="c96">
    <property name="widget">daterange</property>
-   <property name="title">Dernier événement réceptionné</property>
+   <property name="title">Dernier événement reçu</property>
    <property name="position">top</property>
    <property name="section">advanced</property>
    <property name="hidden">False</property>

--- a/src/Products/urban/dashboard/config/codt_urbancertificateones.xml
+++ b/src/Products/urban/dashboard/config/codt_urbancertificateones.xml
@@ -173,5 +173,15 @@
    <property name="hidezerocount">False</property>
    <property name="sortreversed">False</property>
   </criterion>
+  <criterion name="c96">
+   <property name="widget">daterange</property>
+   <property name="title">Dernier événement réceptionné</property>
+   <property name="position">top</property>
+   <property name="section">advanced</property>
+   <property name="hidden">False</property>
+   <property name="index">last_received_notice_notification</property>
+   <property name="default"></property>
+   <property name="calYearRange">c-10:c+10</property>
+  </criterion>
  </criteria>
 </object>

--- a/src/Products/urban/dashboard/config/codt_urbancertificatetwos.xml
+++ b/src/Products/urban/dashboard/config/codt_urbancertificatetwos.xml
@@ -186,7 +186,7 @@
   </criterion>
   <criterion name="c96">
    <property name="widget">daterange</property>
-   <property name="title">Dernier événement réceptionné</property>
+   <property name="title">Dernier événement reçu</property>
    <property name="position">top</property>
    <property name="section">advanced</property>
    <property name="hidden">False</property>

--- a/src/Products/urban/dashboard/config/codt_urbancertificatetwos.xml
+++ b/src/Products/urban/dashboard/config/codt_urbancertificatetwos.xml
@@ -184,5 +184,15 @@
    <property name="hidezerocount">False</property>
    <property name="sortreversed">False</property>
   </criterion>
+  <criterion name="c96">
+   <property name="widget">daterange</property>
+   <property name="title">Dernier événement réceptionné</property>
+   <property name="position">top</property>
+   <property name="section">advanced</property>
+   <property name="hidden">False</property>
+   <property name="index">last_received_notice_notification</property>
+   <property name="default"></property>
+   <property name="calYearRange">c-10:c+10</property>
+  </criterion>
  </criteria>
 </object>

--- a/src/Products/urban/dashboard/config/declarations.xml
+++ b/src/Products/urban/dashboard/config/declarations.xml
@@ -93,7 +93,7 @@
   </criterion>
   <criterion name="c96">
    <property name="widget">daterange</property>
-   <property name="title">Dernier événement réceptionné</property>
+   <property name="title">Dernier événement reçu</property>
    <property name="position">top</property>
    <property name="section">advanced</property>
    <property name="hidden">False</property>

--- a/src/Products/urban/dashboard/config/declarations.xml
+++ b/src/Products/urban/dashboard/config/declarations.xml
@@ -91,5 +91,15 @@
    <property name="hidezerocount">False</property>
    <property name="sortreversed">False</property>
   </criterion>
+  <criterion name="c96">
+   <property name="widget">daterange</property>
+   <property name="title">Dernier événement réceptionné</property>
+   <property name="position">top</property>
+   <property name="section">advanced</property>
+   <property name="hidden">False</property>
+   <property name="index">last_received_notice_notification</property>
+   <property name="default"></property>
+   <property name="calYearRange">c-10:c+10</property>
+  </criterion>
  </criteria>
 </object>

--- a/src/Products/urban/dashboard/config/divisions.xml
+++ b/src/Products/urban/dashboard/config/divisions.xml
@@ -175,7 +175,7 @@
   </criterion>
   <criterion name="c96">
    <property name="widget">daterange</property>
-   <property name="title">Dernier événement réceptionné</property>
+   <property name="title">Dernier événement reçu</property>
    <property name="position">top</property>
    <property name="section">advanced</property>
    <property name="hidden">False</property>

--- a/src/Products/urban/dashboard/config/divisions.xml
+++ b/src/Products/urban/dashboard/config/divisions.xml
@@ -173,5 +173,15 @@
    <property name="hidezerocount">False</property>
    <property name="sortreversed">False</property>
   </criterion>
+  <criterion name="c96">
+   <property name="widget">daterange</property>
+   <property name="title">Dernier événement réceptionné</property>
+   <property name="position">top</property>
+   <property name="section">advanced</property>
+   <property name="hidden">False</property>
+   <property name="index">last_received_notice_notification</property>
+   <property name="default"></property>
+   <property name="calYearRange">c-10:c+10</property>
+  </criterion>
  </criteria>
 </object>

--- a/src/Products/urban/dashboard/config/envclassborderings.xml
+++ b/src/Products/urban/dashboard/config/envclassborderings.xml
@@ -186,7 +186,7 @@
   </criterion>
   <criterion name="c96">
    <property name="widget">daterange</property>
-   <property name="title">Dernier événement réceptionné</property>
+   <property name="title">Dernier événement reçu</property>
    <property name="position">top</property>
    <property name="section">advanced</property>
    <property name="hidden">False</property>

--- a/src/Products/urban/dashboard/config/envclassborderings.xml
+++ b/src/Products/urban/dashboard/config/envclassborderings.xml
@@ -184,5 +184,15 @@
    <property name="hidezerocount">False</property>
    <property name="sortreversed">False</property>
   </criterion>
+  <criterion name="c96">
+   <property name="widget">daterange</property>
+   <property name="title">Dernier événement réceptionné</property>
+   <property name="position">top</property>
+   <property name="section">advanced</property>
+   <property name="hidden">False</property>
+   <property name="index">last_received_notice_notification</property>
+   <property name="default"></property>
+   <property name="calYearRange">c-10:c+10</property>
+  </criterion>
  </criteria>
 </object>

--- a/src/Products/urban/dashboard/config/envclassones.xml
+++ b/src/Products/urban/dashboard/config/envclassones.xml
@@ -186,7 +186,7 @@
   </criterion>
   <criterion name="c96">
    <property name="widget">daterange</property>
-   <property name="title">Dernier événement réceptionné</property>
+   <property name="title">Dernier événement reçu</property>
    <property name="position">top</property>
    <property name="section">advanced</property>
    <property name="hidden">False</property>

--- a/src/Products/urban/dashboard/config/envclassones.xml
+++ b/src/Products/urban/dashboard/config/envclassones.xml
@@ -184,5 +184,15 @@
    <property name="hidezerocount">False</property>
    <property name="sortreversed">False</property>
   </criterion>
+  <criterion name="c96">
+   <property name="widget">daterange</property>
+   <property name="title">Dernier événement réceptionné</property>
+   <property name="position">top</property>
+   <property name="section">advanced</property>
+   <property name="hidden">False</property>
+   <property name="index">last_received_notice_notification</property>
+   <property name="default"></property>
+   <property name="calYearRange">c-10:c+10</property>
+  </criterion>
  </criteria>
 </object>

--- a/src/Products/urban/dashboard/config/envclassthrees.xml
+++ b/src/Products/urban/dashboard/config/envclassthrees.xml
@@ -162,5 +162,15 @@
    <property name="hidezerocount">False</property>
    <property name="sortreversed">False</property>
   </criterion>
+  <criterion name="c96">
+   <property name="widget">daterange</property>
+   <property name="title">Dernier événement réceptionné</property>
+   <property name="position">top</property>
+   <property name="section">advanced</property>
+   <property name="hidden">False</property>
+   <property name="index">last_received_notice_notification</property>
+   <property name="default"></property>
+   <property name="calYearRange">c-10:c+10</property>
+  </criterion>
  </criteria>
 </object>

--- a/src/Products/urban/dashboard/config/envclassthrees.xml
+++ b/src/Products/urban/dashboard/config/envclassthrees.xml
@@ -164,7 +164,7 @@
   </criterion>
   <criterion name="c96">
    <property name="widget">daterange</property>
-   <property name="title">Dernier événement réceptionné</property>
+   <property name="title">Dernier événement reçu</property>
    <property name="position">top</property>
    <property name="section">advanced</property>
    <property name="hidden">False</property>

--- a/src/Products/urban/dashboard/config/envclasstwos.xml
+++ b/src/Products/urban/dashboard/config/envclasstwos.xml
@@ -186,7 +186,7 @@
   </criterion>
   <criterion name="c96">
    <property name="widget">daterange</property>
-   <property name="title">Dernier événement réceptionné</property>
+   <property name="title">Dernier événement reçu</property>
    <property name="position">top</property>
    <property name="section">advanced</property>
    <property name="hidden">False</property>

--- a/src/Products/urban/dashboard/config/envclasstwos.xml
+++ b/src/Products/urban/dashboard/config/envclasstwos.xml
@@ -184,5 +184,15 @@
    <property name="hidezerocount">False</property>
    <property name="sortreversed">False</property>
   </criterion>
+  <criterion name="c96">
+   <property name="widget">daterange</property>
+   <property name="title">Dernier événement réceptionné</property>
+   <property name="position">top</property>
+   <property name="section">advanced</property>
+   <property name="hidden">False</property>
+   <property name="index">last_received_notice_notification</property>
+   <property name="default"></property>
+   <property name="calYearRange">c-10:c+10</property>
+  </criterion>
  </criteria>
 </object>

--- a/src/Products/urban/dashboard/config/explosivespossessions.xml
+++ b/src/Products/urban/dashboard/config/explosivespossessions.xml
@@ -172,5 +172,15 @@
    <property name="hidezerocount">False</property>
    <property name="sortreversed">False</property>
   </criterion>
+  <criterion name="c96">
+   <property name="widget">daterange</property>
+   <property name="title">Dernier événement réceptionné</property>
+   <property name="position">top</property>
+   <property name="section">advanced</property>
+   <property name="hidden">False</property>
+   <property name="index">last_received_notice_notification</property>
+   <property name="default"></property>
+   <property name="calYearRange">c-10:c+10</property>
+  </criterion>
  </criteria>
 </object>

--- a/src/Products/urban/dashboard/config/explosivespossessions.xml
+++ b/src/Products/urban/dashboard/config/explosivespossessions.xml
@@ -174,7 +174,7 @@
   </criterion>
   <criterion name="c96">
    <property name="widget">daterange</property>
-   <property name="title">Dernier événement réceptionné</property>
+   <property name="title">Dernier événement reçu</property>
    <property name="position">top</property>
    <property name="section">advanced</property>
    <property name="hidden">False</property>

--- a/src/Products/urban/dashboard/config/housings.xml
+++ b/src/Products/urban/dashboard/config/housings.xml
@@ -156,5 +156,15 @@
          <property name="step">10</property>
          <property name="default">20</property>
       </criterion>
+      <criterion name="c96">
+         <property name="widget">daterange</property>
+         <property name="title">Dernier événement réceptionné</property>
+         <property name="position">top</property>
+         <property name="section">advanced</property>
+         <property name="hidden">False</property>
+         <property name="index">last_received_notice_notification</property>
+         <property name="default"></property>
+         <property name="calYearRange">c-10:c+10</property>
+      </criterion>
    </criteria>
 </object>

--- a/src/Products/urban/dashboard/config/housings.xml
+++ b/src/Products/urban/dashboard/config/housings.xml
@@ -158,7 +158,7 @@
       </criterion>
       <criterion name="c96">
          <property name="widget">daterange</property>
-         <property name="title">Dernier événement réceptionné</property>
+         <property name="title">Dernier événement reçu</property>
          <property name="position">top</property>
          <property name="section">advanced</property>
          <property name="hidden">False</property>

--- a/src/Products/urban/dashboard/config/import_notice.xml
+++ b/src/Products/urban/dashboard/config/import_notice.xml
@@ -161,5 +161,15 @@
    <property name="hidezerocount">False</property>
    <property name="sortreversed">False</property>
   </criterion>
+  <criterion name="c96">
+   <property name="widget">daterange</property>
+   <property name="title">Dernier événement réceptionné</property>
+   <property name="position">top</property>
+   <property name="section">advanced</property>
+   <property name="hidden">False</property>
+   <property name="index">last_received_notice_notification</property>
+   <property name="default"></property>
+   <property name="calYearRange">c-10:c+10</property>
+  </criterion>
  </criteria>
 </object>

--- a/src/Products/urban/dashboard/config/import_notice.xml
+++ b/src/Products/urban/dashboard/config/import_notice.xml
@@ -163,7 +163,7 @@
   </criterion>
   <criterion name="c96">
    <property name="widget">daterange</property>
-   <property name="title">Dernier événement réceptionné</property>
+   <property name="title">Dernier événement reçu</property>
    <property name="position">top</property>
    <property name="section">advanced</property>
    <property name="hidden">False</property>

--- a/src/Products/urban/dashboard/config/inspections.xml
+++ b/src/Products/urban/dashboard/config/inspections.xml
@@ -172,5 +172,15 @@
    <property name="hidezerocount">False</property>
    <property name="sortreversed">False</property>
   </criterion>
+  <criterion name="c96">
+   <property name="widget">daterange</property>
+   <property name="title">Dernier événement réceptionné</property>
+   <property name="position">top</property>
+   <property name="section">advanced</property>
+   <property name="hidden">False</property>
+   <property name="index">last_received_notice_notification</property>
+   <property name="default"></property>
+   <property name="calYearRange">c-10:c+10</property>
+  </criterion>
  </criteria>
 </object>

--- a/src/Products/urban/dashboard/config/inspections.xml
+++ b/src/Products/urban/dashboard/config/inspections.xml
@@ -174,7 +174,7 @@
   </criterion>
   <criterion name="c96">
    <property name="widget">daterange</property>
-   <property name="title">Dernier événement réceptionné</property>
+   <property name="title">Dernier événement reçu</property>
    <property name="position">top</property>
    <property name="section">advanced</property>
    <property name="hidden">False</property>

--- a/src/Products/urban/dashboard/config/integratedlicences.xml
+++ b/src/Products/urban/dashboard/config/integratedlicences.xml
@@ -175,7 +175,7 @@
   </criterion>
   <criterion name="c96">
    <property name="widget">daterange</property>
-   <property name="title">Dernier événement réceptionné</property>
+   <property name="title">Dernier événement reçu</property>
    <property name="position">top</property>
    <property name="section">advanced</property>
    <property name="hidden">False</property>

--- a/src/Products/urban/dashboard/config/integratedlicences.xml
+++ b/src/Products/urban/dashboard/config/integratedlicences.xml
@@ -173,5 +173,15 @@
    <property name="hidezerocount">False</property>
    <property name="sortreversed">False</property>
   </criterion>
+  <criterion name="c96">
+   <property name="widget">daterange</property>
+   <property name="title">Dernier événement réceptionné</property>
+   <property name="position">top</property>
+   <property name="section">advanced</property>
+   <property name="hidden">False</property>
+   <property name="index">last_received_notice_notification</property>
+   <property name="default"></property>
+   <property name="calYearRange">c-10:c+10</property>
+  </criterion>
  </criteria>
 </object>

--- a/src/Products/urban/dashboard/config/miscdemands.xml
+++ b/src/Products/urban/dashboard/config/miscdemands.xml
@@ -174,5 +174,15 @@
    <property name="hidezerocount">False</property>
    <property name="sortreversed">False</property>
   </criterion>
+  <criterion name="c96">
+   <property name="widget">daterange</property>
+   <property name="title">Dernier événement réceptionné</property>
+   <property name="position">top</property>
+   <property name="section">advanced</property>
+   <property name="hidden">False</property>
+   <property name="index">last_received_notice_notification</property>
+   <property name="default"></property>
+   <property name="calYearRange">c-10:c+10</property>
+  </criterion>
  </criteria>
 </object>

--- a/src/Products/urban/dashboard/config/miscdemands.xml
+++ b/src/Products/urban/dashboard/config/miscdemands.xml
@@ -176,7 +176,7 @@
   </criterion>
   <criterion name="c96">
    <property name="widget">daterange</property>
-   <property name="title">Dernier événement réceptionné</property>
+   <property name="title">Dernier événement reçu</property>
    <property name="position">top</property>
    <property name="section">advanced</property>
    <property name="hidden">False</property>

--- a/src/Products/urban/dashboard/config/notaryletters.xml
+++ b/src/Products/urban/dashboard/config/notaryletters.xml
@@ -162,5 +162,15 @@
    <property name="hidezerocount">False</property>
    <property name="sortreversed">False</property>
   </criterion>
+  <criterion name="c96">
+   <property name="widget">daterange</property>
+   <property name="title">Dernier événement réceptionné</property>
+   <property name="position">top</property>
+   <property name="section">advanced</property>
+   <property name="hidden">False</property>
+   <property name="index">last_received_notice_notification</property>
+   <property name="default"></property>
+   <property name="calYearRange">c-10:c+10</property>
+  </criterion>
  </criteria>
 </object>

--- a/src/Products/urban/dashboard/config/notaryletters.xml
+++ b/src/Products/urban/dashboard/config/notaryletters.xml
@@ -164,7 +164,7 @@
   </criterion>
   <criterion name="c96">
    <property name="widget">daterange</property>
-   <property name="title">Dernier événement réceptionné</property>
+   <property name="title">Dernier événement reçu</property>
    <property name="position">top</property>
    <property name="section">advanced</property>
    <property name="hidden">False</property>

--- a/src/Products/urban/dashboard/config/parceloutlicences.xml
+++ b/src/Products/urban/dashboard/config/parceloutlicences.xml
@@ -92,5 +92,15 @@
    <property name="hidezerocount">False</property>
    <property name="sortreversed">False</property>
   </criterion>
+  <criterion name="c96">
+   <property name="widget">daterange</property>
+   <property name="title">Dernier événement réceptionné</property>
+   <property name="position">top</property>
+   <property name="section">advanced</property>
+   <property name="hidden">False</property>
+   <property name="index">last_received_notice_notification</property>
+   <property name="default"></property>
+   <property name="calYearRange">c-10:c+10</property>
+  </criterion>
  </criteria>
 </object>

--- a/src/Products/urban/dashboard/config/parceloutlicences.xml
+++ b/src/Products/urban/dashboard/config/parceloutlicences.xml
@@ -94,7 +94,7 @@
   </criterion>
   <criterion name="c96">
    <property name="widget">daterange</property>
-   <property name="title">Dernier événement réceptionné</property>
+   <property name="title">Dernier événement reçu</property>
    <property name="position">top</property>
    <property name="section">advanced</property>
    <property name="hidden">False</property>

--- a/src/Products/urban/dashboard/config/patrimonycertificates.xml
+++ b/src/Products/urban/dashboard/config/patrimonycertificates.xml
@@ -174,5 +174,15 @@
    <property name="hidezerocount">False</property>
    <property name="sortreversed">False</property>
   </criterion>
+  <criterion name="c96">
+   <property name="widget">daterange</property>
+   <property name="title">Dernier événement réceptionné</property>
+   <property name="position">top</property>
+   <property name="section">advanced</property>
+   <property name="hidden">False</property>
+   <property name="index">last_received_notice_notification</property>
+   <property name="default"></property>
+   <property name="calYearRange">c-10:c+10</property>
+  </criterion>
  </criteria>
 </object>

--- a/src/Products/urban/dashboard/config/patrimonycertificates.xml
+++ b/src/Products/urban/dashboard/config/patrimonycertificates.xml
@@ -176,7 +176,7 @@
   </criterion>
   <criterion name="c96">
    <property name="widget">daterange</property>
-   <property name="title">Dernier événement réceptionné</property>
+   <property name="title">Dernier événement reçu</property>
    <property name="position">top</property>
    <property name="section">advanced</property>
    <property name="hidden">False</property>

--- a/src/Products/urban/dashboard/config/preliminarynotices.xml
+++ b/src/Products/urban/dashboard/config/preliminarynotices.xml
@@ -174,5 +174,15 @@
    <property name="hidezerocount">False</property>
    <property name="sortreversed">False</property>
   </criterion>
+  <criterion name="c96">
+   <property name="widget">daterange</property>
+   <property name="title">Dernier événement réceptionné</property>
+   <property name="position">top</property>
+   <property name="section">advanced</property>
+   <property name="hidden">False</property>
+   <property name="index">last_received_notice_notification</property>
+   <property name="default"></property>
+   <property name="calYearRange">c-10:c+10</property>
+  </criterion>
  </criteria>
 </object>

--- a/src/Products/urban/dashboard/config/preliminarynotices.xml
+++ b/src/Products/urban/dashboard/config/preliminarynotices.xml
@@ -176,7 +176,7 @@
   </criterion>
   <criterion name="c96">
    <property name="widget">daterange</property>
-   <property name="title">Dernier événement réceptionné</property>
+   <property name="title">Dernier événement reçu</property>
    <property name="position">top</property>
    <property name="section">advanced</property>
    <property name="hidden">False</property>

--- a/src/Products/urban/dashboard/config/projectmeetings.xml
+++ b/src/Products/urban/dashboard/config/projectmeetings.xml
@@ -174,5 +174,15 @@
    <property name="hidezerocount">False</property>
    <property name="sortreversed">False</property>
   </criterion>
+  <criterion name="c96">
+   <property name="widget">daterange</property>
+   <property name="title">Dernier événement réceptionné</property>
+   <property name="position">top</property>
+   <property name="section">advanced</property>
+   <property name="hidden">False</property>
+   <property name="index">last_received_notice_notification</property>
+   <property name="default"></property>
+   <property name="calYearRange">c-10:c+10</property>
+  </criterion>
  </criteria>
 </object>

--- a/src/Products/urban/dashboard/config/projectmeetings.xml
+++ b/src/Products/urban/dashboard/config/projectmeetings.xml
@@ -176,7 +176,7 @@
   </criterion>
   <criterion name="c96">
    <property name="widget">daterange</property>
-   <property name="title">Dernier événement réceptionné</property>
+   <property name="title">Dernier événement reçu</property>
    <property name="position">top</property>
    <property name="section">advanced</property>
    <property name="hidden">False</property>

--- a/src/Products/urban/dashboard/config/roaddecrees.xml
+++ b/src/Products/urban/dashboard/config/roaddecrees.xml
@@ -161,5 +161,15 @@
    <property name="hidezerocount">False</property>
    <property name="sortreversed">False</property>
   </criterion>
+  <criterion name="c96">
+   <property name="widget">daterange</property>
+   <property name="title">Dernier événement réceptionné</property>
+   <property name="position">top</property>
+   <property name="section">advanced</property>
+   <property name="hidden">False</property>
+   <property name="index">last_received_notice_notification</property>
+   <property name="default"></property>
+   <property name="calYearRange">c-10:c+10</property>
+  </criterion>
  </criteria>
 </object>

--- a/src/Products/urban/dashboard/config/roaddecrees.xml
+++ b/src/Products/urban/dashboard/config/roaddecrees.xml
@@ -163,7 +163,7 @@
   </criterion>
   <criterion name="c96">
    <property name="widget">daterange</property>
-   <property name="title">Dernier événement réceptionné</property>
+   <property name="title">Dernier événement reçu</property>
    <property name="position">top</property>
    <property name="section">advanced</property>
    <property name="hidden">False</property>

--- a/src/Products/urban/dashboard/config/tickets.xml
+++ b/src/Products/urban/dashboard/config/tickets.xml
@@ -172,5 +172,15 @@
    <property name="hidezerocount">False</property>
    <property name="sortreversed">False</property>
   </criterion>
+  <criterion name="c96">
+   <property name="widget">daterange</property>
+   <property name="title">Dernier événement réceptionné</property>
+   <property name="position">top</property>
+   <property name="section">advanced</property>
+   <property name="hidden">False</property>
+   <property name="index">last_received_notice_notification</property>
+   <property name="default"></property>
+   <property name="calYearRange">c-10:c+10</property>
+  </criterion>
  </criteria>
 </object>

--- a/src/Products/urban/dashboard/config/tickets.xml
+++ b/src/Products/urban/dashboard/config/tickets.xml
@@ -174,7 +174,7 @@
   </criterion>
   <criterion name="c96">
    <property name="widget">daterange</property>
-   <property name="title">Dernier événement réceptionné</property>
+   <property name="title">Dernier événement reçu</property>
    <property name="position">top</property>
    <property name="section">advanced</property>
    <property name="hidden">False</property>

--- a/src/Products/urban/dashboard/config/uniquelicences.xml
+++ b/src/Products/urban/dashboard/config/uniquelicences.xml
@@ -175,7 +175,7 @@
   </criterion>
   <criterion name="c96">
    <property name="widget">daterange</property>
-   <property name="title">Dernier événement réceptionné</property>
+   <property name="title">Dernier événement reçu</property>
    <property name="position">top</property>
    <property name="section">advanced</property>
    <property name="hidden">False</property>

--- a/src/Products/urban/dashboard/config/uniquelicences.xml
+++ b/src/Products/urban/dashboard/config/uniquelicences.xml
@@ -173,5 +173,15 @@
    <property name="hidezerocount">False</property>
    <property name="sortreversed">False</property>
   </criterion>
+  <criterion name="c96">
+   <property name="widget">daterange</property>
+   <property name="title">Dernier événement réceptionné</property>
+   <property name="position">top</property>
+   <property name="section">advanced</property>
+   <property name="hidden">False</property>
+   <property name="index">last_received_notice_notification</property>
+   <property name="default"></property>
+   <property name="calYearRange">c-10:c+10</property>
+  </criterion>
  </criteria>
 </object>

--- a/src/Products/urban/dashboard/config/urbancertificateones.xml
+++ b/src/Products/urban/dashboard/config/urbancertificateones.xml
@@ -162,5 +162,15 @@
    <property name="hidezerocount">False</property>
    <property name="sortreversed">False</property>
   </criterion>
+  <criterion name="c96">
+   <property name="widget">daterange</property>
+   <property name="title">Dernier événement réceptionné</property>
+   <property name="position">top</property>
+   <property name="section">advanced</property>
+   <property name="hidden">False</property>
+   <property name="index">last_received_notice_notification</property>
+   <property name="default"></property>
+   <property name="calYearRange">c-10:c+10</property>
+  </criterion>
  </criteria>
 </object>

--- a/src/Products/urban/dashboard/config/urbancertificateones.xml
+++ b/src/Products/urban/dashboard/config/urbancertificateones.xml
@@ -164,7 +164,7 @@
   </criterion>
   <criterion name="c96">
    <property name="widget">daterange</property>
-   <property name="title">Dernier événement réceptionné</property>
+   <property name="title">Dernier événement reçu</property>
    <property name="position">top</property>
    <property name="section">advanced</property>
    <property name="hidden">False</property>

--- a/src/Products/urban/dashboard/config/urbancertificatetwos.xml
+++ b/src/Products/urban/dashboard/config/urbancertificatetwos.xml
@@ -175,7 +175,7 @@
   </criterion>
   <criterion name="c96">
    <property name="widget">daterange</property>
-   <property name="title">Dernier événement réceptionné</property>
+   <property name="title">Dernier événement reçu</property>
    <property name="position">top</property>
    <property name="section">advanced</property>
    <property name="hidden">False</property>

--- a/src/Products/urban/dashboard/config/urbancertificatetwos.xml
+++ b/src/Products/urban/dashboard/config/urbancertificatetwos.xml
@@ -173,5 +173,15 @@
    <property name="hidezerocount">False</property>
    <property name="sortreversed">False</property>
   </criterion>
+  <criterion name="c96">
+   <property name="widget">daterange</property>
+   <property name="title">Dernier événement réceptionné</property>
+   <property name="position">top</property>
+   <property name="section">advanced</property>
+   <property name="hidden">False</property>
+   <property name="index">last_received_notice_notification</property>
+   <property name="default"></property>
+   <property name="calYearRange">c-10:c+10</property>
+  </criterion>
  </criteria>
 </object>

--- a/src/Products/urban/index.zcml
+++ b/src/Products/urban/index.zcml
@@ -31,6 +31,7 @@
   <adapter name="cmf_uid" factory=".indexes.eventconfig_urbaneventtype" />
   <adapter name="getStreetCode" factory=".indexes.streetcode_indexer" />
   <adapter name="getAdditionalReference" factory=".indexes.additional_reference" />
+  <adapter name="last_received_notice_notification" factory=".indexes.last_received_notice_notification" />
 
   <!-- Unindex UrbanEvent, UrbanDoc, Applicant and PortionOut -->
 

--- a/src/Products/urban/indexes.py
+++ b/src/Products/urban/indexes.py
@@ -26,6 +26,7 @@ from imio.schedule.content.task import IAutomatedTask
 from plone import api
 from plone.indexer import indexer
 from requests.exceptions import RequestException
+from zope.annotation.interfaces import IAnnotations
 from zope.component import queryAdapter
 from zope.interface import Interface
 
@@ -426,3 +427,23 @@ def streetcode_indexer(obj):
 @indexer(interfaces.IGenericLicence)
 def additional_reference(object):
     return object.getAdditionalReference()
+
+
+@indexer(interfaces.IGenericLicence)
+def last_received_notice_notification(object):
+    """
+    Get the creation date of the last received NOTICe event
+    """
+
+    all_licence_events = sorted(
+        object.getAllEvents(), key=lambda e: e.created(), reverse=True
+    )
+    for event in all_licence_events:
+        annotations = IAnnotations(event)
+        key = "notice_notification"
+        notice = annotations.get(key, {})
+        incoming = notice.get("incoming", {})
+        if incoming.get("notice_id"):
+            return event.created()
+
+    return None

--- a/src/Products/urban/migration/update_290.py
+++ b/src/Products/urban/migration/update_290.py
@@ -714,6 +714,8 @@ def add_last_received_notice_notification(context):
     # add dashboard widget
     urban_base_folder = api.portal.get().urban
     urban_dashboard_folders = [urban_base_folder]  # needed for dashboard 'All'
+    if "import-notice" in urban_base_folder.objectIds():
+        urban_dashboard_folders.append(getattr(urban_base_folder, "import-notice"))
     for urban_type in URBAN_TYPES:
         licence_folder = getattr(urban_base_folder, "{}s".format(urban_type.lower()), None)
         if licence_folder is not None:

--- a/src/Products/urban/migration/update_290.py
+++ b/src/Products/urban/migration/update_290.py
@@ -725,7 +725,7 @@ def add_last_received_notice_notification(context):
             criteria.add(
                 _cid_=u"c96",
                 wid="daterange",
-                title=u"Dernier événement réceptionné",
+                title=u"Dernier événement reçu",
                 position="top",
                 section="advanced",
                 hidden=False,

--- a/src/Products/urban/migration/update_290.py
+++ b/src/Products/urban/migration/update_290.py
@@ -14,6 +14,7 @@ from Products.urban.setuphandlers import add_new_urban_licence_type
 from Products.urban.utils import moveElementAfter
 from Products.urban.setuphandlers import set_licence_folder_security
 from dm.historical import getHistory
+from eea.facetednavigation.criteria.interfaces import ICriteria
 from imio.helpers.catalog import reindexIndexes
 from plone import api
 from plone.app.textfield import RichTextValue
@@ -700,6 +701,39 @@ def normalize_externaldecisions_vocabulary(context):
             logger.info("Created missing vocabulary term: %s", vocabulary_term)
 
     logger.info("Upgrade done!")
+
+
+def add_last_received_notice_notification(context):
+    logger = logging.getLogger("urban: Add last received notice notification")
+
+    # add catalog index
+    setup_tool = api.portal.get_tool("portal_setup")
+    setup_tool.runImportStepFromProfile("profile-Products.urban:urbantypes", "catalog")
+    reindexIndexes(None, ["last_received_notice_notification"])
+
+    # add dashboard widget
+    urban_base_folder = api.portal.get().urban
+    urban_dashboard_folders = [urban_base_folder]  # needed for dashboard 'All'
+    for urban_type in URBAN_TYPES:
+        licence_folder = getattr(urban_base_folder, "{}s".format(urban_type.lower()), None)
+        if licence_folder is not None:
+            urban_dashboard_folders.append(licence_folder)
+
+    for licence_folder in urban_dashboard_folders:
+        criteria = ICriteria(licence_folder)
+        if criteria is not None and not criteria.get("c96"):
+            criteria.add(
+                _cid_=u"c96",
+                wid="daterange",
+                title=u"Dernier événement réceptionné",
+                position="top",
+                section="advanced",
+                hidden=False,
+                index=u"last_received_notice_notification",
+                calYearRange=u"c-10:c+10",
+            )
+
+    logger.info("upgrade step done!")
 
 
 def setup_referenceFT_PM(context):

--- a/src/Products/urban/migration/upgrades_290.zcml
+++ b/src/Products/urban/migration/upgrades_290.zcml
@@ -156,4 +156,12 @@
         handler=".update_290.setup_referenceFT_PM"
         profile="Products.urban:default" />
 
+    <gs:upgradeStep
+        title="Add last received notice notification"
+        description=""
+        source="2919"
+        destination="2920"
+        handler=".update_290.add_last_received_notice_notification"
+        profile="Products.urban:default" />
+
 </configure>

--- a/src/Products/urban/profiles/default/metadata.xml
+++ b/src/Products/urban/profiles/default/metadata.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <metadata>
-  <version>2919</version>
+  <version>2920</version>
   <dependencies>
     <dependency>profile-Products.urban:preinstall</dependency>
   </dependencies>

--- a/src/Products/urban/profiles/urban_types/catalog.xml
+++ b/src/Products/urban/profiles/urban_types/catalog.xml
@@ -143,5 +143,10 @@
   </index>
   <column value="referenceDGATLP"/>
 
+  <index name="last_received_notice_notification" meta_type="DateIndex">
+    <indexed_attr value="last_received_notice_notification"/>
+  </index>
+  <column value="last_received_notice_notification"/>
+
 <!-- ##/code-section FOOT -->
 </object>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new advanced date-range filter, “Dernier événement reçu”, to relevant dashboards.
  * Users can filter by the date of the last received notice notification, with a selectable window covering the previous and next ten calendar years.
* **Chores**
  * Existing installations are automatically updated to enable the new filtering capability, including the necessary reindexing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->