### PR TITLE
URB-3660: Use reception date for incoming notice event dates

### DIFF
--- a/news/URB-3660.bugfix
+++ b/news/URB-3660.bugfix
@@ -1,0 +1,2 @@
+Use reception date for incoming notice event dates
+[daggelpop]

--- a/src/Products/urban/browser/cron/notice.py
+++ b/src/Products/urban/browser/cron/notice.py
@@ -391,15 +391,8 @@ class IncomingNoticeHandler(object):
         api.content.transition(self.event, "close")
 
     def fill_incoming_event(self):
-        usable_date = None
-        if self.notification.send_date:
-            usable_date = self.notification.send_date
-        elif self.notification.status_date:
-            usable_date = self.notification.status_date
-
-        if usable_date:
-            event_date = DateTime(str(usable_date))
-            self.event.setEventDate(event_date)
+        event_date = DateTime(str(self.notification.reception_date))
+        self.event.setEventDate(event_date)
 
         self.event.store_incoming_notice(
             self.notification.noticeId,


### PR DESCRIPTION
Note: 
The receptionDate data received so far has never been missing.
No clear fix if that changes, so no point in checking for None at the moment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Incoming notice events now use the notice’s reception date as the event date, ensuring more accurate event timelines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->