### PR TITLE
URB-3722: Import buttons for NOTICe forms

### DIFF
--- a/news/URB-3722.feature
+++ b/news/URB-3722.feature
@@ -1,0 +1,2 @@
+Import buttons for GESPER forms
+[daggelpop]

--- a/src/Products/urban/migration/update_290.py
+++ b/src/Products/urban/migration/update_290.py
@@ -721,3 +721,10 @@ def setup_referenceFT_PM(context):
     reindexIndexes(None, ["referenceFT_PM"])
 
     logger.info("upgrade step done!")
+
+
+def import_notice_form_buttons(context):
+    logger = logging.getLogger("urban: Import buttons for NOTICe forms")
+    setup_tool = api.portal.get_tool("portal_setup")
+    setup_tool.runImportStepFromProfile("profile-Products.urban:default", "actions")
+    logger.info("upgrade step done!")

--- a/src/Products/urban/migration/upgrades_290.zcml
+++ b/src/Products/urban/migration/upgrades_290.zcml
@@ -156,4 +156,12 @@
         handler=".update_290.setup_referenceFT_PM"
         profile="Products.urban:default" />
 
+    <gs:upgradeStep
+        title="Import buttons for NOTICe forms"
+        description=""
+        source="2919"
+        destination="2920"
+        handler=".update_290.import_notice_form_buttons"
+        profile="Products.urban:default" />
+
 </configure>

--- a/src/Products/urban/profiles/default/metadata.xml
+++ b/src/Products/urban/profiles/default/metadata.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <metadata>
-  <version>2919</version>
+  <version>2920</version>
   <dependencies>
     <dependency>profile-Products.urban:preinstall</dependency>
   </dependencies>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added default import buttons to NOTICE forms in GESPER.
  * Existing NOTICE forms receive the buttons automatically during the application upgrade.

* **Documentation**
  * Added feature coverage for NOTICE form import buttons.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->