### PR TITLE
URB-3711: Avoid double import of NOTICe notification

### DIFF
--- a/news/URB-3711.bugfix
+++ b/news/URB-3711.bugfix
@@ -1,0 +1,2 @@
+Avoid double import of NOTICe notification
+[daggelpop]

--- a/src/Products/urban/browser/cron/notice.py
+++ b/src/Products/urban/browser/cron/notice.py
@@ -78,6 +78,12 @@ class ImportFromNoticeView(BrowserView):
             try:
                 self._handle_notification(failed_notice_id)
                 logger.info(u"Retried notification %s succeeded", failed_notice_id)
+            except NotificationAlreadyHandledException:
+                savepoint.rollback()
+                logger.warning(
+                    u"Ignoring import of existing notification %s",
+                    failed_notice_id,
+                )
             except Exception as exc:
                 savepoint.rollback()
                 custom_exc = ErrorProcessingNotificationException(
@@ -126,6 +132,12 @@ class ImportFromNoticeView(BrowserView):
                 if notif_last_status_date > self.latest_successful_date:
                     self.latest_successful_date = notif_last_status_date
                 logger.info(u"Notification %s succeeded", notice_id)
+            except NotificationAlreadyHandledException:
+                savepoint.rollback()
+                logger.warning(
+                    u"Ignoring import of existing notification %s",
+                    notice_id,
+                )
             except Exception as exc:
                 savepoint.rollback()
                 custom_exc = ErrorProcessingNotificationException(notice_id, exc)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented duplicate notification imports.
  * Improved handling of already-processed notifications during retries, avoiding unnecessary failures and duplicate processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->